### PR TITLE
新功能: 为行内复合文本悬停显示信息功能新增多行支持

### DIFF
--- a/module/module-chat/src/main/kotlin/taboolib/module/chat/ComponentText.kt
+++ b/module/module-chat/src/main/kotlin/taboolib/module/chat/ComponentText.kt
@@ -46,6 +46,9 @@ interface ComponentText : Source {
     /** 显示文本 */
     fun hoverText(text: String): ComponentText
 
+    /** 显示多行文本 */
+    fun hoverText(text: List<String>): ComponentText
+
     /** 显示 [ComponentText] */
     fun hoverText(text: ComponentText): ComponentText
 

--- a/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/DefaultComponent.kt
+++ b/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/DefaultComponent.kt
@@ -123,6 +123,17 @@ class DefaultComponent() : ComponentText {
         return hoverText(ComponentText.of(text))
     }
 
+    override fun hoverText(text: List<String>): ComponentText {
+        val component = ComponentText.empty()
+        text.forEachIndexed { index, s ->
+            component.append(s)
+            if (index != text.size - 1) {
+                component.newLine()
+            }
+        }
+        return hoverText(component)
+    }
+
     override fun hoverText(text: ComponentText): ComponentText {
         text as? DefaultComponent ?: error("Unsupported component type.")
         try {

--- a/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
+++ b/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
@@ -114,8 +114,8 @@ open class TextBlock(val level: Int, val properties: MutableMap<String, Property
                         rawMessage.hoverText(value.getValue(transfer))
                     } else {
                         val content = transfer(value)
-                        if (content.contains(",")) {
-                            rawMessage.hoverText(content.split(','))
+                        if (content.contains("\n")) {
+                            rawMessage.hoverText(content.split('\n'))
                         } else {
                             rawMessage.hoverText(transfer(value))
                         }

--- a/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
+++ b/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
@@ -113,7 +113,12 @@ open class TextBlock(val level: Int, val properties: MutableMap<String, Property
                     if (value is PropertyValue.Link) {
                         rawMessage.hoverText(value.getValue(transfer))
                     } else {
-                        rawMessage.hoverText(transfer(value))
+                        val content = transfer(value)
+                        if (content.contains(",")) {
+                            rawMessage.hoverText(content.split(','))
+                        } else {
+                            rawMessage.hoverText(transfer(value))
+                        }
                     }
                 }
                 "color", "c" -> {

--- a/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
+++ b/module/module-chat/src/main/kotlin/taboolib/module/chat/impl/TextBlock.kt
@@ -117,7 +117,7 @@ open class TextBlock(val level: Int, val properties: MutableMap<String, Property
                         if (content.contains("\n")) {
                             rawMessage.hoverText(content.split('\n'))
                         } else {
-                            rawMessage.hoverText(transfer(value))
+                            rawMessage.hoverText(content)
                         }
                     }
                 }


### PR DESCRIPTION
`[测试](hover=这是他妈的第一行\n这是他妈的第二行)`