### PR TITLE
Fix MySQL charset collation conflicts in database operations

### DIFF
--- a/module/database/src/main/kotlin/taboolib/module/database/Filterable.kt
+++ b/module/database/src/main/kotlin/taboolib/module/database/Filterable.kt
@@ -70,6 +70,16 @@ abstract class Filterable {
         return Criteria("${asFormattedColumnName()} IN (${unwrapArray(value, el)})", el).apply(this@Filterable)
     }
 
+    /**
+     * 在某集合之内（强制使用二进制校对规则，解决字符集冲突）
+     * 适用于MySQL utf8_general_ci 校对规则冲突的情况
+     */
+    infix fun String.insideBinary(value: Array<Any>): Criteria {
+        if (value.isEmpty()) error("empty value")
+        val el = arrayListOf<Any>()
+        return Criteria("${asFormattedColumnName()} COLLATE utf8mb4_bin IN (${unwrapArray(value, el)})", el).apply(this@Filterable)
+    }
+
     /** 在某范围之内 */
     infix fun String.between(value: Pair<Any, Any>): Criteria {
         val el = arrayListOf<Any>()

--- a/module/database/src/main/kotlin/taboolib/module/database/HostSQL.kt
+++ b/module/database/src/main/kotlin/taboolib/module/database/HostSQL.kt
@@ -12,7 +12,8 @@ import taboolib.module.database.Database.settingsFile
 class HostSQL(val host: String, val port: String, val user: String, val password: String, val database: String) : Host<SQL>() {
 
     // allowPublicKeyRetrieval=true 用来针对 MySQL8 版本出现的 Public Key Retrieval is not allowed 异常
-    val flags = arrayListOf("characterEncoding=utf-8", "useSSL=false", "allowPublicKeyRetrieval=true")
+    // useUnicode=true&connectionCollation=utf8mb4_unicode_ci 解决字符集校对规则冲突
+    val flags = arrayListOf("characterEncoding=utf-8", "useSSL=false", "allowPublicKeyRetrieval=true", "useUnicode=true", "connectionCollation=utf8mb4_unicode_ci")
 
     val flagsURL: String
         get() = if (flags.isEmpty()) "" else "?${flags.joinToString("&")}"


### PR DESCRIPTION
Fix MySQL charset/collation conflicts that occur when using the `inside` operator with utf8_general_ci collation.

## Changes
- Add `useUnicode=true` and `connectionCollation=utf8mb4_unicode_ci` to MySQL connection flags
- Add `insideBinary` operator for explicit binary collation when needed

## Fixes
Fixes #603

Generated with [Claude Code](https://claude.ai/code)