### PR TITLE
Restore the process method of CustomModelData on ItemBuilder

### DIFF
--- a/module/bukkit/bukkit-util/src/main/kotlin/taboolib/platform/util/ItemBuilder.kt
+++ b/module/bukkit/bukkit-util/src/main/kotlin/taboolib/platform/util/ItemBuilder.kt
@@ -296,11 +296,8 @@ open class ItemBuilder {
         }
         // CustomModelData
         try {
-            // 1.21.5+ 必须判断 hasCustomModelData() 否则报错
-            if (itemMeta.hasCustomModelData()) {
-                if (customModelData != -1) {
-                    itemMeta.setCustomModelData(customModelData)
-                }
+            if (customModelData != -1) {
+                itemMeta.setCustomModelData(customModelData)
             }
         } catch (_: NoSuchMethodError) {
         }


### PR DESCRIPTION
Certainly, this is a very bad change, it leads to not available of customModelData feature on ItemBuilder. The origin code below([ItemBuilder.kt#L297](https://github.com/TabooLib/taboolib/blob/5297ae69e742143dbd29bbd89f30cc8009b2dfc0/module/bukkit/bukkit-util/src/main/kotlin/taboolib/platform/util/ItemBuilder.kt#L297)):
```kotlin
        // CustomModelData
        try {
            // 1.21.5+ 必须判断 hasCustomModelData() 否则报错
            if (itemMeta.hasCustomModelData()) {
                if (customModelData != -1) {
                    itemMeta.setCustomModelData(customModelData)
                }
            }
        } catch (_: NoSuchMethodError) {
        }
```

Correspondingly, in `CraftMetaItem`(paper), the method of `setCustomModelData` is never throw any exception, related source code below:
```kotlin
    @Override
    public int getCustomModelData() {
        Preconditions.checkState(this.hasCustomModelData(), "We don't have CustomModelData! Check hasCustomModelData first!");

        return customModelData.getFloats().get(0).intValue();
    }

    @Override
    public void setCustomModelData(Integer data) {
        this.customModelData = (data == null) ? null : new CraftCustomModelDataComponent(new CustomModelData(List.of(data.floatValue()), List.of(), List.of(), List.of()));
    }

    @Override
    public boolean hasCustomModelData() {
        if (customModelData != null) {
            List<Float> floats = customModelData.getFloats();
            return !floats.isEmpty();
        }

        return false;
    }
```

Only the getCustomModelData will be get exception of `IllegalStateException` when the customModelData not defined. instead of the `setCustomModelData`!