### PR TITLE
隔离 module-ai 以确保 jdk 低版本兼容性

### DIFF
--- a/module/bukkit-nms/bukkit-nms-ai/build.gradle.kts
+++ b/module/bukkit-nms/bukkit-nms-ai/build.gradle.kts
@@ -6,3 +6,7 @@ dependencies {
     compileOnly("ink.ptms:nms-all:1.0.0")
     compileOnly("ink.ptms.core:v12104:12104:mapped")
 }
+
+kotlin {
+    jvmToolchain(21) // 仅针对该模块
+}


### PR DESCRIPTION
<img width="462" alt="d6516a754d025c37895e02972558a372" src="https://github.com/user-attachments/assets/4bbe0166-19bb-47c0-85e6-f463a4002b0f" />
<img width="342" alt="image" src="https://github.com/user-attachments/assets/e4e0ef68-b046-4114-93d1-e7be1e677e81" />
<img width="338" alt="image" src="https://github.com/user-attachments/assets/39395c58-fbbe-4026-a20c-50958ba96ae9" />
<img width="675" alt="7b6d96ea1ed8e688c0381ce6f18a59cf" src="https://github.com/user-attachments/assets/8cf6a9cf-f488-4f72-9f76-204b1a3803ad" />
<img width="836" alt="image" src="https://github.com/user-attachments/assets/fa3d640c-a7b9-481e-992e-01668229606d" />
啥时候出 tabooai 赶超 deepseek