### PR TITLE
更新 XItemStack 以修复 custommodeldata 问题

### DIFF
--- a/platform/platform-bukkit-impl/src/main/java/taboolib/library/xseries/XItemStack.java
+++ b/platform/platform-bukkit-impl/src/main/java/taboolib/library/xseries/XItemStack.java
@@ -118,9 +118,9 @@ public final class XItemStack {
         }
 
         try {
-            Class.forName("org.bukkit.inventory.meta.components.CustomModelDataComponent");
+            ItemMeta.class.getDeclaredMethod("getCustomModelDataComponent");
             supportsAdvancedCustomModelData = true;
-        } catch (ClassNotFoundException ignored) {
+        } catch (NoSuchMethodException ignored) {
         }
 
         try {
@@ -486,7 +486,7 @@ public final class XItemStack {
             }
 
             if (SUPPORTS_CUSTOM_MODEL_DATA) {
-                if (SUPPORTS_ADVANCED_CUSTOM_MODEL_DATA && meta.hasCustomModelDataComponent()) {
+                if (SUPPORTS_ADVANCED_CUSTOM_MODEL_DATA) {
                     CustomModelDataComponent customModelData = meta.getCustomModelDataComponent();
                     List<String> strings = customModelData.getStrings();
                     List<Float> floats = customModelData.getFloats();


### PR DESCRIPTION
修复 #635 ，已在1.21.4 1.21.10上测试。