### PR TITLE
修复 & 优化头颅相关内容

### DIFF
--- a/module/module-bukkit-util/src/main/kotlin/taboolib/platform/util/ItemBuilder.kt
+++ b/module/module-bukkit-util/src/main/kotlin/taboolib/platform/util/ItemBuilder.kt
@@ -83,7 +83,7 @@ open class ItemBuilder {
     /**
      * 头颅材质信息
      */
-    class SkullTexture(val textures: String, val uuid: UUID? = UUID.randomUUID())
+    class SkullTexture(val textures: String, val uuid: UUID? = UUID(0, 0))
 
     /**
      * 物品材质
@@ -274,7 +274,7 @@ open class ItemBuilder {
                     itemMeta.owner = skullOwner
                 }
                 if (skullTexture != null) {
-                    itemMeta.setProperty("profile", GameProfile(skullTexture!!.uuid, null).also {
+                    itemMeta.setProperty("profile", GameProfile(skullTexture!!.uuid, "skull").also { // 谁让你 null 了
                         it.properties.put("textures", Property("textures", skullTexture!!.textures))
                     })
                 }


### PR DESCRIPTION
这玩意可不兴 ```null``` 啊

其次如果用 ```randomUUID``` 的话，那我启动两次服务器所生成的头颅没法堆叠，即使材质一模一样，所以我换成了一个固定的 ```UUID```