### PR TITLE
[6.2.0][dev] 更新 ItemTag

### DIFF
--- a/module/nms-util-tag-12005/src/main/kotlin/taboolib/module/nms/ItemTag.kt
+++ b/module/nms-util-tag-12005/src/main/kotlin/taboolib/module/nms/ItemTag.kt
@@ -1,0 +1,28 @@
+package taboolib.module.nms
+
+import org.bukkit.inventory.ItemStack
+
+/**
+ * TabooLib
+ * taboolib.module.nms.ItemTag
+ *
+ * @author mical
+ * @date 2024/9/7 13:35
+ */
+class ItemTag12005 : ItemTag {
+
+    constructor() : super()
+
+    constructor(map: Map<String, ItemTagData>) : super(map)
+
+    /**
+     * 在 1.20.5 上将完整的 [ItemTag] 写入物品
+     */
+    override fun saveTo(item: ItemStack) {
+        val newItem = item.setItemTag(this)
+        item.type = newItem.type
+        item.amount = newItem.amount
+        item.durability = newItem.durability
+        item.itemMeta = newItem.itemMeta
+    }
+}

--- a/module/nms-util-tag-legacy/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
+++ b/module/nms-util-tag-legacy/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
@@ -37,10 +37,18 @@ open class NMSItemTagImpl1 : NMSItemTag() {
         return if (nmsItem.hasTag()) itemTagToBukkitCopy(nmsItem.tag!!).asCompound() else ItemTag()
     }
 
+    override fun getItemTagGeneral(itemStack: ItemStack): ItemTag {
+        return getItemTag(itemStack)
+    }
+
     override fun setItemTag(itemStack: ItemStack, itemTag: ItemTag): ItemStack {
         val nmsItem = getNMSCopy(itemStack)
         nmsItem.tag = itemTagToNMSCopy(itemTag) as NBTTagCompound12
         return getBukkitCopy(nmsItem)
+    }
+
+    override fun setItemTagGeneral(itemStack: ItemStack, itemTagGeneral: ItemTag): ItemStack {
+        return setItemTag(itemStack, itemTagGeneral)
     }
 
     override fun itemTagToString(itemTagData: ItemTagData): String {

--- a/module/nms-util-tag/src/main/kotlin/taboolib/module/nms/ItemTag.kt
+++ b/module/nms-util-tag/src/main/kotlin/taboolib/module/nms/ItemTag.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap
  * @author 坏黑
  * @since 2023/8/9 01:40
  */
-class ItemTag : ItemTagData, MutableMap<String, ItemTagData> {
+open class ItemTag : ItemTagData, MutableMap<String, ItemTagData> {
 
     private val value = ConcurrentHashMap<String, ItemTagData>()
 
@@ -29,7 +29,7 @@ class ItemTag : ItemTagData, MutableMap<String, ItemTagData> {
     /**
      * 将 [ItemTag] 写入物品
      */
-    fun saveTo(item: ItemStack) {
+    open fun saveTo(item: ItemStack) {
         item.setItemMeta(item.setItemTag(this).itemMeta)
     }
 

--- a/module/nms-util-tag/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
+++ b/module/nms-util-tag/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
@@ -21,6 +21,22 @@ fun ItemStack.setItemTag(itemTag: ItemTag): ItemStack {
 }
 
 /**
+ * 1.20.5+ 获取物品的完整 [ItemTag]
+ * 在 1.20.4 及以下版本该函数与 [getItemTag] 无异
+ */
+fun ItemStack.getItemTagGeneral(): ItemTag {
+    return NMSItemTag.instance.getItemTagGeneral(validation())
+}
+
+/**
+ * 1.20.5+ 将完整的 [ItemTag] 写入物品（不会改变该物品）并返回一个新的物品
+ * 在 1.20.4 及以下版本该函数与 [setItemTag] 无异
+ */
+fun ItemStack.setItemTagGeneral(itemTag: ItemTag): ItemStack {
+    return NMSItemTag.instance.setItemTagGeneral(validation(), itemTag)
+}
+
+/**
  * 将 [ItemTagData] 转换为字符串
  */
 fun ItemTagData.saveToString(): String {
@@ -39,8 +55,14 @@ abstract class NMSItemTag {
     /** 获取物品 [ItemTag] */
     abstract fun getItemTag(itemStack: ItemStack): ItemTag
 
+    /** 1.20.5+ 获取物品完整 [ItemTag] */
+    abstract fun getItemTagGeneral(itemStack: ItemStack): ItemTag
+
     /** 将 [ItemTag] 写入物品（不会改变该物品）并返回一个新的物品 */
     abstract fun setItemTag(itemStack: ItemStack, itemTag: ItemTag): ItemStack
+
+    /** 1.20.5+ 将 [ItemTag] 写入物品（不会改变该物品）并返回一个新的物品 */
+    abstract fun setItemTagGeneral(itemStack: ItemStack, itemTagGeneral: ItemTag): ItemStack
 
     /** 将 [ItemTag] 转换为字符串 */
     abstract fun itemTagToString(itemTagData: ItemTagData): String


### PR DESCRIPTION
更新了 1.20.5 上的 ItemTag 工具，增加了 `getItemTagGeneral` 与 `setItemTagGeneral` 函数用于在 1.20.5 上获取/设置完整的物品 NBT 数据，同时不破坏原有 API。已使用 Fenestra 在 Spigot 1.21 与 Paper 1.21.1 上通过测试。