### PR TITLE
[Repull] 补全ItemTag的LongArray&更新部分库版本&修复RuntimeEnv无法正常配置自定义库的问题

### DIFF
--- a/common/src/main/java/taboolib/common/env/RuntimeEnv.java
+++ b/common/src/main/java/taboolib/common/env/RuntimeEnv.java
@@ -194,7 +194,7 @@ public class RuntimeEnv {
         // 支持用户对源进行替换
         if (repository == null || repository.isEmpty()) {
             repository = defaultRepositoryCentral;
-        } else if (ENV_PROPERTIES.contains("repository-" + repository)) {
+        } else if (ENV_PROPERTIES.containsKey("repository-" + repository)) {
             repository = ENV_PROPERTIES.getProperty("repository-" + repository);
         }
         downloader.addRepository(new Repository(repository));

--- a/expansion/expansion-javascript/build.gradle.kts
+++ b/expansion/expansion-javascript/build.gradle.kts
@@ -1,6 +1,6 @@
 @file:Suppress("GradlePackageUpdate")
 
 dependencies {
-    compileOnly("org.openjdk.nashorn:nashorn-core:15.3")
+    compileOnly("org.openjdk.nashorn:nashorn-core:15.4")
     compileOnly(project(":common"))
 }

--- a/expansion/expansion-javascript/src/main/kotlin/taboolib/common5/NashornCompiler.kt
+++ b/expansion/expansion-javascript/src/main/kotlin/taboolib/common5/NashornCompiler.kt
@@ -1,7 +1,7 @@
 @file:Isolated
 @file:RuntimeDependencies(
     RuntimeDependency(
-        "!org.openjdk.nashorn:nashorn-core:15.3",
+        "!org.openjdk.nashorn:nashorn-core:15.4",
         test = "!jdk.nashorn.api.scripting.NashornScriptEngineFactory"
     )
 )

--- a/expansion/expansion-player-fake-op/build.gradle.kts
+++ b/expansion/expansion-player-fake-op/build.gradle.kts
@@ -4,9 +4,9 @@ dependencies {
     compileOnly(project(":common"))
     compileOnly(project(":module:module-nms"))
     compileOnly("ink.ptms.core:v11701:11701-minimize:universal")
-    compileOnly("net.bytebuddy:byte-buddy:1.14.6")
+    compileOnly("net.bytebuddy:byte-buddy:1.14.9")
 }
 
 tasks.withType<ShadowJar> {
-    relocate("net.bytebuddy.", "net.bytebuddy_1_14_6.")
+    relocate("net.bytebuddy.", "net.bytebuddy_1_14_9.")
 }

--- a/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMS.kt
+++ b/expansion/expansion-player-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMS.kt
@@ -6,9 +6,9 @@ import taboolib.common.util.unsafeLazy
 import taboolib.module.nms.nmsProxy
 
 @RuntimeDependency(
-    value = "!net.bytebuddy:byte-buddy:1.14.6",
-    relocate = ["!net.bytebuddy", "!net.bytebuddy_1_14_6"],
-    test = "!net.bytebuddy_1_14_6.ByteBuddy",
+    value = "!net.bytebuddy:byte-buddy:1.14.9",
+    relocate = ["!net.bytebuddy", "!net.bytebuddy_1_14_9"],
+    test = "!net.bytebuddy_1_14_9.ByteBuddy",
     transitive = false
 )
 abstract class PlayerFakeOpNMS {

--- a/module/module-configuration-shaded/build.gradle.kts
+++ b/module/module-configuration-shaded/build.gradle.kts
@@ -1,12 +1,12 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 dependencies {
-    implementation("org.yaml:snakeyaml:2.0")
-    implementation("com.typesafe:config:1.4.2")
-    implementation("com.electronwill.night-config:core:3.6.6")
-    implementation("com.electronwill.night-config:toml:3.6.6")
-    implementation("com.electronwill.night-config:json:3.6.6")
-    implementation("com.electronwill.night-config:hocon:3.6.6")
+    implementation("org.yaml:snakeyaml:2.2")
+    implementation("com.typesafe:config:1.4.3")
+    implementation("com.electronwill.night-config:core:3.6.7")
+    implementation("com.electronwill.night-config:toml:3.6.7")
+    implementation("com.electronwill.night-config:json:3.6.7")
+    implementation("com.electronwill.night-config:hocon:3.6.7")
     implementation(project(":module:module-configuration"))
 }
 

--- a/module/module-configuration/build.gradle.kts
+++ b/module/module-configuration/build.gradle.kts
@@ -2,12 +2,12 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 dependencies {
     implementation("com.electronwill.night-config:core-conversion:6.0.0")
-    compileOnly("org.yaml:snakeyaml:2.0")
-    compileOnly("com.typesafe:config:1.4.2")
-    compileOnly("com.electronwill.night-config:core:3.6.6")
-    compileOnly("com.electronwill.night-config:toml:3.6.6")
-    compileOnly("com.electronwill.night-config:json:3.6.6")
-    compileOnly("com.electronwill.night-config:hocon:3.6.6")
+    compileOnly("org.yaml:snakeyaml:2.2")
+    compileOnly("com.typesafe:config:1.4.3")
+    compileOnly("com.electronwill.night-config:core:3.6.7")
+    compileOnly("com.electronwill.night-config:toml:3.6.7")
+    compileOnly("com.electronwill.night-config:json:3.6.7")
+    compileOnly("com.electronwill.night-config:hocon:3.6.7")
     compileOnly(project(":common"))
     compileOnly(project(":common-5"))
     compileOnly(project(":module:module-chat"))

--- a/module/module-configuration/src/main/kotlin/taboolib/module/configuration/ConfigLoader.kt
+++ b/module/module-configuration/src/main/kotlin/taboolib/module/configuration/ConfigLoader.kt
@@ -14,15 +14,15 @@ import java.util.function.Supplier
 
 @RuntimeDependencies(
     RuntimeDependency(
-        "!org.yaml:snakeyaml:2.0",
-        test = "!org.yaml.snakeyaml_2_0.Yaml",
-        relocate = ["!org.yaml.snakeyaml", "!org.yaml.snakeyaml_2_0"]
+        "!org.yaml:snakeyaml:2.2",
+        test = "!org.yaml.snakeyaml_2_2.Yaml",
+        relocate = ["!org.yaml.snakeyaml", "!org.yaml.snakeyaml_2_2"]
     ),
-    RuntimeDependency("!com.typesafe:config:1.4.2", test = "!com.typesafe.config.Config"),
-    RuntimeDependency("!com.electronwill.night-config:core:3.6.6", test = "!com.electronwill.nightconfig.core.Config"),
-    RuntimeDependency("!com.electronwill.night-config:toml:3.6.6", test = "!com.electronwill.nightconfig.toml.TomlFormat"),
-    RuntimeDependency("!com.electronwill.night-config:json:3.6.6", test = "!com.electronwill.nightconfig.json.JsonFormat"),
-    RuntimeDependency("!com.electronwill.night-config:hocon:3.6.6", test = "!com.electronwill.nightconfig.hocon.HoconFormat")
+    RuntimeDependency("!com.typesafe:config:1.4.3", test = "!com.typesafe.config.Config"),
+    RuntimeDependency("!com.electronwill.night-config:core:3.6.7", test = "!com.electronwill.nightconfig.core.Config"),
+    RuntimeDependency("!com.electronwill.night-config:toml:3.6.7", test = "!com.electronwill.nightconfig.toml.TomlFormat"),
+    RuntimeDependency("!com.electronwill.night-config:json:3.6.7", test = "!com.electronwill.nightconfig.json.JsonFormat"),
+    RuntimeDependency("!com.electronwill.night-config:hocon:3.6.7", test = "!com.electronwill.nightconfig.hocon.HoconFormat")
 )
 @Awake
 class ConfigLoader : ClassVisitor(1) {

--- a/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTag.kt
+++ b/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTag.kt
@@ -266,6 +266,15 @@ class ItemTag : ItemTagData, MutableMap<String, ItemTagData> {
                             }
                             ItemTagData(ints)
                         }
+                        // long 数组
+                        ItemTagType.LONG_ARRAY -> {
+                            val array = json.get("data").asJsonArray
+                            val longs = LongArray(array.size())
+                            for (i in 0 until array.size()) {
+                                longs[i] = array.get(i).asLong
+                            }
+                            ItemTagData(longs)
+                        }
                         // 不支持的类型
                         else -> error("Unsupported nbt type: $type")
                     }

--- a/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTagData.kt
+++ b/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTagData.kt
@@ -35,6 +35,8 @@ open class ItemTagData(val type: ItemTagType, protected var data: Any) {
 
     constructor(data: IntArray) : this(ItemTagType.INT_ARRAY, data)
 
+    constructor(data: LongArray) : this(ItemTagType.LONG_ARRAY, data)
+
     /**
      * 获取为 [Byte]
      */
@@ -91,6 +93,11 @@ open class ItemTagData(val type: ItemTagType, protected var data: Any) {
     open fun asIntArray() = data as IntArray
 
     /**
+     * 获取为 [LongArray]
+     */
+    open fun asLongArray() = data as LongArray
+
+    /**
      * 通过不安全的方式获取数据
      */
     open fun unsafeData() = data
@@ -126,6 +133,7 @@ open class ItemTagData(val type: ItemTagType, protected var data: Any) {
             // 数组和列表需要深拷贝
             ItemTagType.BYTE_ARRAY -> ItemTagData(type, asByteArray().copyOf())
             ItemTagType.INT_ARRAY -> ItemTagData(type, asIntArray().copyOf())
+            ItemTagType.LONG_ARRAY -> ItemTagData(type, asLongArray().copyOf())
             ItemTagType.LIST -> ItemTagList().also { list -> asList().forEach { list.add(it.clone()) } }
             ItemTagType.COMPOUND -> ItemTag().also { compound -> asCompound().forEach { (k, v) -> compound[k] = v.clone() } }
         }
@@ -157,6 +165,7 @@ open class ItemTagData(val type: ItemTagType, protected var data: Any) {
                 is Byte -> ItemTagData(obj)
                 is ByteArray -> ItemTagData(obj)
                 is IntArray -> ItemTagData(obj)
+                is LongArray -> ItemTagData(obj)
                 is List<*> -> translateList(ItemTagList(), obj)
                 is Map<*, *> -> ItemTag(obj.map { (k, v) -> k.toString() to toNBT(v) }.toMap())
                 is ConfigurationSection -> translateSection(ItemTag(), obj)

--- a/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTagSerializer.kt
+++ b/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTagSerializer.kt
@@ -45,6 +45,7 @@ object ItemTagSerializer {
             ItemTagType.STRING, ItemTagType.END -> JsonPrimitive("${tagData.asString()}t")
             ItemTagType.INT_ARRAY -> JsonPrimitive("${tagData.asIntArray().joinToString(",") { it.toString() }}i]")
             ItemTagType.BYTE_ARRAY -> JsonPrimitive("${tagData.asByteArray().joinToString(",") { it.toString() }}b]")
+            ItemTagType.LONG_ARRAY -> JsonPrimitive("${tagData.asLongArray().joinToString(",") { it.toString() }}l]")
         }
     }
 
@@ -79,6 +80,7 @@ object ItemTagSerializer {
                     when (val i = str.substring(str.length - 2, str.length - 1)) {
                         "b" -> ItemTagData(str.substring(0, str.length - 2).split(",").map { NumberConversions.toByte(it) }.toByteArray())
                         "i" -> ItemTagData(str.substring(0, str.length - 2).split(",").map { NumberConversions.toInt(it) }.toIntArray())
+                        "l" -> ItemTagData(str.substring(0, str.length - 2).split(",").map { NumberConversions.toLong(it) }.toLongArray())
                         else -> error("unsupported array $json ($i)")
                     }
                 } else {

--- a/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTagType.kt
+++ b/module/module-nms-util/src/main/kotlin/taboolib/module/nms/ItemTagType.kt
@@ -21,7 +21,8 @@ enum class ItemTagType(@JvmField val id: Byte) {
     STRING(8),
     LIST(9),
     COMPOUND(10),
-    INT_ARRAY(11);
+    INT_ARRAY(11),
+    LONG_ARRAY(12);
 
     companion object {
 

--- a/module/module-nms-util/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
+++ b/module/module-nms-util/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
@@ -3,7 +3,6 @@ package taboolib.module.nms
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import org.tabooproject.reflex.UnsafeAccess
-import taboolib.common.platform.function.info
 import java.lang.invoke.MethodHandle
 
 /**
@@ -70,6 +69,7 @@ class NMSItemTagImpl : NMSItemTag() {
     val nbtTagStringGetter = unreflectGetter<net.minecraft.server.v1_12_R1.NBTTagString>(if (MinecraftVersion.isUniversal) "A" else "data")
     val nbtTagByteArrayGetter = unreflectGetter<net.minecraft.server.v1_12_R1.NBTTagByteArray>(if (MinecraftVersion.isUniversal) "c" else "data")
     val nbtTagIntArrayGetter = unreflectGetter<net.minecraft.server.v1_12_R1.NBTTagIntArray>(if (MinecraftVersion.isUniversal) "c" else "data")
+    val nbtTagLongArrayGetter = unreflectGetter<net.minecraft.server.v1_12_R1.NBTTagLongArray>(if (MinecraftVersion.isUniversal) "c" else "data")
 
     override fun getItemTag(itemStack: ItemStack): ItemTag {
         val nmsItem = NMSItem.asNMSCopy(itemStack) as net.minecraft.server.v1_12_R1.ItemStack
@@ -101,6 +101,7 @@ class NMSItemTagImpl : NMSItemTag() {
             // 数组类型特殊处理
             ItemTagType.BYTE_ARRAY -> net.minecraft.server.v1_12_R1.NBTTagByteArray(itemTagData.asByteArray().copyOf())
             ItemTagType.INT_ARRAY -> net.minecraft.server.v1_12_R1.NBTTagIntArray(itemTagData.asIntArray().copyOf())
+            ItemTagType.LONG_ARRAY -> net.minecraft.server.v1_12_R1.NBTTagLongArray(itemTagData.asLongArray().copyOf())
 
             // 列表类型特殊处理
             ItemTagType.LIST -> {
@@ -146,6 +147,7 @@ class NMSItemTagImpl : NMSItemTag() {
             // 数组类型特殊处理
             is net.minecraft.server.v1_12_R1.NBTTagByteArray -> ItemTagData(ItemTagType.BYTE_ARRAY, nbtTagByteArrayGetter.get<ByteArray>(nbtTag).copyOf())
             is net.minecraft.server.v1_12_R1.NBTTagIntArray -> ItemTagData(ItemTagType.INT_ARRAY, nbtTagIntArrayGetter.get<IntArray>(nbtTag).copyOf())
+            is net.minecraft.server.v1_12_R1.NBTTagLongArray -> ItemTagData(ItemTagType.LONG_ARRAY, nbtTagLongArrayGetter.get<LongArray>(nbtTag).copyOf())
 
             // 列表类型特殊处理
             is net.minecraft.server.v1_12_R1.NBTTagList -> {


### PR DESCRIPTION
针对 #365 重新拉取请求

已知晓[错误](https://github.com/TabooLib/taboolib/pull/365#issuecomment-1788480179)

现已更正，只带有补全部分，已删除“重命名”的提交

也是非常感谢提醒，对于之前的错误，
我在此作出道歉。

2023/11/4 19:37 补充 - 对于RuntimeEnv的修改：
``` Java
// 支持用户对源进行替换
if (repository == null || repository.isEmpty()) {
   repository = defaultRepositoryCentral;
} else if (ENV_PROPERTIES.containsKey("repository-" + repository)) { // 修改处 原本为contains()方法
  repository = ENV_PROPERTIES.getProperty("repository-" + repository);
}
```
此处本就该是containsKey()
原些contains()方法实际上是调用了containsValue()
然后就导致了你需要两个键值对（一个用于使方法判断为true，另一个用于配置自定义库）