### PR TITLE
添加枚举类型的命令参数支持和建议功能

### DIFF
--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponent.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponent.kt
@@ -3,6 +3,7 @@ package taboolib.common.platform.command
 import taboolib.common.platform.command.component.CommandComponent
 import taboolib.common.platform.command.component.CommandComponentDynamic
 import taboolib.common.platform.command.component.CommandSuggestProviderLoader
+import kotlin.enums.EnumEntries
 
 /**
  * 添加一层整型节点（自动约束）
@@ -49,6 +50,25 @@ fun CommandComponent.bool(
 ): CommandComponentDynamic {
     return dynamic(comment, optional, permission, dynamic).also {
         CommandSuggestProviderLoader.getProvider().provideBoolSuggest(it, comment)
+    }
+}
+
+/**
+ * 添加一层枚举节点（自动约束、自动建议）
+ *
+ * @param suggest 额外建议
+ */
+@OptIn(ExperimentalStdlibApi::class)
+fun CommandComponent.enum(
+    enums: EnumEntries<*>,
+    comment: String = "enum",
+    suggest: List<String> = emptyList(),
+    optional: Boolean = false,
+    permission: String = "",
+    dynamic: CommandComponentDynamic.() -> Unit = {}
+): CommandComponentDynamic {
+    return dynamic(comment, optional, permission, dynamic).also {
+        CommandSuggestProviderLoader.getProvider().provideEnumSuggest(it, enums, comment, suggest)
     }
 }
 

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponentRestrict.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponentRestrict.kt
@@ -2,6 +2,7 @@ package taboolib.common.platform.command
 
 import taboolib.common.platform.ProxyCommandSender
 import taboolib.common.platform.command.component.CommandComponentDynamic
+import kotlin.enums.EnumEntries
 
 /**
  * 创建参数约束（仅 int 类型）

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponentSuggest.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponentSuggest.kt
@@ -5,6 +5,7 @@ import taboolib.common.platform.command.component.CommandComponentDynamic
 import taboolib.common.platform.command.component.SuggestContext
 import taboolib.common.platform.function.allWorlds
 import taboolib.common.platform.function.onlinePlayers
+import kotlin.enums.EnumEntries
 
 /**
  * 创建参数补全
@@ -32,15 +33,25 @@ fun CommandComponentDynamic.suggestBoolean(): CommandComponentDynamic {
 }
 
 /**
+ * 创建参数补全（仅枚举）
+ *
+ * @param suggest 额外建议
+ */
+@OptIn(ExperimentalStdlibApi::class)
+fun CommandComponentDynamic.suggestEnums(enums: EnumEntries<*>, suggest: List<String> = emptyList()): CommandComponentDynamic {
+    return suggest {
+        enums.map { it.name } + suggest
+    }
+}
+
+/**
  * 创建参数补全（仅在线玩家名称）
  *
  * @param suggest 额外建议
  */
 fun CommandComponentDynamic.suggestPlayers(suggest: List<String> = emptyList()): CommandComponentDynamic {
     return suggest {
-        val el = onlinePlayers().map { it.name }.toMutableList()
-        el += suggest
-        el
+        onlinePlayers().map { it.name } + suggest
     }
 }
 
@@ -51,8 +62,6 @@ fun CommandComponentDynamic.suggestPlayers(suggest: List<String> = emptyList()):
  */
 fun CommandComponentDynamic.suggestWorlds(suggest: List<String> = emptyList()): CommandComponentDynamic {
     return suggest {
-        val el = allWorlds().toMutableList()
-        el += suggest
-        el
+        allWorlds() + suggest
     }
 }

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandSuggestProvider.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandSuggestProvider.kt
@@ -1,5 +1,7 @@
 package taboolib.common.platform.command.component
 
+import kotlin.enums.EnumEntries
+
 /**
  * 命令建议提供者接口
  *
@@ -25,6 +27,16 @@ interface CommandSuggestProvider {
      * @param suggest 额外的建议列表
      */
     fun provideDecimalSuggest(component: CommandComponentDynamic, comment: String, suggest: List<String>)
+
+    /**
+     * 提供枚举类型的建议
+     *
+     * @param component 动态命令组件
+     * @param comment 注释
+     * @param suggest 额外的建议列表
+     */
+    @OptIn(ExperimentalStdlibApi::class)
+    fun provideEnumSuggest(component: CommandComponentDynamic, enums: EnumEntries<*>, comment: String, suggest: List<String>)
 
     /**
      * 提供布尔类型的建议

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/DefaultCommandSuggestProvider.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/DefaultCommandSuggestProvider.kt
@@ -1,10 +1,7 @@
 package taboolib.common.platform.command.component
 
-import taboolib.common.platform.command.restrictDouble
-import taboolib.common.platform.command.restrictInt
-import taboolib.common.platform.command.suggestBoolean
-import taboolib.common.platform.command.suggestPlayers
-import taboolib.common.platform.command.suggestUncheck
+import taboolib.common.platform.command.*
+import kotlin.enums.EnumEntries
 
 /**
  * 默认的命令建议提供者实现
@@ -29,6 +26,11 @@ class DefaultCommandSuggestProvider : CommandSuggestProvider {
         }
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun provideEnumSuggest(component: CommandComponentDynamic, enums: EnumEntries<*>, comment: String, suggest: List<String>) {
+        component.suggestEnums(enums, suggest)
+    }
+
     override fun provideBoolSuggest(component: CommandComponentDynamic, comment: String) {
         component.suggestBoolean()
     }
@@ -37,4 +39,3 @@ class DefaultCommandSuggestProvider : CommandSuggestProvider {
         component.suggestPlayers(suggest)
     }
 }
-

--- a/module/bukkit/bukkit-ui/src/main/kotlin/taboolib/module/ui/ClickEvent.kt
+++ b/module/bukkit/bukkit-ui/src/main/kotlin/taboolib/module/ui/ClickEvent.kt
@@ -6,6 +6,7 @@ import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryDragEvent
 import org.bukkit.event.inventory.InventoryInteractEvent
 import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.InventoryView
 import org.bukkit.inventory.ItemStack
 import taboolib.common.util.t
 import taboolib.module.ui.type.Chest
@@ -23,6 +24,9 @@ class ClickEvent(private val bukkitEvent: InventoryInteractEvent, val clickType:
 
     val inventory: Inventory
         get() = bukkitEvent.inventory
+
+    val view: InventoryView
+        get() = bukkitEvent.view
 
     /** 影响物品 */
     val affectItems: List<ItemStack>


### PR DESCRIPTION
feat(command): 为 `CommandComponentDynamic` 添加 `suggestEnums` 方法
feat(command): 为 `CommandComponent` 添加 `enum` 动态节点方法
feat(command): 在 `CommandSuggestProvider` 接口中添加 `provideEnumSuggest` 方法
feat(command): 在 `DefaultCommandSuggestProvider` 中实现枚举建议功能
refactor(command): 简化 `suggestPlayers` 和 `suggestWorlds` 方法的实现