### PR TITLE
更新minecraft-chat模块

### DIFF
--- a/module/minecraft/minecraft-chat/build.gradle.kts
+++ b/module/minecraft/minecraft-chat/build.gradle.kts
@@ -1,6 +1,8 @@
 dependencies {
     compileOnly("com.google.code.gson:gson:2.8.7")
-    compileOnly("net.md-5:bungeecord-chat:1.20")
+    compileOnly("net.md-5:bungeecord-chat:1.21-R0.2")
+    compileOnly("net.kyori:adventure-platform-bukkit:4.4.0")
+    compileOnly("net.kyori:adventure-text-serializer-plain:4.21.0")
     compileOnly(project(":common"))
     compileOnly(project(":common-legacy-api"))
     compileOnly(project(":common-env"))

--- a/module/minecraft/minecraft-chat/src/main/kotlin/taboolib/module/chat/ComponentText.kt
+++ b/module/minecraft/minecraft-chat/src/main/kotlin/taboolib/module/chat/ComponentText.kt
@@ -1,6 +1,5 @@
 package taboolib.module.chat
 
-import net.md_5.bungee.api.chat.BaseComponent
 import java.awt.Color
 
 /**
@@ -23,7 +22,7 @@ interface ComponentText : Source {
     operator fun plusAssign(other: ComponentText)
 
     /** 添加文本块 */
-    fun append(text: String): ComponentText
+    fun append(text: String, color: Boolean = true): ComponentText
 
     /** 追加另一个 [ComponentText] */
     fun append(other: ComponentText): ComponentText

--- a/module/minecraft/minecraft-chat/src/main/kotlin/taboolib/module/chat/Components.kt
+++ b/module/minecraft/minecraft-chat/src/main/kotlin/taboolib/module/chat/Components.kt
@@ -1,8 +1,10 @@
 package taboolib.module.chat
 
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
 import net.md_5.bungee.chat.ComponentSerializer
 import taboolib.common.Inject
 import taboolib.common.env.RuntimeDependency
+import taboolib.module.chat.impl.AdventureComponent
 import taboolib.module.chat.impl.DefaultComponent
 import taboolib.module.chat.impl.DefaultSimpleComponent
 import taboolib.module.chat.impl.ErrorSimpleComponent
@@ -23,29 +25,45 @@ import taboolib.module.chat.impl.ErrorSimpleComponent
 )
 object Components {
 
+    /** 使用adventure作为底层 */
+    var useAdventure = false
+
     /** 创建空白块 */
-    fun empty(): ComponentText = DefaultComponent()
+    fun empty(): ComponentText {
+        return if (useAdventure) {
+            AdventureComponent()
+        } else {
+            DefaultComponent()
+        }
+    }
 
     /** 创建文本块 */
-    fun text(text: String): ComponentText = DefaultComponent().append(text)
+    @JvmOverloads
+    fun text(text: String, color: Boolean = true): ComponentText = empty().append(text, color)
 
     /** 创建分数文本块 */
-    fun score(name: String, objective: String): ComponentText = DefaultComponent().appendScore(name, objective)
+    fun score(name: String, objective: String): ComponentText = empty().appendScore(name, objective)
 
     /** 创建按键文本块 */
-    fun keybind(key: String): ComponentText = DefaultComponent().appendKeybind(key)
+    fun keybind(key: String): ComponentText = empty().appendKeybind(key)
 
     /** 创建选择器文本块 */
-    fun selector(selector: String): ComponentText = DefaultComponent().appendSelector(selector)
+    fun selector(selector: String): ComponentText = empty().appendSelector(selector)
 
     /** 创建翻译文本块 */
-    fun translation(text: String, vararg obj: Any): ComponentText = DefaultComponent().appendTranslation(text, *obj)
+    fun translation(text: String, vararg obj: Any): ComponentText = empty().appendTranslation(text, *obj)
 
     /** 创建翻译文本块 */
-    fun translation(text: String, obj: List<Any>): ComponentText = DefaultComponent().appendTranslation(text, obj)
+    fun translation(text: String, obj: List<Any>): ComponentText = empty().appendTranslation(text, obj)
 
     /** 从原始信息中读取 */
-    fun parseRaw(text: String): ComponentText = DefaultComponent(ComponentSerializer.parse(text).toList())
+    fun parseRaw(text: String): ComponentText {
+        return if (useAdventure) {
+            AdventureComponent(GsonComponentSerializer.gson().deserialize(text))
+        } else {
+            DefaultComponent(ComponentSerializer.parse(text).toList())
+        }
+    }
 
     /**
      * 解析一种文本格式：

--- a/module/minecraft/minecraft-chat/src/main/kotlin/taboolib/module/chat/Source.kt
+++ b/module/minecraft/minecraft-chat/src/main/kotlin/taboolib/module/chat/Source.kt
@@ -1,5 +1,6 @@
 package taboolib.module.chat
 
+import net.kyori.adventure.text.Component
 import net.md_5.bungee.api.chat.BaseComponent
 import taboolib.common.platform.ProxyCommandSender
 
@@ -23,6 +24,9 @@ interface Source {
 
     /** 转换为 Spigot 对象 */
     fun toSpigotObject(): BaseComponent
+
+    /** 转换为 Adventure 对象 */
+    fun toAdventureObject(): Component
 
     /** 转换为 RawMessage */
     fun toLegacyRawMessage(): RawMessage


### PR DESCRIPTION
1. 为ComponentText增加AdventureComponent实现
有些特殊情况必须使用adventure，例如1.21.5将hoverEvent改为hover_event，而bungee-chat库更新缓慢，导致无法使用hover功能
2. ComponentText.append()增加color参数，有些时候不需要经过Legacy解析，如龙核颜色直接在文本中使用`§`
3. 将DefaultComponent.latest改为public，特殊情况需直接操作，如https://github.com/TrPlugins/TrChat/blob/v2/project/runtime-bukkit/src/main/kotlin/me/arasple/mc/trchat/util/ComponentUtil.kt#L33-L36