### PR TITLE
[6.2.0][dev] 尝试修复 #456

### DIFF
--- a/common/src/main/java/taboolib/common/PrimitiveLoader.java
+++ b/common/src/main/java/taboolib/common/PrimitiveLoader.java
@@ -4,6 +4,7 @@ import me.lucko.jarrelocator.JarRelocator;
 import me.lucko.jarrelocator.Relocation;
 import org.objectweb.asm.Opcodes;
 import taboolib.common.classloader.IsolatedClassLoader;
+import taboolib.common.platform.Platform;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,8 +56,8 @@ public class PrimitiveLoader {
     static List<String[]> deps() {
         List<String[]> deps = new ArrayList<>();
         deps.add(new String[]{"me.lucko", "jar-relocator", "1.7"});
-        // 非 ASM 9 环境下加载 ASM 9
-        if (!isASM9) {
+        // 非 ASM 9 环境下, 或非 Bukkit 环境下加载 ASM 9
+        if (!isASM9 || Platform.CURRENT != Platform.BUKKIT) {
             deps.add(new String[]{"org.ow2.asm", "asm", "9.6"});
             deps.add(new String[]{"org.ow2.asm", "asm-util", "9.6"});
             deps.add(new String[]{"org.ow2.asm", "asm-commons", "9.6"});

--- a/module/bukkit/bukkit-ui/src/main/kotlin/taboolib/module/ui/virtual/InventoryHandler.kt
+++ b/module/bukkit/bukkit-ui/src/main/kotlin/taboolib/module/ui/virtual/InventoryHandler.kt
@@ -15,6 +15,7 @@ import taboolib.common.util.unsafeLazy
 import taboolib.module.nms.MinecraftVersion
 import taboolib.module.nms.PacketReceiveEvent
 import taboolib.module.nms.nmsProxy
+import taboolib.module.ui.InventoryViewProxy
 import taboolib.module.ui.MenuHolder
 import taboolib.module.ui.type.AnvilCallback
 import java.util.concurrent.ConcurrentHashMap
@@ -118,7 +119,7 @@ abstract class InventoryHandler {
                     }
                     // 普通容器处理
                     else {
-                        val openInventory = player.openInventory.topInventory
+                        val openInventory = InventoryViewProxy.getTopInventory(player.openInventory)
                         val builder = MenuHolder.fromInventory(openInventory)
                         if (builder is AnvilCallback) {
                             builder.invoke(player, text, openInventory)


### PR DESCRIPTION
尝试修复 [无法在 Velocity 平台上启动](https://github.com/TabooLib/taboolib/issues/456) 的问题。

问题根源在于 Velocity 服务端自带 ASM 库，所以 `PrimitiveLoader#isASM9()` 返回 true，但 Velocity 所带的 ASM 库不全 (没有导入 `asm-commons` 模块)，导致插件无法启动 (报错提示无 `org.objectweb.asm.commons.Remapper`)。

解决方案是在加载 ASM 库前判断是否非 ASM 环境或非 Bukkit 环境，满足任一条件则由 TabooLib 下载并加载完整的 `ASM` 库并重定向。

这个方案我认为不是很聪明。另外，BungeeCord (Waterfall) 我发现应该是不自带 ASM 库的，其他平台未知，所以目前看来应该只有 Velocity 有这个问题。

已在最新的 Velocity (`Velocity 3.3.0-SNAPSHOT (git-0cd069ec-b431)`) 环境中通过测试。