### PR TITLE
在使用 module-lang 向玩家发送信息时可自定义修改信息内容或使用自定义变量替换

### DIFF
--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/Lang.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/Lang.kt
@@ -16,15 +16,40 @@ fun ProxyCommandSender.sendLang(node: String, vararg args: Any) {
         }
     }
 }
+fun ProxyCommandSender.sendLang(node: String, func: (String?) -> String?) {
+    val file = getLocaleFile()
+    if (file == null) {
+        sendMessage("{$node}")
+    } else {
+        val type = file.nodes[node]
+        if (type != null) {
+            type.send(this, func)
+        } else {
+            sendMessage("{$node}")
+        }
+    }
+}
 
 fun ProxyCommandSender.asLangText(node: String, vararg args: Any): String {
     return asLangTextOrNull(node, *args) ?: "{$node}"
+}
+
+fun ProxyCommandSender.asLangText(node: String, func: (String?) -> String?): String {
+    return asLangTextOrNull(node, func) ?: "{$node}"
 }
 
 fun ProxyCommandSender.asLangTextOrNull(node: String, vararg args: Any): String? {
     val file = getLocaleFile()
     if (file != null) {
         return (file.nodes[node] as? TypeText)?.asText(this, *args)
+    }
+    return null
+}
+
+fun ProxyCommandSender.asLangTextOrNull(node: String, func: (String?) -> String?): String? {
+    val file = getLocaleFile()
+    if (file != null) {
+        return (file.nodes[node] as? TypeText)?.asText(this, func)
     }
     return null
 }
@@ -41,6 +66,26 @@ fun ProxyCommandSender.asLangTextList(node: String, vararg args: Any): List<Stri
             }
             is TypeList -> {
                 type.asTextList(this, *args)
+            }
+            else -> {
+                listOf("{$node}")
+            }
+        }
+    }
+}
+
+fun ProxyCommandSender.asLangTextList(node: String, func: (String?) -> String?): List<String> {
+    val file = getLocaleFile()
+    return if (file == null) {
+        listOf("{$node}")
+    } else {
+        when (val type = file.nodes[node]) {
+            is TypeText -> {
+                val text = type.asText(this, func)
+                if (text != null) listOf(text) else emptyList()
+            }
+            is TypeList -> {
+                type.asTextList(this, func)
             }
             else -> {
                 listOf("{$node}")

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/LangQualify.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/LangQualify.kt
@@ -12,45 +12,89 @@ fun ProxyCommandSender.sendInfo(node: String, vararg args: Any) {
     sendLang(Level.INFO, node, *args)
 }
 
+fun ProxyCommandSender.sendInfo(node: String, func: (String?) -> String?) {
+    sendLang(Level.INFO, node, func)
+}
+
 fun ProxyCommandSender.sendWarn(node: String, vararg args: Any) {
     sendLang(Level.WARN, node, *args)
+}
+
+fun ProxyCommandSender.sendWarn(node: String, func: (String?) -> String?) {
+    sendLang(Level.WARN, node, func)
 }
 
 fun ProxyCommandSender.sendError(node: String, vararg args: Any) {
     sendLang(Level.ERROR, node, *args)
 }
 
+fun ProxyCommandSender.sendError(node: String, func: (String?) -> String?) {
+    sendLang(Level.ERROR, node, func)
+}
+
 fun ProxyCommandSender.sendLang(level: Level, node: String, vararg args: Any) {
     asLangTextList(level, node, *args).forEach { sendMessage(it) }
+}
+
+fun ProxyCommandSender.sendLang(level: Level, node: String, func: (String?) -> String?) {
+    asLangTextList(level, node, func).forEach { sendMessage(it) }
 }
 
 fun ProxyCommandSender.sendInfoMessage(message: String, vararg args: Any) {
     sendMessage(Level.INFO, message, *args)
 }
 
+fun ProxyCommandSender.sendInfoMessage(message: String, func: (String?) -> String?) {
+    sendMessage(Level.INFO, message, func)
+}
+
 fun ProxyCommandSender.sendWarnMessage(message: String, vararg args: Any) {
     sendMessage(Level.WARN, message, *args)
+}
+
+fun ProxyCommandSender.sendWarnMessage(message: String, func: (String?) -> String?) {
+    sendMessage(Level.WARN, message, func)
 }
 
 fun ProxyCommandSender.sendErrorMessage(message: String, vararg args: Any) {
     sendMessage(Level.ERROR, message, *args)
 }
 
+fun ProxyCommandSender.sendErrorMessage(message: String, func: (String?) -> String?) {
+    sendMessage(Level.ERROR, message, func)
+}
+
 fun ProxyCommandSender.sendMessage(level: Level, message: String, vararg args: Any) {
     sendMessage(asQualifyText(level, message, *args))
 }
 
+fun ProxyCommandSender.sendMessage(level: Level, message: String, func: (String?) -> String?) {
+    sendMessage(asQualifyText(level, message, func))
+}
 fun ProxyCommandSender.asLangText(level: Level, node: String, vararg args: Any): String {
     return asQualifyText(level, asLangText(node, *args))
+}
+
+fun ProxyCommandSender.asLangText(level: Level, node: String, func: (String?) -> String?): String {
+    return asQualifyText(level, asLangText(node, func))
 }
 
 fun ProxyCommandSender.asLangTextList(level: Level, node: String, vararg args: Any): List<String> {
     return asLangTextList(node, *args).map { asQualifyText(level, it, *args) }
 }
 
+fun ProxyCommandSender.asLangTextList(level: Level, node: String, func: (String?) -> String?): List<String> {
+    return asLangTextList(node, func).map { asQualifyText(level, it, func) }
+}
+
 fun ProxyCommandSender.asQualifyText(level: Level, message: String, vararg args: Any): String {
     val prefix = asLangTextOrNull("prefix-${level.name.lowercase()}") ?: asLangTextOrNull("prefix") ?: "§c[$pluginId]"
     return "$prefix§r $message".replaceWithOrder(*args).colored()
+}
+
+fun ProxyCommandSender.asQualifyText(level: Level, message: String, func: (String?) -> String?): String {
+    val prefix = asLangTextOrNull("prefix-${level.name.lowercase()}") ?: asLangTextOrNull("prefix") ?:  "§c[$pluginId]"
+    return func.invoke("$prefix§r $message")!!.colored()
 }
 
 @Isolated

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/Type.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/Type.kt
@@ -37,6 +37,8 @@ interface Type {
 
     fun send(sender: ProxyCommandSender, vararg args: Any)
 
+    fun send(sender: ProxyCommandSender, func: (String?) -> String?)
+
     fun String.translate(sender: ProxyCommandSender): String {
         var s = this
         Language.textTransfer.forEach { s = it.translate(sender, s) }

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeActionBar.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeActionBar.kt
@@ -27,6 +27,12 @@ class TypeActionBar : Type {
         }
     }
 
+    override fun send(sender: ProxyCommandSender, func: (String?) -> String?) {
+        if (sender is ProxyPlayer) {
+            sender.sendActionBar(func.invoke(text.translate(sender))!!)
+        }
+    }
+
     override fun toString(): String {
         return "NodeActionBar(text='$text')"
     }

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeCommand.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeCommand.kt
@@ -23,6 +23,10 @@ class TypeCommand : Type {
         command?.forEach { console().performCommand(it.replace("@p", sender.name)) }
     }
 
+    override fun send(sender: ProxyCommandSender, func: (String?) -> String?) {
+        send(sender)
+    }
+
     override fun toString(): String {
         return "TypeCommand(command='$command')"
     }

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeJson.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeJson.kt
@@ -66,6 +66,46 @@ class TypeJson : Type {
         }
     }
 
+    override fun send(sender: ProxyCommandSender, func: (String?) -> String?) {
+        TellrawJson().sendTo(sender) {
+            var i = 0
+            text?.forEachIndexed { index, line ->
+                parser.readToFlatten(line).forEach { part ->
+                    append(func.invoke(part.text.translate(sender))!!)
+                    if (part.isVariable) {
+                        val arg = jsonArgs.getOrNull(i++)
+                        if (arg != null) {
+                            if (arg.containsKey("hover")) {
+                                hoverText(func.invoke(arg["hover"].toString().translate(sender))!!)
+                            }
+                            if (arg.containsKey("command")) {
+                                runCommand(func.invoke(arg["command"].toString().translate(sender))!!)
+                            }
+                            if (arg.containsKey("suggest")) {
+                                suggestCommand(func.invoke(arg["suggest"].toString().translate(sender))!!)
+                            }
+                            if (arg.containsKey("insertion")) {
+                                insertion(func.invoke(arg["insertion"].toString().translate(sender))!!)
+                            }
+                            if (arg.containsKey("copy")) {
+                                copyToClipboard(func.invoke(arg["copy"].toString().translate(sender))!!)
+                            }
+                            if (arg.containsKey("file")) {
+                                openFile(func.invoke(arg["file"].toString().translate(sender))!!)
+                            }
+                            if (arg.containsKey("url")) {
+                                openURL(func.invoke(arg["url"].toString().translate(sender))!!)
+                            }
+                        }
+                    }
+                }
+                if (index + 1 < text!!.size) {
+                    newLine()
+                }
+            }
+        }
+    }
+
     companion object {
 
         private val parser = VariableReader("[", "]")

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeList.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeList.kt
@@ -15,11 +15,19 @@ class TypeList(val list: List<Type>) : Type {
         return list.filterIsInstance<TypeText>().mapNotNull { it.asText(sender, *args) }
     }
 
+    fun asTextList(sender: ProxyCommandSender, func: (String) -> (String)): List<String> {
+        return list.filterIsInstance<TypeText>().mapNotNull { it.asText(sender, func) }
+    }
+
     override fun init(source: Map<String, Any>) {
     }
 
     override fun send(sender: ProxyCommandSender, vararg args: Any) {
         list.forEach { it.send(sender, *args) }
+    }
+
+    override fun send(sender: ProxyCommandSender, func: (String?) -> String?) {
+        list.forEach { it.send(sender, func) }
     }
 
     override fun toString(): String {

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeSound.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeSound.kt
@@ -39,6 +39,10 @@ class TypeSound : Type {
         }
     }
 
+    override fun send(sender: ProxyCommandSender, func: (String?) -> String?) {
+        send(sender)
+    }
+
     override fun toString(): String {
         return "NodeSound(sound='$sound', volume=$volume, pitch=$pitch)"
     }

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeText.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeText.kt
@@ -25,6 +25,10 @@ class TypeText : Type {
         return text?.translate(sender)?.replaceWithOrder(*args)
     }
 
+    fun asText(sender: ProxyCommandSender, func: (String?) -> (String?)): String? {
+        return func.invoke(text?.translate(sender))
+    }
+
     override fun init(source: Map<String, Any>) {
         text = source["text"]?.toString()
         // if blocked
@@ -36,6 +40,12 @@ class TypeText : Type {
     override fun send(sender: ProxyCommandSender, vararg args: Any) {
         if (text != null) {
             sender.sendMessage(text!!.translate(sender).replaceWithOrder(*args))
+        }
+    }
+
+    override fun send(sender: ProxyCommandSender, func: (String?) -> String?) {
+        if (text != null) {
+            sender.sendMessage(func.invoke(text!!.translate(sender))!!)
         }
     }
 

--- a/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeTitle.kt
+++ b/module/module-lang/src/main/kotlin/taboolib/module/lang/TypeTitle.kt
@@ -35,6 +35,14 @@ class TypeTitle : Type {
         }
     }
 
+    override fun send(sender: ProxyCommandSender, func: (String?) -> String?) {
+        if (sender is ProxyPlayer) {
+            sender.sendTitle(func.invoke(title?.translate(sender)), func.invoke(subtitle?.translate(sender)), fadein, stay, fadeout)
+        } else {
+            sender.sendMessage(toString())
+        }
+    }
+
     override fun toString(): String {
         return "NodeTitle(title=$title, subtitle=$subtitle, fadein=$fadein, stay=$stay, fadeout=$fadeout)"
     }

--- a/platform/platform-bukkit/src/main/kotlin/taboolib/platform/util/BukkitLang.kt
+++ b/platform/platform-bukkit/src/main/kotlin/taboolib/platform/util/BukkitLang.kt
@@ -14,14 +14,30 @@ fun CommandSender.sendLang(node: String, vararg args: Any) {
     adaptCommandSender(this).sendLang(node, *args)
 }
 
+fun CommandSender.sendLang(node: String, func: (String?) -> String?) {
+    adaptCommandSender(this).sendLang(node, func)
+}
+
 fun CommandSender.asLangTextOrNull(node: String, vararg args: Any): String? {
     return adaptCommandSender(this).asLangTextOrNull(node, *args)
+}
+
+fun CommandSender.asLangTextOrNull(node: String, func: (String?) -> String?): String? {
+    return adaptCommandSender(this).asLangTextOrNull(node, func)
 }
 
 fun CommandSender.asLangText(node: String, vararg args: Any): String {
     return adaptCommandSender(this).asLangText(node, *args)
 }
 
+fun CommandSender.asLangText(node: String, func: (String?) -> String?): String {
+    return adaptCommandSender(this).asLangText(node, func)
+}
+
 fun CommandSender.asLangTextList(node: String, vararg args: Any): List<String> {
     return adaptCommandSender(this).asLangTextList(node, *args)
+}
+
+fun CommandSender.asLangTextList(node: String, func: (String?) -> String?): List<String> {
+    return adaptCommandSender(this).asLangTextList(node, func)
 }

--- a/platform/platform-bukkit/src/main/kotlin/taboolib/platform/util/BukkitLangQualify.kt
+++ b/platform/platform-bukkit/src/main/kotlin/taboolib/platform/util/BukkitLangQualify.kt
@@ -11,38 +11,78 @@ fun CommandSender.sendInfo(node: String, vararg args: Any) {
     sendLang(Level.INFO, node, *args)
 }
 
+fun CommandSender.sendInfo(node: String, func: (String?) -> String?) {
+    sendLang(Level.INFO, node, func)
+}
+
 fun CommandSender.sendWarn(node: String, vararg args: Any) {
     sendLang(Level.WARN, node, *args)
+}
+
+fun CommandSender.sendWarn(node: String, func: (String?) -> String?) {
+    sendLang(Level.WARN, node, func)
 }
 
 fun CommandSender.sendError(node: String, vararg args: Any) {
     sendLang(Level.ERROR, node, *args)
 }
 
+fun CommandSender.sendError(node: String, func: (String?) -> String?) {
+    sendLang(Level.ERROR, node, func)
+}
+
 fun CommandSender.sendLang(level: Level, node: String, vararg args: Any) {
     adaptCommandSender(this).sendLang(level, node, *args)
+}
+
+fun CommandSender.sendLang(level: Level, node: String, func: (String?) -> String?) {
+    adaptCommandSender(this).sendLang(level, node, func)
 }
 
 fun CommandSender.sendInfoMessage(message: String, vararg args: Any) {
     sendMessage(Level.INFO, message, *args)
 }
 
+fun CommandSender.sendInfoMessage(message: String, func: (String?) -> String?) {
+    sendMessage(Level.INFO, message, func)
+}
+
 fun CommandSender.sendWarnMessage(message: String, vararg args: Any) {
     sendMessage(Level.WARN, message, *args)
+}
+
+fun CommandSender.sendWarnMessage(message: String, func: (String?) -> String?) {
+    sendMessage(Level.WARN, message, func)
 }
 
 fun CommandSender.sendErrorMessage(message: String, vararg args: Any) {
     sendMessage(Level.ERROR, message, *args)
 }
 
+fun CommandSender.sendErrorMessage(message: String, func: (String?) -> String?) {
+    sendMessage(Level.ERROR, message, func)
+}
+
 fun CommandSender.sendMessage(level: Level, message: String, vararg args: Any) {
     adaptCommandSender(this).sendMessage(level, message, *args)
+}
+
+fun CommandSender.sendMessage(level: Level, message: String, func: (String?) -> String?) {
+    adaptCommandSender(this).sendMessage(level, message, func)
 }
 
 fun CommandSender.asLangText(level: Level, node: String, vararg args: Any): String {
     return adaptCommandSender(this).asLangText(level, node, *args)
 }
 
+fun CommandSender.asLangText(level: Level, node: String, func: (String?) -> String?): String {
+    return adaptCommandSender(this).asLangText(level, node, func)
+}
+
 fun CommandSender.asLangTextList(level: Level, node: String, vararg args: Any): List<String> {
     return adaptCommandSender(this).asLangTextList(level, node, *args)
+}
+
+fun CommandSender.asLangTextList(level: Level, node: String, func: (String?) -> String?): List<String> {
+    return adaptCommandSender(this).asLangTextList(level, node, func)
 }


### PR DESCRIPTION
今天在写插件时，发现 taboolib 的替换变量都是诸如 {0} {1} 的东西，如果没有注释或其他告诉服主这些代表什么意义的方式，我个人认为服主会较不易配置该插件的语言文件。
为此，我写了一些方法，能让开发者在向玩家发送这些方法时对获取到的语言文本做些修改再发出去，例如添加 %player% 之类的非 PlaceholderAPi 变量，开发者自定义变量。我觉得开发者写起来会更加方便。

使用方法举例：
```java
            e.player.sendLang("motd") {
                it?.replace("%player%", e.player.name)?.replace("%online%", onlinePlayers().size.toString())
                    ?.replace("%worldtime%", "上午1:61")
            }
```
在语言文件中：
```yaml
motd:
  - "&6Welcome, %player%&6!"
  - "&6Type &c/help&6 for a list of commands."
  - "&6Type &c/list&6 to see who else is online."
  - "&6Players online:&c %online% &6- World time:&c %worldtime%"
```

以上为个人见解，如果有错误或代码有不足之处还请指出，非常感谢。