### PR TITLE
[6.2.0][dev] 1.21 Fix nmsProxy

### DIFF
--- a/module/nms/src/main/kotlin/taboolib/module/nms/remap/RemapTranslation.kt
+++ b/module/nms/src/main/kotlin/taboolib/module/nms/remap/RemapTranslation.kt
@@ -52,7 +52,12 @@ open class RemapTranslation : Remapper() {
             // 将低版本包名替换为高版本包名
             // net/minecraft/server/v1_17_R1/EntityPlayer -> net/minecraft/server/level/EntityPlayer
             if (key.startsWith("net/minecraft/server/v1_")) {
-                MinecraftVersion.spigotMapping.classMapSpigotS2F[key.substringAfterLast('/', "")]?.replace('.', '/') ?: key
+                // 如果为 Universal CraftBukkit 环境, 则应转译为 Mojang.FullName, 反之则为 Spigot.FullName
+                if (MinecraftVersion.isUniversalCraftBukkit) {
+                    MinecraftVersion.paperMapping.classMapSpigotToMojang[key.replace('/', '.')]?.replace('.', '/') ?: key
+                } else {
+                    MinecraftVersion.spigotMapping.classMapSpigotS2F[key.substringAfterLast('/', "")]?.replace('.', '/') ?: key
+                }
             } else {
                 key
             }

--- a/module/nms/src/main/kotlin/taboolib/module/nms/remap/RemapTranslation.kt
+++ b/module/nms/src/main/kotlin/taboolib/module/nms/remap/RemapTranslation.kt
@@ -52,12 +52,13 @@ open class RemapTranslation : Remapper() {
             // 将低版本包名替换为高版本包名
             // net/minecraft/server/v1_17_R1/EntityPlayer -> net/minecraft/server/level/EntityPlayer
             if (key.startsWith("net/minecraft/server/v1_")) {
-                // 如果为 Universal CraftBukkit 环境, 则应转译为 Mojang.FullName, 反之则为 Spigot.FullName
-                if (MinecraftVersion.isUniversalCraftBukkit) {
-                    MinecraftVersion.paperMapping.classMapSpigotToMojang[key.replace('/', '.')]?.replace('.', '/') ?: key
-                } else {
-                    MinecraftVersion.spigotMapping.classMapSpigotS2F[key.substringAfterLast('/', "")]?.replace('.', '/') ?: key
-                }
+                // 先转译为 Spigot.FullName
+                MinecraftVersion.spigotMapping.classMapSpigotS2F[key.substringAfterLast('/', "")]?.let { spigotFull ->
+                    // 如果为 Universal CraftBukkit 环境, 则应进一步转译为 Mojang.FullName
+                    if (MinecraftVersion.isUniversalCraftBukkit) {
+                        MinecraftVersion.paperMapping.classMapSpigotToMojang[spigotFull] ?: spigotFull
+                    } else spigotFull
+                }?.replace('.', '/') ?: key
             } else {
                 key
             }

--- a/module/nms/src/main/kotlin/taboolib/module/nms/remap/RemapTranslationLegacy.kt
+++ b/module/nms/src/main/kotlin/taboolib/module/nms/remap/RemapTranslationLegacy.kt
@@ -1,0 +1,53 @@
+package taboolib.module.nms.remap
+
+import taboolib.module.nms.MinecraftVersion
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * TabooLib
+ * taboolib.module.nms.remap.MinecraftRemapper
+ *
+ * @author sky
+ * @since 2021/7/17 2:02 上午
+ */
+open class RemapTranslationLegacy : RemapTranslation() {
+
+    /**
+     * 缓存类的父类和接口
+     */
+    val parentsCacheMap = ConcurrentHashMap<String, List<String>>()
+
+    /**
+     * 在 1.17 版本下进行字段转换
+     *
+     * $owner.$name
+     * net/minecraft/server/level/EntityPlayer.connection -> b
+     */
+    override fun mapFieldName(owner: String, name: String, descriptor: String): String {
+        if (MinecraftVersion.isUniversal) {
+            // 当前运行时的 Owner 名称
+            val runningOwner = translate(owner).replace('/', '.')
+            // 追溯父类和接口
+            val findPath = parentsCacheMap.getOrPut(runningOwner) { findParents(runningOwner).reversed() }
+            return MinecraftVersion.spigotMapping.fields.find { it.translateName == name && it.path in findPath }?.mojangName ?: name
+        }
+        return name
+    }
+
+    override fun mapMethodName(owner: String, name: String, descriptor: String): String {
+        // 1.18
+        if (MinecraftVersion.major >= 10) {
+            // 当前运行时的 Owner 名称
+            val runningOwner = translate(owner).replace('/', '.')
+            // 追溯父类和接口
+            val findPath = parentsCacheMap.getOrPut(runningOwner) { findParents(runningOwner).reversed() }
+            return MinecraftVersion.spigotMapping.methods.find {
+                // 根据复杂程度依次对比
+                it.translateName == name
+                        && it.path in findPath
+                        && RemapHelper.checkParameterType(descriptor, it.descriptor)
+            }?.mojangName ?: name
+        }
+        return name
+    }
+}


### PR DESCRIPTION
对于 TabooLib 内的类，
使用 RemapTranslationTabooLib 进行 Spigot Deobf -> Mojang Obf -> Mojang Deobf 转换。

而插件内的类，已经由 Paper 进行转译了，所以不应该再使用 RemapTranslation (现在为 RemapTranslationLegacy) 进行转译，
应该只需要使用该 RemapTranslation 移除包名中的跨版本信息 (诸如 v1_20_R3) ，
而无需对字段名、方法名进行任何操作。


> 注：我对 TabooLib nms 内部运行逻辑暂时还了解的不是很清楚，不清楚有没有错误，写的垃圾别骂我😭（逃