### PR TITLE
开启enable-isolated-classloader选项时允许通过SPI排除指定类或包（使其非隔离加载）为其他插件提供API

### DIFF
--- a/common/src/main/java/taboolib/common/classloader/IsolatedClassLoader.java
+++ b/common/src/main/java/taboolib/common/classloader/IsolatedClassLoader.java
@@ -9,6 +9,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 public class IsolatedClassLoader extends URLClassLoader {
@@ -39,6 +40,18 @@ public class IsolatedClassLoader extends URLClassLoader {
 		excludedClasses.add("taboolib.common.classloader.IsolatedClassLoader");
 		excludedClasses.add("taboolib.common.platform.Plugin");
 		excludedPackages.add("java.");
+
+		// Load excluded classes and packages by SPI
+		ServiceLoader<IsolatedClassLoaderConfig> serviceLoader = ServiceLoader.load(IsolatedClassLoaderConfig.class, parent);
+		for (IsolatedClassLoaderConfig config : serviceLoader) {
+			Set<String> configExcludedClasses = config.excludedClasses();
+			if (configExcludedClasses != null && !configExcludedClasses.isEmpty())
+				excludedClasses.addAll(configExcludedClasses);
+
+			Set<String> configExcludedPackages = config.excludedPackages();
+			if (configExcludedPackages != null && !configExcludedPackages.isEmpty())
+				excludedPackages.addAll(configExcludedPackages);
+		}
 	}
 	
 	@Override

--- a/common/src/main/java/taboolib/common/classloader/IsolatedClassLoaderConfig.java
+++ b/common/src/main/java/taboolib/common/classloader/IsolatedClassLoaderConfig.java
@@ -1,0 +1,16 @@
+package taboolib.common.classloader;
+
+import java.util.Collections;
+import java.util.Set;
+
+public interface IsolatedClassLoaderConfig {
+	
+	default Set<String> excludedClasses() {
+		return Collections.emptySet();
+	}
+	
+	default Set<String> excludedPackages() {
+		return Collections.emptySet();
+	}
+	
+}


### PR DESCRIPTION
## 使用方法

1. 新建一个java类(不能是kotlin类)实现taboolib.common.classloader.IsolatedClassLoaderConfig接口，excludedClasses()方法返回排除的类的全限定名(包名.类名)，excludedPackages()方法返回排除的包名(最好以 **.** 结尾)
2. 在resources目录下新建META-INF/services目录
3. 在其中新建文件 **项目包名.taboolib.common.classloader.IsolatedClassLoaderConfig**
4. 在该文件中填写接口IsolatedClassLoaderConfig的实现类的全限定名(包名.类名)

## 使用SPI的原因

- 在使用隔离类加载器([IsolatedClassLoader](https://github.com/TabooLib/taboolib/pull/293))时，通过打破类加载器的双亲委派机制以实现类的隔离加载，无需将包名重定向(relocate)即可避免依赖冲突，这样可以使kotlin-reflect正常工作。
- 但是，隔离加载的类虽然可以访问其他插件的类，其他插件却无法访问隔离加载的类，这使得插件无法对外提供API。
- 因此，我在IsolatedClassLoader中加入了addExcludedClass和addExcludedPackage两个方法，分别排除指定的类和包，使它们非隔离加载，这样其他插件就能访问到被排除的类了。
- 不过由于依赖注入需要主动加载所有的类，无论在哪个生命周期调用上面两个方法都无法真正排除指定的类和包。这是因为在任何一个生命周期开始之前，所有的类都已经被加载过了，此时为时已晚。
- 综上所述，只能在IsolatedClassLoader被实例化后立即排除指定的类和包才能生效。为此通过java的SPI(Service Provider Interface)机制，当IsolatedClassLoader实例被构造时，寻找接口IsolatedClassLoaderConfig的服务实现，将实现类指定的类和包排除。

## 注意事项

1. 排除的类和包中最好只提供接口，不能调用任何自身被隔离加载的类、自身加载的依赖和kotlin标准库中的内容(因为它们都是被隔离加载的)
2. 排除的类和包中最好使用java编写，使用kotlin时请严格遵守第1条注意事项