### PR TITLE
[Improvement] Colored qualified lang text

### DIFF
--- a/module-lang/src/main/kotlin/taboolib/module/lang/LangQualify.kt
+++ b/module-lang/src/main/kotlin/taboolib/module/lang/LangQualify.kt
@@ -6,6 +6,7 @@ import taboolib.common.Isolated
 import taboolib.common.platform.ProxyCommandSender
 import taboolib.common.platform.function.pluginId
 import taboolib.common.util.replaceWithOrder
+import taboolib.module.chat.colored
 
 fun ProxyCommandSender.sendInfo(node: String, vararg args: Any) {
     sendLang(Level.INFO, node, *args)
@@ -49,7 +50,7 @@ fun ProxyCommandSender.asLangTextList(level: Level, node: String, vararg args: A
 
 fun ProxyCommandSender.asQualifyText(level: Level, message: String, vararg args: Any): String {
     val prefix = asLangTextOrNull("prefix-${level.name.lowercase()}") ?: asLangTextOrNull("prefix") ?: "§c[$pluginId]"
-    return "$prefix§r $message".replaceWithOrder(*args)
+    return "$prefix§r $message".replaceWithOrder(*args).colored()
 }
 
 @Isolated


### PR DESCRIPTION
因为使用 QualifyLang 的时候一般都是 sendInfo/Warn/Error(node), 没有机会给消息内容 `colored()`, 所以想要能够在 QualifyLang 的底层格式化方法上就将消息内容着色了. :D