### PR TITLE
版本更新至 4.01

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.skymc</groupId>
     <artifactId>TabooLib</artifactId>
-    <version>4.0</version>
+    <version>4.01</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/ilummc/tlib/resources/TLocale.java
+++ b/src/main/java/com/ilummc/tlib/resources/TLocale.java
@@ -7,12 +7,11 @@ import com.ilummc.tlib.util.Ref;
 import com.ilummc.tlib.util.Strings;
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.skymc.taboolib.Main;
+import me.skymc.taboolib.TabooLib;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,15 +23,15 @@ public class TLocale {
     }
 
     static String asString(String path, Class<?> callerClass, String... args) {
-        return TLocaleLoader.asString(getCallerPlugin(callerClass), path, args);
+        return TLocaleLoader.asString(Ref.getCallerPlugin(callerClass), path, args);
     }
 
     static List<String> asStringList(String path, Class<?> callerClass, String... args) {
-        return TLocaleLoader.asStringList(getCallerPlugin(callerClass), path, args);
+        return TLocaleLoader.asStringList(Ref.getCallerPlugin(callerClass), path, args);
     }
 
     private static void sendTo(String path, CommandSender sender, String[] args, Class<?> callerClass) {
-        TLocaleLoader.sendTo(getCallerPlugin(callerClass), path, sender, args);
+        TLocaleLoader.sendTo(Ref.getCallerPlugin(callerClass), path, sender, args);
     }
 
     public static void sendToConsole(String path, String... args) {
@@ -49,7 +48,7 @@ public class TLocale {
 
     public static String asString(String path, String... args) {
         try {
-            return asString(path, Ref.getCallerClassNotOptional(3), args);
+            return asString(path, Ref.getCallerClass(3).orElse(Main.class), args);
         } catch (Exception e) {
             TLib.getTLib().getLogger().error(Strings.replaceWithOrder(TLib.getInternalLanguage().getString("FETCH-LOCALE-ERROR"), path));
             TLib.getTLib().getLogger().error(Strings.replaceWithOrder(TLib.getInternalLanguage().getString("LOCALE-ERROR-REASON"), e.getMessage()));
@@ -59,7 +58,7 @@ public class TLocale {
 
     public static List<String> asStringList(String path, String... args) {
         try {
-            return asStringList(path, Ref.getCallerClassNotOptional(3), args);
+            return asStringList(path, Ref.getCallerClass(3).orElse(Main.class), args);
         } catch (Exception e) {
             TLib.getTLib().getLogger().error(Strings.replaceWithOrder(TLib.getInternalLanguage().getString("FETCH-LOCALE-ERROR"), path));
             TLib.getTLib().getLogger().error(Strings.replaceWithOrder(TLib.getInternalLanguage().getString("LOCALE-ERROR-REASON"), e.getMessage()));
@@ -68,18 +67,7 @@ public class TLocale {
     }
 
     public static void reload() {
-        Ref.getCallerClass(3).ifPresent(clazz -> TLocaleLoader.load(getCallerPlugin(clazz), false));
-    }
-
-    private static JavaPlugin getCallerPlugin(Class<?> callerClass) {
-        try {
-            Field pluginField = callerClass.getClassLoader().getClass().getDeclaredField("plugin");
-            pluginField.setAccessible(true);
-            return (JavaPlugin) pluginField.get(callerClass.getClassLoader());
-        } catch (Exception ignored) {
-            TLocale.Logger.error("LOCALE.CALLER-PLUGIN-NOT-FOUND", callerClass.getName());
-        }
-        return (JavaPlugin) Main.getInst();
+        Ref.getCallerClass(3).ifPresent(clazz -> TLocaleLoader.load(Ref.getCallerPlugin(clazz), false));
     }
 
     public static final class Translate extends TLocale {
@@ -112,31 +100,31 @@ public class TLocale {
     public static final class Logger extends TLocale {
 
         public static void info(String path, String... args) {
-            Ref.getCallerClass(3).ifPresent(clazz -> TLoggerManager.getLogger(TLocale.getCallerPlugin(clazz)).info(asString(path, clazz, args)));
+            Ref.getCallerClass(3).ifPresent(clazz -> asStringList(path, clazz, args).forEach(locale -> TLoggerManager.getLogger(Ref.getCallerPlugin(clazz)).info(locale)));
         }
 
         public static void warn(String path, String... args) {
-            Ref.getCallerClass(3).ifPresent(clazz -> TLoggerManager.getLogger(TLocale.getCallerPlugin(clazz)).warn(asString(path, clazz, args)));
+            Ref.getCallerClass(3).ifPresent(clazz -> asStringList(path, clazz, args).forEach(locale -> TLoggerManager.getLogger(Ref.getCallerPlugin(clazz)).warn(locale)));
         }
 
         public static void error(String path, String... args) {
-            Ref.getCallerClass(3).ifPresent(clazz -> TLoggerManager.getLogger(TLocale.getCallerPlugin(clazz)).error(asString(path, clazz, args)));
+            Ref.getCallerClass(3).ifPresent(clazz -> asStringList(path, clazz, args).forEach(locale -> TLoggerManager.getLogger(Ref.getCallerPlugin(clazz)).error(locale)));
         }
 
         public static void fatal(String path, String... args) {
-            Ref.getCallerClass(3).ifPresent(clazz -> TLoggerManager.getLogger(TLocale.getCallerPlugin(clazz)).fatal(asString(path, clazz, args)));
+            Ref.getCallerClass(3).ifPresent(clazz -> asStringList(path, clazz, args).forEach(locale -> TLoggerManager.getLogger(Ref.getCallerPlugin(clazz)).fatal(locale)));
         }
 
         public static void fine(String path, String... args) {
-            Ref.getCallerClass(3).ifPresent(clazz -> TLoggerManager.getLogger(TLocale.getCallerPlugin(clazz)).fine(asString(path, clazz, args)));
+            Ref.getCallerClass(3).ifPresent(clazz -> asStringList(path, clazz, args).forEach(locale -> TLoggerManager.getLogger(Ref.getCallerPlugin(clazz)).fine(locale)));
         }
 
         public static void finest(String path, String... args) {
-            Ref.getCallerClass(3).ifPresent(clazz -> TLoggerManager.getLogger(TLocale.getCallerPlugin(clazz)).finest(asString(path, clazz, args)));
+            Ref.getCallerClass(3).ifPresent(clazz -> asStringList(path, clazz, args).forEach(locale -> TLoggerManager.getLogger(Ref.getCallerPlugin(clazz)).finest(locale)));
         }
 
         public static void verbose(String path, String... args) {
-            Ref.getCallerClass(3).ifPresent(clazz -> TLoggerManager.getLogger(TLocale.getCallerPlugin(clazz)).verbose(asString(path, clazz, args)));
+            Ref.getCallerClass(3).ifPresent(clazz -> asStringList(path, clazz, args).forEach(locale -> TLoggerManager.getLogger(Ref.getCallerPlugin(clazz)).verbose(locale)));
         }
     }
 

--- a/src/main/java/com/ilummc/tlib/resources/TLocaleInstance.java
+++ b/src/main/java/com/ilummc/tlib/resources/TLocaleInstance.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.ilummc.tlib.TLib;
 import com.ilummc.tlib.resources.type.TLocaleText;
 import com.ilummc.tlib.util.Strings;
+import me.skymc.taboolib.TabooLib;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
@@ -11,10 +12,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 
 import javax.annotation.concurrent.ThreadSafe;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -63,7 +61,6 @@ class TLocaleInstance {
         } catch (Exception | Error e) {
             TLib.getTLib().getLogger().error(Strings.replaceWithOrder(TLib.getInternalLanguage().getString("SEND-LOCALE-ERROR"), path));
             TLib.getTLib().getLogger().error(Strings.replaceWithOrder(TLib.getInternalLanguage().getString("LOCALE-ERROR-REASON"), e.toString()));
-            e.printStackTrace();
         }
     }
 

--- a/src/main/java/com/ilummc/tlib/resources/TLocaleSerialize.java
+++ b/src/main/java/com/ilummc/tlib/resources/TLocaleSerialize.java
@@ -57,12 +57,12 @@ public abstract class TLocaleSerialize implements TLocaleSender, ConfigurationSe
 
             @Override
             public void sendTo(CommandSender sender, String... args) {
-                sender.sendMessage("§4<" + path + "§4>");
+                sender.sendMessage("§8<" + path + "§8>");
             }
 
             @Override
             public String asString(String... args) {
-                return "§4<" + path + "§4>";
+                return "§8<" + path + "§8>";
             }
 
             @Override

--- a/src/main/java/com/ilummc/tlib/util/Ref.java
+++ b/src/main/java/com/ilummc/tlib/util/Ref.java
@@ -2,7 +2,10 @@ package com.ilummc.tlib.util;
 
 import com.google.gson.annotations.SerializedName;
 import com.ilummc.tlib.TLib;
+import com.ilummc.tlib.resources.TLocale;
 import com.ilummc.tlib.util.asm.AsmAnalyser;
+import me.skymc.taboolib.Main;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import sun.reflect.Reflection;
@@ -94,6 +97,17 @@ public class Ref {
             }
         }
         return Optional.empty();
+    }
+
+    public static JavaPlugin getCallerPlugin(Class<?> callerClass) {
+        try {
+            Field pluginField = callerClass.getClassLoader().getClass().getDeclaredField("plugin");
+            pluginField.setAccessible(true);
+            return (JavaPlugin) pluginField.get(callerClass.getClassLoader());
+        } catch (Exception ignored) {
+            TLocale.Logger.error("LOCALE.CALLER-PLUGIN-NOT-FOUND", callerClass.getName());
+        }
+        return (JavaPlugin) Main.getInst();
     }
 
     private static abstract class CallerClass {

--- a/src/main/java/me/skymc/taboolib/Main.java
+++ b/src/main/java/me/skymc/taboolib/Main.java
@@ -1,6 +1,8 @@
 package me.skymc.taboolib;
 
 import com.ilummc.tlib.TLib;
+import com.ilummc.tlib.inject.TConfigWatcher;
+import com.ilummc.tlib.resources.TLocale;
 import me.skymc.taboolib.anvil.AnvilContainerAPI;
 import me.skymc.taboolib.bstats.Metrics;
 import me.skymc.taboolib.commands.TabooLibMainCommand;
@@ -180,7 +182,7 @@ public class Main extends JavaPlugin implements Listener {
                     String hash = connection.getValue(getTablePrefix() + "_serveruuid", "uuid", TabooLib.getServerUID(), "hash").toString();
                     // 如果这个值和我的值不同
                     if (!hash.equals(StringUtils.hashKeyForDisk(getDataFolder().getPath()))) {
-                        MsgUtils.warn("检测到本服序列号与其他服务器相同, 已重新生成!");
+                        TLocale.Logger.error("NOTIFY.ERROR-SERVER-KEY");
                         // 重新生成序列号
                         TabooLib.resetServerUID();
                         // 关服
@@ -189,7 +191,7 @@ public class Main extends JavaPlugin implements Listener {
                 }
             } else {
                 // 提示
-                MsgUtils.warn("数据库连接失败, 请检查配置是否正确!");
+                TLocale.Logger.error("NOTIFY.ERROR-CONNECTION-FALL");
                 // 关服
                 Bukkit.shutdown();
             }
@@ -235,14 +237,16 @@ public class Main extends JavaPlugin implements Listener {
         }
 
         // 载入完成
-        MsgUtils.send("§7插件载入完成!");
-        MsgUtils.send("§7插件版本: §f" + getDescription().getVersion());
-        MsgUtils.send("§7插件作者: §f" + getDescription().getAuthors());
-        MsgUtils.send("§7游戏版本: §f" + TabooLib.getVerint());
+        TLocale.Logger.info("NOTIFY.SUCCESS-LOADED", getDescription().getAuthors().toString(), getDescription().getVersion(), String.valueOf(TabooLib.getVersion()));
 
         // 文件保存
         Bukkit.getScheduler().runTaskTimerAsynchronously(this, DataUtils::saveAllCaches, 20, 20 * 120);
         Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> PlayerDataManager.saveAllCaches(true, false), 20, 20 * 60);
+        // 文件监控
+        TLib.getTLib().getConfigWatcher().addListener(new File(getDataFolder(), "config.yml"), null, obj -> {
+            reloadConfig();
+            TLocale.Logger.info("CONFIG.RELOAD-SUCCESS", inst.getName(), "config.yml");
+        });
 
         // 插件联动
         new BukkitRunnable() {
@@ -277,8 +281,7 @@ public class Main extends JavaPlugin implements Listener {
 
         // 如果插件尚未启动完成
         if (!started) {
-            MsgUtils.send("&c插件尚未启动完成, 已跳过卸载代码");
-            MsgUtils.send("&c插件作者: &4坏黑");
+            TLocale.Logger.error("NOTIFY.FALL-DISABLE");
             return;
         }
 
@@ -312,8 +315,7 @@ public class Main extends JavaPlugin implements Listener {
         }
 
         // 提示信息
-        MsgUtils.send("&c插件已卸载, 感谢您使用&4禁忌书库");
-        MsgUtils.send("&c插件作者: &4坏黑");
+        TLocale.Logger.error("NOTIFY.SUCCESS-DISABLE");
 
         // 清理头衔
         TagUtils.delete();

--- a/src/main/java/me/skymc/taboolib/TabooLib.java
+++ b/src/main/java/me/skymc/taboolib/TabooLib.java
@@ -10,6 +10,10 @@ import java.util.UUID;
 
 public class TabooLib {
 
+    public static boolean isDebug() {
+        return Main.getInst().getConfig().getBoolean("DEBUG");
+    }
+
     public static void debug(Plugin plugin, String... args) {
         if (Main.getInst().getConfig().getBoolean("DEBUG")) {
             Arrays.stream(args).forEach(var -> Bukkit.getConsoleSender().sendMessage(ChatColor.DARK_RED + "[TabooLib - DEBUG][" + plugin.getName() + "] " + ChatColor.RED + var));

--- a/src/main/java/me/skymc/taboolib/commands/plugin/TabooLibPluginMainCommand.java
+++ b/src/main/java/me/skymc/taboolib/commands/plugin/TabooLibPluginMainCommand.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import com.ilummc.tlib.resources.TLocale;
 import me.skymc.taboolib.commands.internal.BaseMainCommand;
 import me.skymc.taboolib.commands.internal.BaseSubCommand;
+import me.skymc.taboolib.commands.internal.ISubCommand;
 import me.skymc.taboolib.commands.internal.type.CommandArgument;
 import me.skymc.taboolib.plugin.PluginUtils;
 import me.skymc.taboolib.string.ArrayUtils;
@@ -12,6 +13,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,6 +30,21 @@ public class TabooLibPluginMainCommand extends BaseMainCommand {
         loadCommand();
         unloadCommand();
         reloadCommand();
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender commandSender, Command command, String s, String[] args) {
+        if (args.length == 1) {
+            return getSubCommands().stream().filter(internalCommandExecutor -> internalCommandExecutor != null && (args[0].isEmpty() || internalCommandExecutor.getLabel().toLowerCase().startsWith(args[0].toLowerCase()))).map(ISubCommand::getLabel).collect(Collectors.toList());
+        } else if (args.length > 1 && isPluginCommand(args[0])) {
+            return Arrays.stream(Bukkit.getPluginManager().getPlugins()).filter(x -> !PluginUtils.isIgnored(x)).collect(Collectors.toList()).stream().filter(plugin -> args[1].isEmpty() || plugin.getName().toLowerCase().startsWith(args[1].toLowerCase())).map(Plugin::getName).collect(Collectors.toList());
+        } else {
+            return null;
+        }
+    }
+
+    private boolean isPluginCommand(String label) {
+        return "info".equalsIgnoreCase(label) || "load".equalsIgnoreCase(label) || "unload".equalsIgnoreCase(label) || "reload".equalsIgnoreCase(label);
     }
 
     @Override

--- a/src/main/resources/lang/zh_CN.yml
+++ b/src/main/resources/lang/zh_CN.yml
@@ -30,6 +30,21 @@ CONFIG:
   RELOAD-FAIL: '插件 {0} 的配置 {1} 成功重载'
   LISTEN-START: '开始监听 {0} 插件的 {1} 配置文件'
   
+NOTIFY:
+  ERROR-SERVER-KEY: '&4检测到本服序列号与其他服务器相同, 已重新生成!'
+  ERROR-CONNECTION-FALL: '&4数据库连接失败, 请检查配置是否正确!'
+  SUCCESS-LOADED:
+  - '§7插件载入完成!'
+  - '§7插件作者: §f{0}'
+  - '§7插件版本: §f{1}'
+  - '§7游戏版本: §f{2}'
+  SUCCESS-DISABLE:
+  - '&c插件已卸载, 感谢您使用&4禁忌书库'
+  - '&c插件作者: &4坏黑'
+  FALL-DISABLE:
+  - '&c插件尚未启动完成, 已跳过卸载代码'
+  - '&c插件作者: &4坏黑'
+  
 LOCALE:
   TITLE-SEND-TO-NON-PLAYER: '该语言类型只能发送给玩家：{0}'
   PLUGIN-NOT-FOUND: '无效的语言文件发送形式: &4{0}'
@@ -138,7 +153,7 @@ COMMANDS:
     SUCCESS-NORMAL: '&8[&3&lTabooLib&8] &7重载成功'
     SUCCESS-ELAPSED-TIME: '&8[&3&lTabooLib&8] &7重载成功, 耗时: &f{0} ms'
   TABOOLIB:
-    COMMAND-TITLE: '&b&l----- &3&lTabooLib Commands &b&l-----'
+    COMMAND-TITLE: '&e&l----- &6&lTabooLib Commands &e&l-----'
     SAVE:
       DESCRIPTION: '载入插件'
       ARGUMENTS:
@@ -400,7 +415,7 @@ COMMANDS:
     SUCCESS-SEND: '&8[&3&lTabooLib&8] &7信息已发送, 耗时&f: {0}'
     HELP:
     - ''
-    - '&b&l----- &3&lLanguage2 Commands &b&l-----'
+    - '&e&l----- &6&lLanguage2 Commands &e&l-----'
     - ''
     - '&f /{0} send &8[&7玩家/ALL&8] &8[&7语言&8] &8<&7变量&8> &6- &e发送语言提示'
     - '&f /{0} reload &6- &e重载语言库'
@@ -417,7 +432,7 @@ COMMANDS:
     - '&f /{0} reload &6- &e重载语言库'
     - ''
   TPLUGIN:
-    COMMAND-TITLE: '&e&l----- &6&lTabooLibPlugin Commands &b&l-----'
+    COMMAND-TITLE: '&e&l----- &6&lTabooLibPlugin Commands &e&l-----'
     LIST:
       DESCRIPTION: '列出插件'
       LIST-PLUGIN: 


### PR DESCRIPTION
调整：TLocale$logger 现在可以发送多行文本了
调整：TLocale 发送不存在的信息，错误提示由红色改为灰色，用于区分发送错误的提示颜色。
调整：TLocaleLoader 中的 getCallerPlugin 方法转移到 Ref 中
修复：BaseMainCommand 接口中 getType 方法失效的问题
修复：Main 中的语言提示无法更改的问题
新增：TPlugin 命令现在可以补全插件名了
新增：config.yml 现在会自动重载了（部分配置还需重启）