### PR TITLE
移除 OpenResult 对 reflex 的依赖

### DIFF
--- a/common/src/main/java/taboolib/common/OpenResult.java
+++ b/common/src/main/java/taboolib/common/OpenResult.java
@@ -2,7 +2,8 @@ package taboolib.common;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.tabooproject.reflex.Reflex;
+
+import java.lang.reflect.Field;
 
 public class OpenResult {
 
@@ -77,8 +78,30 @@ public class OpenResult {
      * 从其他插件的 OpenResult 转换为当前插件的 OpenResult
      */
     public static OpenResult cast(Object source) {
-        Object successful = Reflex.Companion.getLocalProperty(source, "successful");
-        Object value = Reflex.Companion.getLocalProperty(source, "value");
+        if (source == null) {
+            return failed();
+        }
+        if (source instanceof OpenResult) {
+            return (OpenResult) source;
+        }
+        Object successful = readField(source, "successful");
+        Object value = readField(source, "value");
         return new OpenResult(Boolean.TRUE.equals(successful), value);
+    }
+
+    private static Object readField(Object source, String fieldName) {
+        Class<?> type = source.getClass();
+        while (type != null) {
+            try {
+                Field field = type.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field.get(source);
+            } catch (NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            } catch (IllegalAccessException ex) {
+                throw new IllegalStateException("Cannot access field '" + fieldName + "' in " + source.getClass().getName(), ex);
+            }
+        }
+        throw new IllegalArgumentException("Field '" + fieldName + "' not found in " + source.getClass().getName());
     }
 }


### PR DESCRIPTION
Summary

  - 移除 OpenResult.cast() 方法对 org.tabooproject.reflex.Reflex 的依赖
  - 使用标准 Java 反射 API 替代 Reflex 工具类
  - 增加空值检查和类型判断优化

  改动内容

  问题：OpenResult 位于 common 模块的最底层，但却依赖了 reflex 库。这违反了模块分层原则——底层模块不应依赖上层工具。

  解决方案：

  1. 使用 JDK 原生 java.lang.reflect.Field 替代 Reflex.getLocalProperty()
  2. 新增 readField() 私有方法，实现字段读取逻辑（支持父类字段遍历）
  3. 在 cast() 方法中增加防御性检查：
    - null 检查 → 返回 failed()
    - instanceof OpenResult 检查 → 直接类型转换，避免不必要的反射