### PR TITLE
细节优化: 使 keybind 和 selector 更人性化, 新增 newline 换行

### DIFF
--- a/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
+++ b/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
@@ -56,9 +56,9 @@ open class TextBlock(val level: Int, val properties: MutableMap<String, Property
         // 文本类型
         when {
             // 快捷键
-            properties["keybind", "key"] != null -> rawMessage.appendKeybind(newText)
+            properties.containsKey("keybind") || properties.containsKey("key") -> rawMessage.appendKeybind(newText)
             // 选择器
-            properties["selector", "select"] != null -> rawMessage.appendSelector(newText)
+            properties.containsKey("selector") || properties.containsKey("select") -> rawMessage.appendSelector(newText)
             // 分数
             properties["score"] != null -> {
                 val obj = properties["objective", "obj"] ?: error("Missing objective for score.")
@@ -71,7 +71,7 @@ open class TextBlock(val level: Int, val properties: MutableMap<String, Property
             }
             // 语言文件
             // 这玩意儿还是算了吧，泛用性真不高
-            properties["translate", "trans"] != null -> {
+            properties.containsKey("translate") || properties.containsKey("trans") -> {
                 // 语言文件参数
                 // 支持格式: arg0=bar;arg1=foo;args=foo,bar
                 val args = arrayListOf<TransArgument>()
@@ -100,6 +100,7 @@ open class TextBlock(val level: Int, val properties: MutableMap<String, Property
                 "i" -> rawMessage.italic()
                 "b" -> rawMessage.bold()
                 "o" -> rawMessage.obfuscated()
+                "newline", "nl" -> rawMessage.newLine()
                 "font" -> rawMessage.font(transfer(value))
                 "url" -> rawMessage.clickOpenURL(transfer(value))
                 "file" -> rawMessage.clickOpenFile(transfer(value))


### PR DESCRIPTION
新写法：`[key.jump](keybind)`   ->   空格
selector **不会**
新写法：`[](newline)` 或 `[](nl)` 换行