### PR TITLE
Fixed a problem that could cause NullPointerException

### DIFF
--- a/platform/platform-bukkit/src/main/kotlin/taboolib/platform/compat/PlaceholderExpansion.kt
+++ b/platform/platform-bukkit/src/main/kotlin/taboolib/platform/compat/PlaceholderExpansion.kt
@@ -68,7 +68,7 @@ interface PlaceholderExpansion {
                         return BukkitPlugin.getInstance().description.version
                     }
 
-                    override fun onPlaceholderRequest(player: Player, params: String): String {
+                    override fun onPlaceholderRequest(player: Player?, params: String): String {
                         return expansion.onPlaceholderRequest(player, params)
                     }
                 }.register()


### PR DESCRIPTION
Fixed a problem that could cause java.lang.NullPointerException: Parameter specified as non-null is null.