### PR TITLE
feat(database): 增加对字节数组（ByteArray）的支持

### DIFF
--- a/common-legacy-api/src/main/java/taboolib/common5/Coerce.java
+++ b/common-legacy-api/src/main/java/taboolib/common5/Coerce.java
@@ -28,10 +28,15 @@ import com.google.common.collect.Lists;
 import com.google.common.primitives.*;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -566,6 +571,80 @@ public final class Coerce {
             return Optional.of(obj.toString().charAt(0));
         } catch (Exception e) {
             // do nothing
+        }
+        return Optional.empty();
+    }
+
+    public static byte[] toByteArray(@Nullable Object obj) {
+        if (obj == null) {
+            return new byte[0];
+        }
+        if (obj instanceof byte[]) {
+            return (byte[]) obj;
+        }
+        if (obj instanceof String) {
+            return ((String) obj).getBytes(StandardCharsets.UTF_8);
+        }
+        if (obj instanceof Number) {
+            if (obj instanceof Integer) {
+                return ByteBuffer.allocate(4).putInt((Integer) obj).array();
+            } else if (obj instanceof Long) {
+                return ByteBuffer.allocate(8).putLong((Long) obj).array();
+            } else if (obj instanceof Short) {
+                return ByteBuffer.allocate(2).putShort((Short) obj).array();
+            } else if (obj instanceof Byte) {
+                return new byte[]{((Byte) obj)};
+            } else if (obj instanceof Float) {
+                return ByteBuffer.allocate(4).putFloat((Float) obj).array();
+            } else if (obj instanceof Double) {
+                return ByteBuffer.allocate(8).putDouble((Double) obj).array();
+            }
+        }
+        if (obj instanceof Serializable) {
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                 ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+                oos.writeObject(obj);
+                return bos.toByteArray();
+            } catch (Exception e) {
+                // do nothing
+            }
+        }
+        return new byte[0];
+    }
+
+    public static Optional<byte[]> asByteArray(@Nullable Object obj) {
+        if (obj == null) {
+            return Optional.empty();
+        }
+        if (obj instanceof byte[]) {
+            return Optional.of((byte[]) obj);
+        }
+        if (obj instanceof String) {
+            return Optional.of(((String) obj).getBytes(StandardCharsets.UTF_8));
+        }
+        if (obj instanceof Number) {
+            if (obj instanceof Integer) {
+                return Optional.of(ByteBuffer.allocate(4).putInt((Integer) obj).array());
+            } else if (obj instanceof Long) {
+                return Optional.of(ByteBuffer.allocate(8).putLong((Long) obj).array());
+            } else if (obj instanceof Short) {
+                return Optional.of(ByteBuffer.allocate(2).putShort((Short) obj).array());
+            } else if (obj instanceof Byte) {
+                return Optional.of(new byte[]{((Byte) obj)});
+            } else if (obj instanceof Float) {
+                return Optional.of(ByteBuffer.allocate(4).putFloat((Float) obj).array());
+            } else if (obj instanceof Double) {
+                return Optional.of(ByteBuffer.allocate(8).putDouble((Double) obj).array());
+            }
+        }
+        if (obj instanceof Serializable) {
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                 ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+                oos.writeObject(obj);
+                return Optional.of(bos.toByteArray());
+            } catch (Exception e) {
+                // do nothing
+            }
         }
         return Optional.empty();
     }

--- a/common-legacy-api/src/main/kotlin/taboolib/common5/CoerceExtensions.kt
+++ b/common-legacy-api/src/main/kotlin/taboolib/common5/CoerceExtensions.kt
@@ -29,6 +29,9 @@ inline val Any?.cchar: Char
 inline val Any?.cbool: Boolean
     get() = Coerce.toBoolean(this)
 
+inline val Any?.cByteArray: ByteArray
+    get() = Coerce.toByteArray(this)
+
 fun Double.format(digits: Int = 2, roundingMode: Int = BigDecimal.ROUND_HALF_UP): Double {
     return try {
         Coerce.format(this, digits, roundingMode)

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
@@ -124,6 +124,7 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
                     member.isString -> obj.toString()
                     member.isUUID -> UUID.fromString(obj.toString())
                     member.isEnum -> member.returnType.enumConstants.first { it.toString() == obj.toString() }
+                    member.isByteArray -> obj.cByteArray
                     else -> {
                         val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType) ?: error(
                             """

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
@@ -48,6 +48,10 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
     val isShort: Boolean
         get() = returnType == Short::class.java || returnType == Short::class.javaPrimitiveType
 
+    /** 是否为基础类型（ByteArray） */
+    val isByteArray: Boolean
+        get() = returnType == ByteArray::class.java || returnType == ByteArray::class.javaPrimitiveType
+
     /** 是否为基础类型（Int） */
     val isInt: Boolean
         get() = returnType == Int::class.java || returnType == Int::class.javaPrimitiveType
@@ -82,7 +86,7 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
 
     /** 是否为自定义对象 */
     val isCustomObject: Boolean
-        get() = !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID
+        get() = !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID && !isByteArray
 
     /** 是否可以转换成字符串类型 */
     fun canConvertedString(): Boolean {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
@@ -40,6 +40,10 @@ class ContainerSQL(
                     member.isUUID -> add(member.name) {
                         type(ColumnTypeSQL.CHAR, 36) { options(member) }
                     }
+                    // 字节数组
+                    member.isByteArray -> add(member.name) {
+                        type(ColumnTypeSQL.BLOB) { options(member) }
+                    }
                     // 其他类型
                     else -> add(member.name) {
                         val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType)
@@ -76,6 +80,7 @@ class ContainerSQL(
             isFloat -> ColumnTypeSQL.FLOAT
             isDouble -> ColumnTypeSQL.DOUBLE
             isChar -> ColumnTypeSQL.INT
+            isByteArray -> ColumnTypeSQL.BLOB
             else -> error("Unsupported type: $name (${returnType})")
         }
     }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
@@ -25,6 +25,10 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
                     member.canConvertedDecimal() -> add(member.name) {
                         type(ColumnTypeSQLite.REAL) { options(member) }
                     }
+                    // 字节数组
+                    member.isByteArray -> add(member.name) {
+                        type(ColumnTypeSQLite.BLOB) { options(member) }
+                    }
 
                     else -> {
                         val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType) ?: error("Unsupported type: ${member.name} (${member.returnType})")


### PR DESCRIPTION
- 在 AnalyzedClass 中添加对字节数组的处理逻辑
- 在 AnalyzedClassMember 中增加 isByteArray 属性判断
- 在 Coerce 类，增加 toByteArray 和 asByteArray 方法处理字节数组
- 更新 CoerceExtensions.kt，添加 cByteArray 扩展属性
- 在 ContainerSQL 和 ContainerSQLite 中增加对字节数组的列类型支持