### PR TITLE
修复 执行耗时action时无法立即set导致后续变量为空的问题

### DIFF
--- a/module/module-kether/src/main/kotlin/taboolib/module/kether/action/ActionSet.kt
+++ b/module/module-kether/src/main/kotlin/taboolib/module/kether/action/ActionSet.kt
@@ -26,10 +26,9 @@ class ActionSet {
     class ForAction(val key: String, val action: ParsedAction<*>) : QuestAction<Void>() {
 
         override fun process(frame: QuestContext.Frame): CompletableFuture<Void> {
-            frame.newFrame(action).run<Any?>().thenAccept {
+            return frame.newFrame(action).run<Any?>().thenAccept {
                 frame.variables().set(key, it)
             }
-            return CompletableFuture.completedFuture(null)
         }
     }
 


### PR DESCRIPTION
修复使用kether的动作 set token to action 时 action动作执行慢时导致的变量无法及时set的问题