### PR TITLE
docs(guide): 添加 CLAUDE.md 指南和 Claude 技能配置

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: create-pr
+description: 创建补丁：收集需求信息，在主仓库创建 Issue，创建本地分支，进入规划模式。
+user_invocable: true
+---
+
+# 创建补丁流程
+
+## 执行步骤
+
+当用户调用 `/create-pr` 时，严格按以下步骤执行：
+
+### 第一步：收集信息
+
+使用 `AskUserQuestion` 工具向用户收集以下信息（一次性提问，使用多个 question）：
+
+1. **功能简述**（header: "功能"）— 一句话描述要做什么功能
+2. **为什么要做**（header: "原因"）— 这个功能的背景和动机
+3. **怎么做**（header: "方案"）— 大致的实现思路
+
+每个问题都使用自由文本输入（提供 2 个引导性选项让用户参考，但用户通常会选择 Other 自行填写）。
+
+### 第二步：创建 Issue
+
+在 **主仓库** `TabooLib/taboolib` 上创建 Issue：
+
+```bash
+gh issue create --repo TabooLib/taboolib \
+  --title "[feat] {功能简述}" \
+  --body "$(cat <<'EOF'
+## 为什么要做
+
+{用户填写的原因}
+
+## 怎么做
+
+{用户填写的方案}
+EOF
+)"
+```
+
+从命令输出中提取 Issue 编号（如 `#542`）。
+
+### 第三步：创建本地分支
+
+基于当前分支创建新分支，分支名格式为 `feat/{简述关键词}-{issue编号}`：
+
+```bash
+git checkout -b feat/{keyword}-{issue_number}
+```
+
+- `keyword`：从功能简述中提取 1-3 个英文关键词，用连字符连接
+- `issue_number`：不带 `#` 的纯数字
+
+示例：`feat/entity-name-i18n-542`
+
+### 第四步：进入规划模式
+
+使用 `EnterPlanMode` 工具进入规划模式，对需求进行详细分析和实现方案规划。
+
+## 注意事项
+
+1. Issue 必须创建在主仓库 `TabooLib/taboolib`，不是个人 fork
+2. 分支基于当前所在分支创建（通常是 `dev/6.2.0`）
+3. 分支名只使用小写英文字母、数字和连字符
+4. 进入规划模式后，充分分析代码库再制定方案

--- a/.claude/skills/over-pr/SKILL.md
+++ b/.claude/skills/over-pr/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: over-or
+description: 完成补丁：推送分支到个人仓库，向主仓库提交 PR。
+user_invocable: true
+---
+
+# 完成补丁流程
+
+## 执行步骤
+
+当用户调用 `/over-or` 时，表示当前任务已完成，严格按以下步骤执行：
+
+### 第一步：检查状态
+
+```bash
+git status
+git log --oneline dev/6.2.0..HEAD
+```
+
+确认：
+
+- 工作区干净（无未提交的修改）
+- 当前分支有新的 commit（相对于基础分支）
+
+如果有未提交的修改，先提醒用户处理。
+
+### 第二步：推送到个人仓库
+
+将当前分支推送到个人 fork 仓库（origin）：
+
+```bash
+git push -u origin {当前分支名}
+```
+
+### 第三步：创建 PR
+
+使用 `gh` 向主仓库 `TabooLib/taboolib` 提交 PR：
+
+```bash
+gh pr create --repo TabooLib/taboolib \
+  --base dev/6.2.0 \
+  --head FxRayHughes:{当前分支名} \
+  --title "{PR标题}" \
+  --body "$(cat <<'EOF'
+{PR描述}
+
+Closes TabooLib/taboolib#{issue编号}
+EOF
+)"
+```
+
+**PR 标题**：与对应 Issue 标题一致（如 `[feat] 功能简述`）。
+
+**PR 描述**：包含以下内容：
+
+1. 简要说明做了什么改动
+2. 列出主要修改的文件/模块
+3. 关联 Issue（使用 `Closes TabooLib/taboolib#编号`）
+
+Issue 编号从当前分支名中提取（分支名末尾的数字）。
+
+### 第四步：输出结果
+
+向用户展示：
+
+- PR 链接
+- 关联的 Issue 链接
+- 等待主仓库维护者审核合并
+
+## 注意事项
+
+1. PR 的 `--base` 是主仓库的目标分支（通常 `dev/6.2.0`）
+2. PR 的 `--head` 必须带上个人用户名前缀 `FxRayHughes:` (需要使用gh进行获取)
+3. 如果工作区不干净，不要强行推送，提醒用户先处理
+4. 从分支名提取 Issue 编号（如 `feat/xxx-542` → `542`）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**语言约定：所有对话和输出请使用中文。**
+
+## 项目概述
+
+TabooLib 是 Minecraft（Java 版）跨平台插件开发框架，基于 Kotlin 构建，支持 Bukkit、BungeeCord、Velocity、AfyBroker 等平台。当前版本 6.2.2，分支 `dev/6.2.0`。
+
+## 构建命令
+
+```bash
+# 构建整个项目
+./gradlew build
+
+# 构建单个模块（示例）
+./gradlew :common-util:build
+./gradlew :module:bukkit:bukkit-ui:build
+./gradlew :platform:platform-bukkit-impl:build
+
+# 发布到本地 Maven
+./gradlew publishToMavenLocal
+
+# 发布开发版本
+./gradlew build -Pdev
+./gradlew build -PdevLocal
+```
+
+## 架构概览
+
+### 模块层次
+
+```
+common/              → 引导启动、隔离类加载器（IsolatedClassLoader）、生命周期管理
+common-env/          → 运行时环境、依赖下载与重定位
+common-util/         → 工具函数、内部事件总线、反射工具
+common-platform-api/ → 平台抽象层（ProxyPlayer、命令系统、事件系统、调度器）
+common-legacy-api/   → 向后兼容 API
+module/              → 功能模块（按 basic/bukkit/bukkit-nms/minecraft/database/script 分类）
+platform/            → 各平台的具体实现（bukkit-impl、bungee-impl、velocity-impl 等）
+```
+
+### 生命周期
+
+框架按以下阶段顺序初始化：
+`NONE → CONST → INIT → LOAD → ENABLE → ACTIVE → DISABLE`
+
+### 核心注解
+
+- `@Awake` — 自动初始化，绑定到生命周期阶段
+- `@PlatformSide` — 标记代码所属平台（BUKKIT / BUNGEE / VELOCITY / AFYBROKER / APPLICATION）
+- `@Inject` — 依赖注入
+- `@SubscribeEvent` — 事件监听器注册
+
+### 隔离类加载
+
+使用 `IsolatedClassLoader` 沙箱化加载依赖，通过 Shadow 插件重定位 `org.tabooproject` → `taboolib.library`，防止与服务端/其他插件的依赖冲突。
+
+### 平台抽象
+
+`common-platform-api` 定义跨平台接口（ProxyPlayer、ProxyCommandSender 等），各 `platform/*-impl` 模块提供具体实现。通过服务提供者模式（PlatformService）在运行时绑定。
+
+### 模块加载流程
+
+1. IsolatedClassLoader 引导启动
+2. PrimitiveLoader 加载模块
+3. 下载并重定位 TabooLib 模块
+4. 执行模块入口点（定义在 `extra.properties`）
+5. 初始化 Kotlin 环境
+6. 注册类访问器和回调
+
+## 技术约束
+
+- **Java 8 兼容**：`jvmTarget = 1.8`，`sourceCompatibility = 1.8`
+- **Kotlin 1.8.22**，启用 `-Xjvm-default=all`
+- **包结构**：所有代码在 `taboolib.*` 包下（`taboolib.common.*`、`taboolib.platform.*`、`taboolib.module.*`）
+- **Maven 坐标**：`io.izzel.taboolib:{模块名}:{版本}`
+- **不可发布的模块**：名为 `module`、`platform`、`expansion` 的父项目以及 `impl` 开头的模块不参与 Maven 发布
+
+## 关键依赖
+
+- Kotlin stdlib、kotlinx-coroutines-core 1.7.3
+- Google Guava 21.0、Gson 2.8.7
+- Apache Commons Lang3 3.5
+- TabooProject Reflex 1.1.8（反射库）
+- Shadow 7.1.2（JAR 打包与重定位）
+
+## 外部文档
+
+- 官方文档：https://docs.tabooproject.org
+- 构件仓库：https://repo.tabooproject.org
+- 非官方文档（枫溪）：https://taboolib.feishu.cn/wiki/Lzf8wFEsfiHclskCuGkctoUNn9b


### PR DESCRIPTION
## 变更内容

添加 Claude Code 项目指南和技能配置文件：

- **CLAUDE.md** — 项目概述、构建命令、架构概览、技术约束等指导信息
- **.claude/skills/create-pr/SKILL.md** — 创建补丁的技能配置
- **.claude/skills/over-pr/SKILL.md** — 完成补丁的技能配置

这些文件为 Claude Code 提供项目上下文，帮助更好地辅助 TabooLib 开发。