### PR TITLE
feat(nms): 添加冒险模式物品组件支持，包括可破坏方块和可放置方块

### DIFF
--- a/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-12005/src/main/kotlin/taboolib/module/nms/NMSItemTag12005.kt
+++ b/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-12005/src/main/kotlin/taboolib/module/nms/NMSItemTag12005.kt
@@ -1,7 +1,12 @@
 package taboolib.module.nms
 
+import net.minecraft.advancements.critereon.CriterionConditionBlock
+import net.minecraft.core.component.DataComponentType
 import net.minecraft.core.component.DataComponents
+import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.nbt.*
+import net.minecraft.resources.MinecraftKey
+import net.minecraft.world.item.AdventureModePredicate
 import net.minecraft.world.item.component.CustomData
 import org.bukkit.craftbukkit.v1_21_R3.CraftRegistry
 import org.bukkit.craftbukkit.v1_21_R3.inventory.CraftItemStack
@@ -22,7 +27,10 @@ class NMSItemTag12005 : NMSItemTag() {
     }
 
     override fun fromMinecraftJson(json: String): ItemStack? {
-        val nmsItem = net.minecraft.world.item.ItemStack.parse(CraftRegistry.getMinecraftRegistry(), MojangsonParser.parseTag(json)).getOrNull()
+        val nmsItem = net.minecraft.world.item.ItemStack.parse(
+            CraftRegistry.getMinecraftRegistry(),
+            MojangsonParser.parseTag(json)
+        ).getOrNull()
         return if (nmsItem != null) getBukkitCopy(nmsItem) else null
     }
 
@@ -51,9 +59,62 @@ class NMSItemTag12005 : NMSItemTag() {
             nmsItem.set(DataComponents.CUSTOM_DATA, CustomData.of(itemTagToNMSCopy(itemTag) as NBTTagCompound))
             getBukkitCopy(nmsItem)
         } else {
-            val nmsItem = net.minecraft.world.item.ItemStack.parse(CraftRegistry.getMinecraftRegistry(), itemTagToNMSCopy(itemTag))
+            val nmsItem = net.minecraft.world.item.ItemStack.parse(
+                CraftRegistry.getMinecraftRegistry(),
+                itemTagToNMSCopy(itemTag)
+            )
             if (nmsItem.isPresent) getBukkitCopy(nmsItem.get()) else itemStack
         }
+    }
+
+    private fun setAdventurePredicate(
+        itemStack: ItemStack,
+        blocks: List<String>,
+        componentType: DataComponentType<AdventureModePredicate>,
+    ): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        val predicates = blocks.mapNotNull { blockName ->
+            val key = MinecraftKey.parse(blockName)
+            val blockHolder = BuiltInRegistries.BLOCK.get(key).getOrNull()
+            blockHolder?.let { holder ->
+                CriterionConditionBlock.a.block()
+                    .of(BuiltInRegistries.BLOCK, holder.value())
+                    .build()
+            }
+        }
+        val predicate = AdventureModePredicate(predicates, true)
+        nmsItem.set(componentType, predicate)
+        return getBukkitCopy(nmsItem)
+    }
+
+    override fun setItemCanBreak(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        return setAdventurePredicate(itemStack, blocks, DataComponents.CAN_BREAK)
+    }
+
+    override fun setItemCanPlaceOn(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        return setAdventurePredicate(itemStack, blocks, DataComponents.CAN_PLACE_ON)
+    }
+
+    override fun hasItemCanBreak(itemStack: ItemStack): Boolean {
+        val nmsItem = getNMSCopy(itemStack)
+        return nmsItem.get(DataComponents.CAN_BREAK) != null
+    }
+
+    override fun hasItemCanPlaceOn(itemStack: ItemStack): Boolean {
+        val nmsItem = getNMSCopy(itemStack)
+        return nmsItem.get(DataComponents.CAN_PLACE_ON) != null
+    }
+
+    override fun removeItemCanBreak(itemStack: ItemStack): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        nmsItem.remove(DataComponents.CAN_BREAK)
+        return getBukkitCopy(nmsItem)
+    }
+
+    override fun removeItemCanPlaceOn(itemStack: ItemStack): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        nmsItem.remove(DataComponents.CAN_PLACE_ON)
+        return getBukkitCopy(nmsItem)
     }
 
     override fun itemTagToString(itemTagData: ItemTagData): String {

--- a/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-12105/src/main/kotlin/taboolib/module/nms/NMSItemTag12105.kt
+++ b/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-12105/src/main/kotlin/taboolib/module/nms/NMSItemTag12105.kt
@@ -1,7 +1,12 @@
 package taboolib.module.nms
 
+import net.minecraft.advancements.critereon.CriterionConditionBlock
+import net.minecraft.core.component.DataComponentType
 import net.minecraft.core.component.DataComponents
+import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.nbt.*
+import net.minecraft.resources.MinecraftKey
+import net.minecraft.world.item.AdventureModePredicate
 import net.minecraft.world.item.component.CustomData
 import org.bukkit.craftbukkit.v1_21_R4.CraftRegistry
 import org.bukkit.craftbukkit.v1_21_R4.inventory.CraftItemStack
@@ -24,7 +29,10 @@ class NMSItemTag12105 : NMSItemTag() {
     override fun fromMinecraftJson(json: String): ItemStack? {
         // 1.20.5 -> MojangsonParser.parseTag(String)
         // 1.21.5 -> MojangsonParser.parseComponentFully(String)
-        val nmsItem = net.minecraft.world.item.ItemStack.parse(CraftRegistry.getMinecraftRegistry(), MojangsonParser.parseCompoundFully(json)).getOrNull()
+        val nmsItem = net.minecraft.world.item.ItemStack.parse(
+            CraftRegistry.getMinecraftRegistry(),
+            MojangsonParser.parseCompoundFully(json)
+        ).getOrNull()
         return if (nmsItem != null) getBukkitCopy(nmsItem) else null
     }
 
@@ -53,9 +61,62 @@ class NMSItemTag12105 : NMSItemTag() {
             nmsItem.set(DataComponents.CUSTOM_DATA, CustomData.of(itemTagToNMSCopy(itemTag) as NBTTagCompound))
             getBukkitCopy(nmsItem)
         } else {
-            val nmsItem = net.minecraft.world.item.ItemStack.parse(CraftRegistry.getMinecraftRegistry(), itemTagToNMSCopy(itemTag))
+            val nmsItem = net.minecraft.world.item.ItemStack.parse(
+                CraftRegistry.getMinecraftRegistry(),
+                itemTagToNMSCopy(itemTag)
+            )
             if (nmsItem.isPresent) getBukkitCopy(nmsItem.get()) else itemStack
         }
+    }
+
+    private fun setAdventurePredicate(
+        itemStack: ItemStack,
+        blocks: List<String>,
+        componentType: DataComponentType<AdventureModePredicate>
+    ): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        val predicates = blocks.mapNotNull { blockName ->
+            val key = MinecraftKey.parse(blockName)
+            val blockHolder = BuiltInRegistries.BLOCK.get(key).getOrNull()
+            blockHolder?.let { holder ->
+                CriterionConditionBlock.a.block()
+                    .of(BuiltInRegistries.BLOCK, holder.value())
+                    .build()
+            }
+        }
+        val predicate = AdventureModePredicate(predicates)
+        nmsItem.set(componentType, predicate)
+        return getBukkitCopy(nmsItem)
+    }
+
+    override fun setItemCanBreak(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        return setAdventurePredicate(itemStack, blocks, DataComponents.CAN_BREAK)
+    }
+
+    override fun setItemCanPlaceOn(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        return setAdventurePredicate(itemStack, blocks, DataComponents.CAN_PLACE_ON)
+    }
+
+    override fun hasItemCanBreak(itemStack: ItemStack): Boolean {
+        val nmsItem = getNMSCopy(itemStack)
+        return nmsItem.get(DataComponents.CAN_BREAK) != null
+    }
+
+    override fun hasItemCanPlaceOn(itemStack: ItemStack): Boolean {
+        val nmsItem = getNMSCopy(itemStack)
+        return nmsItem.get(DataComponents.CAN_PLACE_ON) != null
+    }
+
+    override fun removeItemCanBreak(itemStack: ItemStack): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        nmsItem.remove(DataComponents.CAN_BREAK)
+        return getBukkitCopy(nmsItem)
+    }
+
+    override fun removeItemCanPlaceOn(itemStack: ItemStack): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        nmsItem.remove(DataComponents.CAN_PLACE_ON)
+        return getBukkitCopy(nmsItem)
     }
 
     override fun itemTagToString(itemTagData: ItemTagData): String {

--- a/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-12106/src/main/kotlin/taboolib/module/nms/NMSItemTag12106.kt
+++ b/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-12106/src/main/kotlin/taboolib/module/nms/NMSItemTag12106.kt
@@ -1,7 +1,12 @@
 package taboolib.module.nms
 
+import net.minecraft.advancements.critereon.CriterionConditionBlock
+import net.minecraft.core.component.DataComponentType
 import net.minecraft.core.component.DataComponents
+import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.nbt.*
+import net.minecraft.resources.MinecraftKey
+import net.minecraft.world.item.AdventureModePredicate
 import net.minecraft.world.item.component.CustomData
 import org.bukkit.craftbukkit.v1_21_R5.CraftRegistry
 import org.bukkit.craftbukkit.v1_21_R5.inventory.CraftItemStack
@@ -57,8 +62,58 @@ class NMSItemTag12106 : NMSItemTag() {
         }
     }
 
+    private fun setAdventurePredicate(
+        itemStack: ItemStack,
+        blocks: List<String>,
+        componentType: DataComponentType<AdventureModePredicate>
+    ): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        val predicates = blocks.mapNotNull { blockName ->
+            val key = MinecraftKey.parse(blockName)
+            val blockHolder = BuiltInRegistries.BLOCK.get(key).getOrNull()
+            blockHolder?.let { holder ->
+                CriterionConditionBlock.a.block()
+                    .of(BuiltInRegistries.BLOCK, holder.value())
+                    .build()
+            }
+        }
+        val predicate = AdventureModePredicate(predicates)
+        nmsItem.set(componentType, predicate)
+        return getBukkitCopy(nmsItem)
+    }
+
+    override fun setItemCanBreak(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        return setAdventurePredicate(itemStack, blocks, DataComponents.CAN_BREAK)
+    }
+
+    override fun setItemCanPlaceOn(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        return setAdventurePredicate(itemStack, blocks, DataComponents.CAN_PLACE_ON)
+    }
+
     override fun itemTagToString(itemTagData: ItemTagData): String {
         return itemTagToNMSCopy(itemTagData).toString()
+    }
+
+    override fun hasItemCanBreak(itemStack: ItemStack): Boolean {
+        val nmsItem = getNMSCopy(itemStack)
+        return nmsItem.get(DataComponents.CAN_BREAK) != null
+    }
+
+    override fun hasItemCanPlaceOn(itemStack: ItemStack): Boolean {
+        val nmsItem = getNMSCopy(itemStack)
+        return nmsItem.get(DataComponents.CAN_PLACE_ON) != null
+    }
+
+    override fun removeItemCanBreak(itemStack: ItemStack): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        nmsItem.remove(DataComponents.CAN_BREAK)
+        return getBukkitCopy(nmsItem)
+    }
+
+    override fun removeItemCanPlaceOn(itemStack: ItemStack): ItemStack {
+        val nmsItem = getNMSCopy(itemStack)
+        nmsItem.remove(DataComponents.CAN_PLACE_ON)
+        return getBukkitCopy(nmsItem)
     }
 
     override fun itemTagToNMSCopy(itemTagData: ItemTagData): NBTBase {

--- a/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-legacy/src/main/kotlin/taboolib/module/nms/NMSItemTagLegacy.kt
+++ b/module/bukkit-nms/bukkit-nms-tag/bukkit-nms-tag-legacy/src/main/kotlin/taboolib/module/nms/NMSItemTagLegacy.kt
@@ -66,6 +66,40 @@ open class NMSItemTagLegacy : NMSItemTag() {
         return getBukkitCopy(nmsItem)
     }
 
+    override fun setItemCanBreak(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        val tag = getItemTag(itemStack, true)
+        tag.putDeep("CanDestroy", ItemTagList.of(*blocks.toTypedArray()))
+        return setItemTag(itemStack, tag, true)
+    }
+
+    override fun setItemCanPlaceOn(itemStack: ItemStack, blocks: List<String>): ItemStack {
+        val tag = getItemTag(itemStack, true)
+        tag.putDeep("CanPlaceOn", ItemTagList.of(*blocks.toTypedArray()))
+        return setItemTag(itemStack, tag, true)
+    }
+
+    override fun hasItemCanBreak(itemStack: ItemStack): Boolean {
+        val tag = getItemTag(itemStack, true)
+        return tag.contains("CanDestroy")
+    }
+
+    override fun hasItemCanPlaceOn(itemStack: ItemStack): Boolean {
+        val tag = getItemTag(itemStack, true)
+        return tag.contains("CanPlaceOn")
+    }
+
+    override fun removeItemCanBreak(itemStack: ItemStack): ItemStack {
+        val tag = getItemTag(itemStack, true)
+        tag.remove("CanDestroy")
+        return setItemTag(itemStack, tag, true)
+    }
+
+    override fun removeItemCanPlaceOn(itemStack: ItemStack): ItemStack {
+        val tag = getItemTag(itemStack, true)
+        tag.remove("CanPlaceOn")
+        return setItemTag(itemStack, tag, true)
+    }
+
     override fun itemTagToString(itemTagData: ItemTagData): String {
         return itemTagToNMSCopy(itemTagData).toString()
     }
@@ -137,8 +171,15 @@ open class NMSItemTagLegacy : NMSItemTag() {
             is NBTTagString12 -> ItemTagData(ItemTagType.STRING, nbtTagStringGetter.get(nbtTag))
 
             // 数组类型特殊处理
-            is NBTTagByteArray12 -> ItemTagData(ItemTagType.BYTE_ARRAY, nbtTagByteArrayGetter.get<ByteArray>(nbtTag).copyOf())
-            is NBTTagIntArray12 -> ItemTagData(ItemTagType.INT_ARRAY, nbtTagIntArrayGetter.get<IntArray>(nbtTag).copyOf())
+            is NBTTagByteArray12 -> ItemTagData(
+                ItemTagType.BYTE_ARRAY,
+                nbtTagByteArrayGetter.get<ByteArray>(nbtTag).copyOf()
+            )
+
+            is NBTTagIntArray12 -> ItemTagData(
+                ItemTagType.INT_ARRAY,
+                nbtTagIntArrayGetter.get<IntArray>(nbtTag).copyOf()
+            )
             // 1.11 及以下版本无此类型
             // is NBTTagLongArray12 -> ItemTagData(ItemTagType.LONG_ARRAY, nbtTagLongArrayGetter.get<LongArray>(nbtTag).copyOf())
 
@@ -149,7 +190,10 @@ open class NMSItemTagLegacy : NMSItemTag() {
 
             // 复合类型特殊处理
             is NBTTagCompound12 -> {
-                ItemTag().apply { nbtTagCompoundGetter.get<Map<String, Any>>(nbtTag).forEach { put(it.key, itemTagToBukkitCopy(it.value)) } }
+                ItemTag().apply {
+                    nbtTagCompoundGetter.get<Map<String, Any>>(nbtTag)
+                        .forEach { put(it.key, itemTagToBukkitCopy(it.value)) }
+                }
             }
 
             // 其他类型

--- a/module/bukkit-nms/bukkit-nms-tag/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
+++ b/module/bukkit-nms/bukkit-nms-tag/src/main/kotlin/taboolib/module/nms/NMSItemTag.kt
@@ -40,6 +40,62 @@ fun ItemStack.toMinecraftJson(): String {
 }
 
 /**
+ * 设置物品可破坏方块列表
+ *
+ * @param blocks 列表，方块名称，如 "minecraft:stone"
+ * @return 添加成功返回新的物品，否则返回原物品
+ */
+fun ItemStack.setItemCanBreak(blocks: List<String>): ItemStack {
+    return NMSItemTag.instance.setItemCanBreak(validation(), blocks)
+}
+
+/**
+ * 设置物品可放置方块列表
+ *
+ * @param blocks 列表，方块名称，如 "minecraft:stone"
+ * @return 添加成功返回新的物品，否则返回原物品
+ */
+fun ItemStack.setItemCanPlaceOn(blocks: List<String>): ItemStack {
+    return NMSItemTag.instance.setItemCanPlaceOn(validation(), blocks)
+}
+
+/**
+ * 移除物品可破坏方块列表
+ *
+ * @return 移除成功返回新的物品，否则返回原物品
+ */
+fun ItemStack.removeItemCanBreak(): ItemStack {
+    return NMSItemTag.instance.removeItemCanBreak(validation())
+}
+
+/**
+ * 移除物品可放置方块列表
+ *
+ * @return 移除成功返回新的物品，否则返回原物品
+ */
+fun ItemStack.removeItemCanPlaceOn(): ItemStack {
+    return NMSItemTag.instance.removeItemCanPlaceOn(validation())
+}
+
+/**
+ * 检查物品是否设置了可破坏方块组件
+ *
+ * @return 如果物品包含 can_break 数据组件则返回 true，否则返回 false
+ */
+fun ItemStack.hasItemCanBreak(): Boolean {
+    return NMSItemTag.instance.hasItemCanBreak(validation())
+}
+
+/**
+ * 检查物品是否设置了可放置方块组件
+ *
+ * @return 如果物品包含 can_place_on 数据组件则返回 true，否则返回 false
+ */
+fun ItemStack.hasItemCanPlaceOn(): Boolean {
+    return NMSItemTag.instance.hasItemCanPlaceOn(validation())
+}
+
+/**
  * TabooLib
  * taboolib.module.nms.NMSItemTag
  *
@@ -71,6 +127,54 @@ abstract class NMSItemTag {
 
     /** 将 [net.minecraft.server] 下的 NBTTag 转换为 [ItemTagData] */
     abstract fun itemTagToBukkitCopy(nbtTag: Any): ItemTagData
+
+    /**
+     * 设置物品可破坏方块列表
+     *
+     * @param blocks 列表，方块名称，如 "minecraft:stone"
+     * @return 设置成功返回新的物品，否则返回原物品
+     */
+    abstract fun setItemCanBreak(itemStack: ItemStack, blocks: List<String>): ItemStack
+
+    /**
+     * 设置物品可放置方块列表
+     *
+     * @param blocks 列表，方块名称，如 "minecraft:stone"
+     * @return 设置成功返回新的物品，否则返回原物品
+     */
+    abstract fun setItemCanPlaceOn(itemStack: ItemStack, blocks: List<String>): ItemStack
+
+    /**
+     * 检查物品是否设置了可破坏方块组件
+     *
+     * @param itemStack 要检查的物品
+     * @return 如果物品包含 can_break 数据组件则返回 true，否则返回 false
+     */
+    abstract fun hasItemCanBreak(itemStack: ItemStack): Boolean
+
+    /**
+     * 检查物品是否设置了可放置方块组件
+     *
+     * @param itemStack 要检查的物品
+     * @return 如果物品包含 can_place_on 数据组件则返回 true，否则返回 false
+     */
+    abstract fun hasItemCanPlaceOn(itemStack: ItemStack): Boolean
+
+    /**
+     * 移除物品可破坏方块列表
+     *
+     * @param itemStack 要移除物品的方块列表的物品
+     * @return 移除成功返回新的物品，否则返回原物品
+     */
+    abstract fun removeItemCanBreak(itemStack: ItemStack): ItemStack
+
+    /**
+     * 移除物品可放置方块列表
+     *
+     * @param itemStack 要移除物品的方块列表的物品
+     * @return 移除成功返回新的物品，否则返回原物品
+     */
+    abstract fun removeItemCanPlaceOn(itemStack: ItemStack): ItemStack
 
     /**
      * 将物品转换为原版 Json 形式，可插入 Tellraw 信息中。


### PR DESCRIPTION
## 功能描述

为 `NMSItemTag` 添加冒险模式物品组件支持，包括可破坏方块 (`can_break`) 和可放置方块 (`can_place_on`) 的完整操作功能，并提供跨版本兼容性。

## 新增 API

- `setItemCanBreak(ItemStack, List<String>)` - 设置物品可破坏方块列表
- `setItemCanPlaceOn(ItemStack, List<String>)` - 设置物品可放置方块列表  
- `hasItemCanBreak(ItemStack)` - 检查物品是否包含可破坏方块组件
- `hasItemCanPlaceOn(ItemStack)` - 检查物品是否包含可放置方块组件
- `removeItemCanBreak(ItemStack)` - 移除物品可破坏方块列表
- `removeItemCanPlaceOn(ItemStack)` - 移除物品可放置方块列表

## 版本兼容性实现

### 1.20.5+ 版本 (现代数据组件系统)
- 使用 `DataComponents.CAN_BREAK` 和 `DataComponents.CAN_PLACE_ON`
- 通过 `AdventureModePredicate` 和 `CriterionConditionBlock` 实现

### 1.20.4 及以下版本 (传统 NBT 系统)  
- 使用传统 NBT 标签 `CanDestroy` 和 `CanPlaceOn`
- 通过 `ItemTagList` 存储方块名称列表

## 测试环境

- [x] Minecraft 1.20.4 (Paper) - NBT 实现
- [x] Minecraft 1.21.4 (Paper) - 数据组件实现  
- [x] Minecraft 1.21.8 (Paper) - 数据组件实现

## Breaking Changes

无破坏性变更，所有新增方法均为可选功能，且保持向下兼容。