### PR TITLE
[Improvement] module-lang & configuration

### DIFF
--- a/module-configuration/src/main/kotlin/taboolib/module/configuration/SecuredFile.kt
+++ b/module-configuration/src/main/kotlin/taboolib/module/configuration/SecuredFile.kt
@@ -69,13 +69,14 @@ class SecuredFile : YamlConfiguration() {
 
         fun dumpAll(key: String, value: Any?, space: Int = 2): String {
             return if (key.contains('.')) {
-                "${key.substring(0, key.indexOf('.'))}:\n${" ".repeat(space)}${dumpAll(key.substring(key.indexOf('.') + 1), value, space + 2)}"
+                "${key.substringBefore('.')}:\n${" ".repeat(space)}${dumpAll(key.substringAfter('.'), value, space + 2)}"
             } else {
                 val dump = dump(value)
                 when {
                     dump.startsWith("-") -> "$key:\n$dump"
                     value is List<*> && value.isEmpty() -> "$key: []"
                     value is Map<*, *> -> if (value.isEmpty()) "$key: {}" else "$key:\n$dump"
+                    value is ConfigurationSection -> "$key: \n  ${dump.replace("\n", "\n  ")}"
                     else -> "$key: $dump"
                 }
             }


### PR DESCRIPTION
## [1] 从旧版本语言文件迁移时高级语言节点的内部参数也被扁平化

**原:**

```yaml
root:
  section:
    node:
      type: sometype
      text: sometext
```

**迁移后:**

```yaml
root-section-node-type: sometype
root-section-node-text: sometext
````

由于直接的 `section.getValues(deep = true)` 导致内部参数也被记入路径.

配置文件更新的自动补全可能也会导致这个问题, 记不清了.

### 解决方案

实现一个特定深度获取节点的方法, 能够在遇到 `type:` 或 `==:` 停止下级内容的扁平化.

**实现:** `chainValue(...)` 方法

- - -

## [2] 配置文件更新的自动补全时高级语言节点的格式不正确

**错误表现:**

```yaml
root-section-node: type: sometype
text: sometext
```

由于直接的将 `ConfigurationSection` `dump` 产生, 漏了换行和一个缩进.

### 解决方案

在 `SecuredFile` 的 (伴生对象) `dumpAll(...)` 方法中单独判断 `ConfigurationSection`, 为它补充一个换行和每一个换行后的一个缩进. 

- - -

## [3] 从旧版本语言文件迁移时产生很多个空 Map 节点

**错误表现:**

```yaml
root:
  section: {}
anotherroot: {}
```

由于在迁移时删除光了所有子节点, 没有删掉父节点. 

具体是 `file.set(it.key, null)` 这一句.

在扁平化的过程中产生了很多这样的 Key:

- root.section.node1
- root.section.node2
- root.section.node3

单独为 `node1`, `node2` 和 `node3` set Null, 却没有为 `root.section` set Null, 就会产生一个:

```yaml
root:
  section: {}
```

### 解决方案

直接删掉根节点, 反正全都被扁平化了.

- - -

## [4] 从旧版本的 JSON  语言节点的数据迁移

### 解决方案

在旧版本语言文件迁移的过程中, 会产生一个 `Map<String, Any>` 表示所有的节点.

在问题 [1] 的解决方案中, 高级语言节点都会被用 `ConfigurationSection` 表示 (为了保证内部结构的不变), 为 JSON 语言节点的数据迁移提供了便利.

(在之前的实现中是 `getValues(deep = true)`, 高级语言节点全都被拍得彻底平平的 :D )

新版本的 JSON 语言节点的 `args` 用的是 `List<Map<*, *>>`, 旧版本是 Section (可以表示为 `Map<String, Map<*, *>>`), 同时也可以利用此点判断是否是新版 JSON 语言节点.

只需要从 `text` 中获取到点击区域的定义 `<显示内容@args ID>` (使用正则表达式), 替换为新版的定义 `[点击区域]`.

这里需要注意 `text` 中 `[]` 的转义.

然后将 `args` 按顺序构建 MapList 再 `set` 回 Section 就行了.

**实现:** `migrateOldJson(...)` 方法

## [5] 小改动

### List 语言节点内的空白字符串 ""

为了避免不必要的 Section 修改, `migrateOldJson(...)` 发生在扁平化时的 `set` 阶段, 这个地方需要判断被 `set` 的对象是否是 `ConfigurationSection` (从而调用 `migrateOldJson(...)` 方法, 不过不用担心, 如果不是 JSON 语言节点会在方法头几行就被返回, 如果以后需要更多的高级语言节点迁移可以在方法外部做判断), 为 `List` 的检查提供了便利.

检查是否是 `String`, 然后判断 `isEmpty()` 然后赋值 `&r` 即可.

### List 语言节点内的旧版本 JSON 语言节点的数据迁移

跟上面一样, 已经遍历 `List` 检查了, 多检查一个也无妨.

不过需要注意的是 `List` 内的高级语言节点是 `LinkedHashMap` 而不是 `ConfigurationSection`.

同时 `migrateOldJson(...)` 方法需要传入一个 Section.

```Kotlin
val section = YamlConfiguration()
map.forEach { (key, value) ->
    section[key.toString()] = value
}
```

这样的简单转化只有一层, 遇到嵌套 Map 时内部的 Map 不会被转化成 Section:

```yaml
node:
  type: JSON # String
  args: {...} # LinkedHashMap
```

就无法使用 `getConfigurationSection("args")` 了.

**实现:** `createConfigurationSection(...)` 方法, 使用 Map 深度创建一个新的 Section :D, 或许你可以把它放到某个 Util 里面...

- - -

## 后言

代码写的不好, 呜呜呜, 可以指出来, 我会改进我的代码习惯.

谢谢您❤️