### PR TITLE
Add expansion-player-fake-op

### DIFF
--- a/expansion/expansion-player-fake-op/build.gradle.kts
+++ b/expansion/expansion-player-fake-op/build.gradle.kts
@@ -1,0 +1,12 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+dependencies {
+    compileOnly(project(":common"))
+    compileOnly(project(":module:module-nms"))
+    compileOnly("ink.ptms.core:v11701:11701-minimize:universal")
+    compileOnly("net.bytebuddy:byte-buddy:1.14.6")
+}
+
+tasks.withType<ShadowJar> {
+    relocate("net.bytebuddy.", "net.bytebuddy_1_14_6.")
+}

--- a/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMS.kt
+++ b/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMS.kt
@@ -1,0 +1,32 @@
+package taboolib.expansion
+
+import org.bukkit.entity.Player
+import taboolib.common.env.RuntimeDependency
+import taboolib.common.util.unsafeLazy
+import taboolib.module.nms.nmsProxy
+
+@RuntimeDependency(
+    value = "!net.bytebuddy:byte-buddy:1.14.6",
+    relocate = ["!net.bytebuddy", "!net.bytebuddy_1_14_6"],
+    test = "!net.bytebuddy_1_14_6.ByteBuddy",
+    transitive = false
+)
+abstract class PlayerFakeOpNMS {
+
+    /**
+     * 获取 [player] 的 PlayerFakeOp 代理对象
+     * 
+     * 此代理对象使得 isOp() hasPermission(String) hasPermission(Permission) 三个方法均返回 true
+     * 
+     * @param player 原 CraftPlayer 对象
+     * @return [player] 的 PlayerFakeOp 代理对象
+     */
+    abstract fun playerFakeOp(player: Player): Player
+    
+    companion object {
+        val INSTANCE by unsafeLazy { 
+            nmsProxy<PlayerFakeOpNMS>()
+        }
+    }
+    
+}

--- a/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMSImpl.kt
+++ b/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMSImpl.kt
@@ -1,0 +1,89 @@
+package taboolib.expansion
+
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.modifier.Visibility
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import net.bytebuddy.implementation.FieldAccessor
+import net.bytebuddy.implementation.FixedValue
+import net.bytebuddy.implementation.MethodCall
+import net.bytebuddy.implementation.MethodDelegation
+import net.bytebuddy.implementation.bind.annotation.FieldValue
+import net.bytebuddy.implementation.bind.annotation.Pipe
+import net.bytebuddy.implementation.bind.annotation.RuntimeType
+import net.bytebuddy.matcher.ElementMatchers
+import net.minecraft.server.level.EntityPlayer
+import org.bukkit.craftbukkit.v1_17_R1.CraftServer
+import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer
+import org.bukkit.entity.Player
+import org.bukkit.permissions.Permission
+import taboolib.common.util.unsafeLazy
+import java.lang.reflect.Constructor
+
+class PlayerFakeOpNMSImpl : PlayerFakeOpNMS() {
+
+    val playerFakeOpUtil: PlayerFakeOpUtil by unsafeLazy { PlayerFakeOpUtil() }
+    
+    override fun playerFakeOp(player: Player): Player {
+        return playerFakeOpUtil.createProxy(player as CraftPlayer)
+    }
+
+    class PlayerFakeOpUtil {
+        val playerFakeOpClass: Class<out CraftPlayer>
+        val playerFakeOpConstructor: Constructor<out CraftPlayer>
+        private lateinit var tempCraftPlayer: CraftPlayer
+        
+        init {
+            // Generate the bytecode of the new class, which extends CraftPlayer
+            val dynamicType = ByteBuddy()
+                .subclass(CraftPlayer::class.java)
+                // Define the field craftPlayer to save the original CraftPlayer
+                .defineField("craftPlayer", CraftPlayer::class.java, Visibility.PUBLIC)
+                // Define the method hasPermission(String) always returning true
+                .defineMethod("hasPermission", Boolean::class.java, Visibility.PUBLIC)
+                .withParameter(String::class.java)
+                .intercept(FixedValue.value(true))
+                // Define the method hasPermission(Permission) always returning true
+                .defineMethod("hasPermission", Boolean::class.java, Visibility.PUBLIC)
+                .withParameter(Permission::class.java)
+                .intercept(FixedValue.value(true))
+                // Define the constructor(CraftServer, EntityPlayer, CraftPlayer) to save the original CraftPlayer in the field craftPlayer
+                .defineConstructor(Visibility.PUBLIC)
+                .withParameters(CraftServer::class.java, EntityPlayer::class.java, CraftPlayer::class.java)
+                .intercept(
+                    MethodCall.invoke(CraftPlayer::class.java.getDeclaredConstructor(CraftServer::class.java, EntityPlayer::class.java))
+                        .withArgument(0, 1)
+                        .andThen(FieldAccessor.ofField("craftPlayer").setsArgumentAt(2))
+                )
+                // Intercept the methods declared by CraftPlayer to the original craftPlayer
+                .method(ElementMatchers.isDeclaredBy(CraftPlayer::class.java))
+                .intercept(
+                    MethodDelegation.withDefaultConfiguration()
+                        .withBinders(Pipe.Binder.install(Forwarder::class.java))
+                        .to(this)
+                )
+                // Intercept the method isOp() to make it always return true
+                .method(ElementMatchers.named("isOp"))
+                .intercept(FixedValue.value(true))
+                .make()
+            
+            // Load the new class by injecting it into the given ClassLoader by reflective access
+            playerFakeOpClass = dynamicType.load(javaClass.classLoader, ClassLoadingStrategy.Default.INJECTION).loaded
+            playerFakeOpConstructor = playerFakeOpClass.getConstructor(CraftServer::class.java, EntityPlayer::class.java, CraftPlayer::class.java)
+        }
+        
+        @RuntimeType
+        fun whatever(@Pipe pipe: Forwarder<Any, CraftPlayer>, @FieldValue("craftPlayer") craftPlayer: CraftPlayer?): Any {
+            // When the object is being initialized, its field craftPlayer will be null, so using tempCraftPlayer instead
+            return pipe.to(craftPlayer ?: tempCraftPlayer)
+        }
+
+        fun createProxy(player: CraftPlayer): CraftPlayer {
+            tempCraftPlayer = player
+            return playerFakeOpConstructor.newInstance(player.server, player.handle, player)
+        }
+
+        interface Forwarder<T, S> {
+            fun to(target: S): T
+        }
+    }
+}

--- a/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpUtils.kt
+++ b/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpUtils.kt
@@ -1,5 +1,6 @@
 package taboolib.expansion
 
+import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 
 /**
@@ -11,3 +12,9 @@ import org.bukkit.entity.Player
  * @return [this] 的 PlayerFakeOp 代理对象
  */
 fun Player.fakeOp(): Player = PlayerFakeOpNMS.INSTANCE.playerFakeOp(this)
+
+/**
+ * 以OP的权限执行指令 (仅针对非原版指令)
+ */
+fun Player.dispatchCommandAsOp(command: String): Boolean =
+    Bukkit.dispatchCommand(fakeOp(), command)

--- a/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpUtils.kt
+++ b/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpUtils.kt
@@ -1,0 +1,13 @@
+package taboolib.expansion
+
+import org.bukkit.entity.Player
+
+/**
+ * 获取 [this] 的 PlayerFakeOp 代理对象
+ * 
+ * 此代理对象使得 isOp() hasPermission(String) hasPermission(Permission) 三个方法均返回 true
+ * 
+ * @receiver 原 CraftPlayer 对象
+ * @return [this] 的 PlayerFakeOp 代理对象
+ */
+fun Player.fakeOp(): Player = PlayerFakeOpNMS.INSTANCE.playerFakeOp(this)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ fun importExtensions() {
     include("expansion:expansion-lang-tools")
     include("expansion:expansion-ioc")
     include("expansion:expansion-application-console")
+    include("expansion:expansion-player-fake-op")
     // 从 common-5 中移除
     include("expansion:expansion-javascript")
 }


### PR DESCRIPTION
通过使用Byte Buddy动态生成字节码，生成了一个继承自CraftPlayer的新类，使得 isOp() hasPermission(String) hasPermission(Permission) 三个方法均返回 true，同时将其他的方法转发到原来的craftPlayer，实现安全的fake op