### PR TITLE
feat(nms): 添加对混合服务端的支持并优化发包逻辑

### DIFF
--- a/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/MinecraftVersion.kt
+++ b/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/MinecraftVersion.kt
@@ -63,6 +63,20 @@ object MinecraftVersion {
         get() = minecraftVersion == "UNKNOWN"
 
     /**
+     * 是否为混合服务端（如 CatServer、Mohist、Arclight、Magma 等）
+     * 这些服务端使用自己的重混淆系统，可能与 Taboolib 的 NMS 重映射不兼容
+     */
+    val isHybridServer by unsafeLazy {
+        try {
+            // 检测 CatServer
+            Class.forName("catserver.server.CatServer")
+            return@unsafeLazy true
+        } catch (_: ClassNotFoundException) {
+        }
+        false
+    }
+
+    /**
      * 当前所有受支持的版本
      */
     val supportedVersion = arrayOf(

--- a/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/MinecraftVersion.kt
+++ b/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/MinecraftVersion.kt
@@ -63,10 +63,10 @@ object MinecraftVersion {
         get() = minecraftVersion == "UNKNOWN"
 
     /**
-     * 是否为混合服务端（如 CatServer、Mohist、Arclight、Magma 等）
+     * 是否为CatServer
      * 这些服务端使用自己的重混淆系统，可能与 Taboolib 的 NMS 重映射不兼容
      */
-    val isHybridServer by unsafeLazy {
+    val isCatServer by unsafeLazy {
         try {
             // 检测 CatServer
             Class.forName("catserver.server.CatServer")

--- a/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/PacketSender.kt
+++ b/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/PacketSender.kt
@@ -27,7 +27,8 @@ import java.util.concurrent.ConcurrentHashMap
 object PacketSender {
 
     private val playerConnectionMap = ConcurrentHashMap<String, Any>()
-    private var sendPacketMethod: ClassMethod? = null
+    private var sendPacketMethod: Any? = null
+    private var isFallbackMethod = false
 
     private var newPacketBundlePacket: Constructor<*>? = null
     private var useMinecraftMethod = false
@@ -66,19 +67,88 @@ object PacketSender {
         // 之前通过 TinyProtocol 的 channel.pipeline().writeAndFlush() 暴力发包会有概率出问题
         val connection = getConnection(player)
         if (sendPacketMethod == null) {
-            val reflexClass = ReflexClass.of(connection.javaClass)
-            // 1.18 更名为 send 方法
-            sendPacketMethod = if (MinecraftVersion.isHigherOrEqual(MinecraftVersion.V1_18)) {
-                try {
-                    reflexClass.getMethod("send", true, true, packet)
-                } catch (_: NoSuchMethodException) {
-                    reflexClass.getMethod("sendPacket", true, true, packet)
-                }
+            // 在混合服务端下，直接使用原生反射避免触发类型加载
+            if (MinecraftVersion.isHybridServer) {
+                sendPacketMethod = getSendPacketMethodHybrid(connection, packet)
+                isFallbackMethod = true
             } else {
-                reflexClass.getMethod("sendPacket", true, true, packet)
+                try {
+                    val reflexClass = ReflexClass.of(connection.javaClass)
+                    sendPacketMethod = if (MinecraftVersion.isHigherOrEqual(MinecraftVersion.V1_18)) {
+                        try {
+                            reflexClass.getMethod("send", true, true, packet)
+                        } catch (_: NoSuchMethodException) {
+                            reflexClass.getMethod("sendPacket", true, true, packet)
+                        }
+                    } else {
+                        reflexClass.getMethod("sendPacket", true, true, packet)
+                    }
+                    isFallbackMethod = false
+                } catch (e: Exception) {
+                    // 如果 ReflexClass 获取方法失败，使用回退方案
+                    sendPacketMethod = getSendPacketMethodHybrid(connection, packet)
+                    isFallbackMethod = true
+                }
             }
         }
-        sendPacketMethod!!.invoke(connection, packet)
+
+        // 根据方法类型调用
+        if (isFallbackMethod) {
+            (sendPacketMethod as java.lang.reflect.Method).invoke(connection, packet)
+        } else {
+            (sendPacketMethod as ClassMethod).invoke(connection, packet)
+        }
+    }
+
+    /**
+     * 获取发送数据包方法的回退方案
+     * 用于处理混合服务端（CatServer等）的兼容性问题
+     *
+     * 注意：在混合服务端下必须使用原生 Java 反射
+     * 因为 TabooLib 的 Reflex API 会尝试获取父类和返回类型
+     * 这会触发 Class.forName() 加载混淆的类名，导致 CatServer 的 remapper 报错
+     */
+    private fun getSendPacketMethodHybrid(connection: Any, packet: Any): java.lang.reflect.Method {
+        val connectionClass = connection.javaClass
+
+        val methodNames = if (MinecraftVersion.isHigherOrEqual(MinecraftVersion.V1_18)) {
+            listOf("send", "a", "sendPacket")
+        } else {
+            listOf("sendPacket", "a", "send")
+        }
+
+        // 首先尝试查找接受 Packet 基类或接口的方法（更通用）
+        for (methodName in methodNames) {
+            for (method in connectionClass.declaredMethods) {
+                if (method.name == methodName && method.parameterCount == 1) {
+                    val paramType = method.parameterTypes[0]
+                    // 检查参数类型是否是 Packet 基类或接口
+                    if (paramType.isAssignableFrom(packet.javaClass)) {
+                        method.isAccessible = true
+                        return method
+                    }
+                }
+            }
+        }
+
+        // 如果找不到通用方法，尝试精确匹配具体的数据包类型
+        for (methodName in methodNames) {
+            try {
+                val method = connectionClass.getDeclaredMethod(methodName, packet.javaClass)
+                method.isAccessible = true
+                // 缓存找到的方法
+                return method
+            } catch (_: NoSuchMethodException) {
+                // 尝试下一个方法名
+            }
+        }
+
+        throw NoSuchMethodException(
+            "Failed to find sendPacket method. " +
+                    "Connection type: ${connectionClass.name}, " +
+                    "Packet type: ${packet.javaClass.name}, " +
+                    "Server: ${if (MinecraftVersion.isHybridServer) "Hybrid Server" else "Standard Server"}"
+        )
     }
 
     /**
@@ -88,14 +158,86 @@ object PacketSender {
         return if (playerConnectionMap.containsKey(player.name)) {
             playerConnectionMap[player.name]!!
         } else {
-            val connection = if (MinecraftVersion.isUniversal) {
-                player.getProperty<Any>("entity/connection")!!
+            val connection = if (!MinecraftVersion.isHybridServer) {
+                // 标准方式获取连接
+                if (MinecraftVersion.isUniversal) {
+                    player.getProperty<Any>("entity/connection")!!
+                } else {
+                    player.getProperty<Any>("entity/playerConnection")!!
+                }
             } else {
-                player.getProperty<Any>("entity/playerConnection")!!
+                // 因为 getProperty 会尝试获取字段类型，触发 Class.forName() 导致 ClassNotFoundException
+                getConnectionHybrid(player)
             }
             playerConnectionMap[player.name] = connection
             connection
         }
+    }
+
+    /**
+     * 获取玩家连接的回退方案
+     * 用于处理混合服务端（CatServer等）的兼容性问题
+     *
+     * 注意：在混合服务端下必须使用原生 Java 反射
+     * 因为 TabooLib 的 Reflex API 会尝试获取返回类型和字段类型
+     * 这会触发 Class.forName() 加载混淆的类名，导致 CatServer 的 remapper 报错
+     */
+    private fun getConnectionHybrid(player: Player): Any {
+        try {
+            val playerClass = player.javaClass
+
+            val getHandleMethod = playerClass.getDeclaredMethod("getHandle")
+            getHandleMethod.isAccessible = true
+
+            val entityPlayer = getHandleMethod.invoke(player)
+            val entityPlayerClass = entityPlayer.javaClass
+
+            val fieldNames = if (MinecraftVersion.isUniversal) {
+                listOf("connection", "b", "c", "playerConnection")
+            } else {
+                listOf("playerConnection", "b", "c", "connection")
+            }
+
+            for (fieldName in fieldNames) {
+                try {
+                    val field = entityPlayerClass.getDeclaredField(fieldName)
+                    field.isAccessible = true
+                    val connection = field.get(entityPlayer)
+                    if (connection != null) {
+                        // 缓存找到的字段
+                        return connection
+                    }
+                } catch (_: NoSuchFieldException) {
+                    continue
+                } catch (_: IllegalAccessException) {
+                    continue
+                }
+            }
+
+            for (field in entityPlayerClass.declaredFields) {
+                val fieldType = field.type.simpleName
+                if (fieldType.contains("Connection") || fieldType.contains("PlayerConnection")) {
+                    try {
+                        field.isAccessible = true
+                        val connection = field.get(entityPlayer)
+                        if (connection != null) {
+                            return connection
+                        }
+                    } catch (_: Exception) {
+                        continue
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+        // 还找不到就真没招了
+        throw RuntimeException(
+            "Failed to get player connection. " +
+                    "Server: ${if (MinecraftVersion.isHybridServer) "Hybrid Server" else "Standard Server"}, " +
+                    "Version: ${MinecraftVersion.runningVersion}"
+        )
     }
 
     @SubscribeEvent

--- a/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/PacketSender.kt
+++ b/module/bukkit-nms/src/main/kotlin/taboolib/module/nms/PacketSender.kt
@@ -68,7 +68,7 @@ object PacketSender {
         val connection = getConnection(player)
         if (sendPacketMethod == null) {
             // 在混合服务端下，直接使用原生反射避免触发类型加载
-            if (MinecraftVersion.isHybridServer) {
+            if (MinecraftVersion.isCatServer) {
                 sendPacketMethod = getSendPacketMethodHybrid(connection, packet)
                 isFallbackMethod = true
             } else {
@@ -147,7 +147,7 @@ object PacketSender {
             "Failed to find sendPacket method. " +
                     "Connection type: ${connectionClass.name}, " +
                     "Packet type: ${packet.javaClass.name}, " +
-                    "Server: ${if (MinecraftVersion.isHybridServer) "Hybrid Server" else "Standard Server"}"
+                    "Server: ${if (MinecraftVersion.isCatServer) "Hybrid Server" else "Standard Server"}"
         )
     }
 
@@ -158,7 +158,7 @@ object PacketSender {
         return if (playerConnectionMap.containsKey(player.name)) {
             playerConnectionMap[player.name]!!
         } else {
-            val connection = if (!MinecraftVersion.isHybridServer) {
+            val connection = if (!MinecraftVersion.isCatServer) {
                 // 标准方式获取连接
                 if (MinecraftVersion.isUniversal) {
                     player.getProperty<Any>("entity/connection")!!
@@ -235,7 +235,7 @@ object PacketSender {
         // 还找不到就真没招了
         throw RuntimeException(
             "Failed to get player connection. " +
-                    "Server: ${if (MinecraftVersion.isHybridServer) "Hybrid Server" else "Standard Server"}, " +
+                    "Server: ${if (MinecraftVersion.isCatServer) "Hybrid Server" else "Standard Server"}, " +
                     "Version: ${MinecraftVersion.runningVersion}"
         )
     }


### PR DESCRIPTION
- 新增 isHybridServer 属性用于检测 CatServer等混合服务端
- 重构 PacketSender 以兼容混合服务端的类加载机制
- 添加回退方案避免 Reflex API 触发混淆类加载异常
- 使用原生反射替代 getProperty 防止 ClassNotFoundException
- 增强 sendPacket 方法查找逻辑支持多种方法名和参数类型
- 改进 getConnection 方法以适配不同服务端环境
- 添加详细的异常信息便于调试和问题排查