### PR TITLE
[6.2.0][dev] 恢复 bukkit-navigation 并进行升级与修复

### DIFF
--- a/module/bukkit/bukkit-navigation/build.gradle.kts
+++ b/module/bukkit/bukkit-navigation/build.gradle.kts
@@ -2,9 +2,11 @@ dependencies {
     compileOnly(project(":common"))
     compileOnly(project(":module:bukkit-nms"))
     // 服务端
-    compileOnly("ink.ptms.core:v12101:12101-minimize:universal")
+    compileOnly("ink.ptms.core:v12101:12101-minimize:mapped")
+    compileOnly("paper:v11701:11701:core")
     // getBlockHeight 用到
     compileOnly("ink.ptms.core:v11200:11200-minimize")
     compileOnly("ink.ptms.core:v11100:11100")
     compileOnly("ink.ptms.core:v10900:10900")
+    compileOnly("ink.ptms:nms-all:1.0.0")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(
 
     // 针对 Bukkit 平台的常规工具
     "module:bukkit:bukkit-hook",
+    "module:bukkit:bukkit-navigation",
     "module:bukkit:bukkit-ui",
     "module:bukkit:bukkit-ui:bukkit-ui-12100",
     "module:bukkit:bukkit-ui:bukkit-ui-legacy",


### PR DESCRIPTION
恢复 bukkit-navigation 模块，升级至 1.21 并对其所存在的问题进行修复，主要表现为：
- `1.14` - `1.16` 版本区间无法使用，原因是在 1.14 中 Mojang 变更了 `IBlockData`，由 **接口** 变为 **类**。
- `1.17` 版本无法使用，原因是使用了不同的 mapping。
- `1.18` - `1.21` 版本区间无法使用，原因是在 1.18 中类 `World` 中的方法 `getType` 名称变更为 `getBlockState`，`IBlockData` 中的方法 `get` 名称变更为 `getValue`。

已在以下环境中通过测试：
- 1.16.5 Spigot
- 1.17.1 Spigot
- 1.20.4 Spigot
- 1.20.4 Paper
- 1.21 Spigot
- 1.21.1 Paper

测试代码如下：
```kotlin
@SubscribeEvent
private fun e(e: PlayerInteractEvent) {
    e.player.sendMessage(
        NMS.instance.getBlockHeight(e.clickedBlock ?: return).toString(),
        kotlin.runCatching { NMS.instance.isDoorOpened(e.clickedBlock ?: return).toString() }.getOrThrow(),
        NMS.instance.getBoundingBox(e.clickedBlock ?: return).toString(),
        NMS.instance.getBoundingBox(e.player).toString()
    )
}
```