### PR TITLE
更新 commons-lang 到 3.12.0.

### DIFF
--- a/common-5/build.gradle.kts
+++ b/common-5/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     compileOnly("com.google.guava:guava:21.0")
-    compileOnly("org.apache.commons:commons-lang3:3.5")
+    compileOnly("org.apache.commons:commons-lang3:3.12.0")
     compileOnly("org.openjdk.nashorn:nashorn-core:15.2")
     compileOnly(project(":common"))
 }

--- a/common-5/src/main/java/taboolib/common5/FileWatcher.java
+++ b/common-5/src/main/java/taboolib/common5/FileWatcher.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
  * @author lzzelAliz
  */
 @Isolated
-@RuntimeDependency(value = "!org.apache.commons:commons-lang3:3.5", test = "!org.apache.commons.lang3.Validate")
+@RuntimeDependency(value = "!org.apache.commons:commons-lang3:3.12.0", test = "!org.apache.commons.lang3.Validate")
 public class FileWatcher implements Releasable {
 
     public final static FileWatcher INSTANCE = new FileWatcher();

--- a/module-kether/build.gradle.kts
+++ b/module-kether/build.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
     compileOnly("public:PlaceholderAPI:2.10.9")
     compileOnly("ink.ptms.core:v11200:11200:all")
     compileOnly("com.google.guava:guava:17.0")
-    compileOnly("org.apache.commons:commons-lang3:3.5")
+    compileOnly("org.apache.commons:commons-lang3:3.12.0")
     compileOnly(project(":common"))
     compileOnly(project(":common-5"))
     compileOnly(project(":module-chat"))


### PR DESCRIPTION
原版本 3.5 的 ArrayUtils 没有 insert 这个方法.
更新后依然能够正常构建.