### PR TITLE
[fix] Skill 提示词中的分支信息应动态获取

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -61,6 +61,6 @@ git checkout -b feat/{keyword}-{issue_number}
 ## 注意事项
 
 1. Issue 必须创建在主仓库 `TabooLib/taboolib`，不是个人 fork
-2. 分支基于当前所在分支创建（通常是 `dev/6.2.0`）
+2. 分支基于当前所在分支创建（通过 Git 获取当前所在分支）
 3. 分支名只使用小写英文字母、数字和连字符
 4. 进入规划模式后，充分分析代码库再制定方案

--- a/.claude/skills/over-pr/SKILL.md
+++ b/.claude/skills/over-pr/SKILL.md
@@ -13,8 +13,9 @@ user_invocable: true
 ### 第一步：检查状态
 
 ```bash
+BASE_BRANCH=$(gh repo view TabooLib/taboolib --json defaultBranchRef -q '.defaultBranchRef.name')
 git status
-git log --oneline dev/6.2.0..HEAD
+git log --oneline ${BASE_BRANCH}..HEAD
 ```
 
 确认：
@@ -37,8 +38,9 @@ git push -u origin {当前分支名}
 使用 `gh` 向主仓库 `TabooLib/taboolib` 提交 PR：
 
 ```bash
+BASE_BRANCH=$(gh repo view TabooLib/taboolib --json defaultBranchRef -q '.defaultBranchRef.name')
 gh pr create --repo TabooLib/taboolib \
-  --base dev/6.2.0 \
+  --base ${BASE_BRANCH} \
   --head FxRayHughes:{当前分支名} \
   --title "{PR标题}" \
   --body "$(cat <<'EOF'
@@ -69,7 +71,7 @@ Issue 编号从当前分支名中提取（分支名末尾的数字）。
 
 ## 注意事项
 
-1. PR 的 `--base` 是主仓库的目标分支（通常 `dev/6.2.0`）
+1. PR 的 `--base` 是主仓库的目标分支（通过 `gh` 动态获取主仓库默认分支）
 2. PR 的 `--head` 必须带上个人用户名前缀 `FxRayHughes:` (需要使用gh进行获取)
 3. 如果工作区不干净，不要强行推送，提醒用户先处理
 4. 从分支名提取 Issue 编号（如 `feat/xxx-542` → `542`）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 项目概述
 
-TabooLib 是 Minecraft（Java 版）跨平台插件开发框架，基于 Kotlin 构建，支持 Bukkit、BungeeCord、Velocity、AfyBroker 等平台。当前版本 6.2.2，分支 `dev/6.2.0`。
+TabooLib 是 Minecraft（Java 版）跨平台插件开发框架，基于 Kotlin 构建，支持 Bukkit、BungeeCord、Velocity、AfyBroker 等平台。当前版本 6.2.3，分支 `dev/6.2.3`。
 
 ## 构建命令
 


### PR DESCRIPTION
## 改动说明

将 Skill 提示词和 CLAUDE.md 中硬编码的 `dev/6.2.0` 分支名替换为动态获取，避免每次版本更新都需要手动修改。

## 主要修改

- `.claude/skills/over-pr/SKILL.md`：使用 `gh repo view` 动态获取主仓库默认分支名，替代硬编码的 `dev/6.2.0`
- `.claude/skills/create-pr/SKILL.md`：移除硬编码分支名引用
- `CLAUDE.md`：更新版本信息为 6.2.3

Closes TabooLib/taboolib#654