### PR TITLE
[feat] 拓展 database-ptc-object 增加快捷操作工具

### DIFF
--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
@@ -1,6 +1,8 @@
 package taboolib.expansion
 
 import taboolib.common.reflect.getAnnotationIfPresent
+import taboolib.module.database.ColumnTypeSQL
+import taboolib.module.database.ColumnTypeSQLite
 import java.lang.reflect.Parameter
 
 /**
@@ -35,6 +37,15 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
 
     /** 长度 */
     val length = root.findAnnotation<Length>()?.value ?: 64
+
+    /** 自定义 SQL 列类型 */
+    val columnTypeSQL: ColumnTypeSQL? = root.findAnnotation<ColumnType>()?.sql
+
+    /** 自定义 SQLite 列类型 */
+    val columnTypeSQLite: ColumnTypeSQLite? = root.findAnnotation<ColumnType>()?.sqlite
+
+    /** 是否指定了自定义列类型 */
+    val hasColumnType: Boolean = root.findAnnotation<ColumnType>() != null
 
     /** 是否为基础类型（Boolean） */
     val isBoolean: Boolean

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
@@ -1,19 +1,146 @@
 package taboolib.expansion
 
+import taboolib.module.database.ColumnTypeSQL
+import taboolib.module.database.ColumnTypeSQLite
+
+/**
+ * 标记数据类的逻辑主键字段。
+ *
+ * 框架的 CRUD 操作（find、update、delete、has）均通过 @Id 字段定位记录。
+ *
+ * **建表行为：**
+ * - 若数据类中存在 @Id 字段，该字段在 SQL 中会被设置为 KEY（索引），在 SQLite 中会被设置为 PRIMARY KEY
+ * - 若数据类中不存在 @Id 字段，框架会自动添加一个名为 `id` 的自增主键列
+ *
+ * **CRUD 行为：**
+ * - `find(id)` / `findOne(id)` — 以 @Id 字段值作为 WHERE 条件查询
+ * - `update(data)` — 以 @Id 字段值定位记录并更新 var 字段
+ * - `delete(id)` — 以 @Id 字段值定位记录并删除
+ * - `has(id)` — 以 @Id 字段值检查记录是否存在
+ * - `upsert` — 以 @Id（+ @Key）判断记录是否存在，存在则更新，不存在则插入
+ *
+ * **约束：** 每个数据类最多标记一个 @Id 字段。
+ *
+ * ```kotlin
+ * data class PlayerHome(
+ *     @Id val username: UUID,   // 逻辑主键，用于定位记录
+ *     var world: String,
+ * )
+ * ```
+ */
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Id
 
+/**
+ * 标记数据类的索引字段，同时作为 updateByKey / upsert 的复合定位条件。
+ *
+ * **建表行为：**
+ * - SQL：为该列创建 KEY（普通索引），加速查询
+ * - SQLite：通过 `CREATE INDEX` 为该列创建索引
+ *
+ * **CRUD 行为：**
+ * - `updateByKey(data)` — 在 @Id 的基础上，追加所有 @Key 字段作为 WHERE 条件，精确定位记录
+ * - `upsert(dataList)` — 以 @Id + 所有 @Key 字段的组合值判断记录是否存在
+ *
+ * **典型场景：** 当 @Id 不唯一时（如同一玩家在多个服务器有数据），
+ * 用 @Key 补充定位条件，形成复合键。
+ *
+ * 允许标记多个 @Key 字段。
+ *
+ * ```kotlin
+ * data class PlayerHome(
+ *     @Id val username: UUID,
+ *     @Key @Length(32) val serverName: String,  // 索引 + 复合定位
+ *     var world: String,
+ * )
+ * // updateByKey(home) → WHERE username = ? AND server_name = ?
+ * ```
+ */
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Key
 
+/**
+ * 标记数据类的唯一索引字段。
+ *
+ * **建表行为：**
+ * - SQL：为该列创建 UNIQUE KEY（唯一索引）
+ * - SQLite：为该列添加 UNIQUE 约束
+ *
+ * **注意：** 这是纯数据库层面的约束，框架的 CRUD 操作不会使用 @UniqueKey 进行定位。
+ * 如果需要在 updateByKey / upsert 中参与定位，请使用 [@Key]。
+ *
+ * ```kotlin
+ * data class PlayerProfile(
+ *     @Id val id: Int,
+ *     @UniqueKey @Length(16) val nickname: String,  // 数据库保证昵称不重复
+ *     var level: Int,
+ * )
+ * ```
+ */
 @Retention(AnnotationRetention.RUNTIME)
 annotation class UniqueKey
 
+/**
+ * 标记字段不允许为空。
+ *
+ * **建表行为：**
+ * - SQL：为该列添加 NOT NULL 约束
+ * - SQLite：为该列添加 NOT NULL 约束
+ */
 @Retention(AnnotationRetention.RUNTIME)
 annotation class NotNull
 
+/**
+ * 指定字段在数据库中的存储长度。
+ *
+ * 主要影响 VARCHAR 类型的列长度，默认值为 64。
+ * 当 value 为 -1 时，SQL 模式下字符串字段会使用 LONGTEXT 类型。
+ *
+ * ```kotlin
+ * data class Player(
+ *     @Id @Length(36) val uuid: String,
+ *     @Length(128) var displayName: String,
+ *     @Length(-1) var jsonData: String,  // SQL: LONGTEXT
+ * )
+ * ```
+ */
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Length(val value: Int = 64)
 
+/**
+ * 为字段指定数据库中的列名别名。
+ *
+ * 默认情况下，框架会将驼峰命名转换为下划线命名（如 serverName → server_name）。
+ * 使用 @Alias 可以覆盖这一行为，指定自定义列名。
+ *
+ * ```kotlin
+ * data class Player(
+ *     @Id val id: Int,
+ *     @Alias("display_name") var name: String,  // 列名为 display_name 而非 name
+ * )
+ * ```
+ */
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Alias(val value: String)
+
+/**
+ * 显式指定字段的数据库列类型。
+ *
+ * 当框架的自动类型推断不满足需求时（如需要 LONGTEXT、MEDIUMINT 等特定类型），
+ * 可以通过此注解手动指定 SQL 和 SQLite 的列类型。
+ *
+ * 此注解的优先级高于框架的自动类型推断，会跳过默认的类型映射逻辑。
+ *
+ * ```kotlin
+ * data class Article(
+ *     @Id val id: Int,
+ *     @ColumnType(sql = ColumnTypeSQL.LONGTEXT) var content: String,
+ *     @ColumnType(sql = ColumnTypeSQL.MEDIUMINT) var viewCount: Int,
+ * )
+ * ```
+ */
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ColumnType(
+    val sql: ColumnTypeSQL = ColumnTypeSQL.VARCHAR,
+    val sqlite: ColumnTypeSQLite = ColumnTypeSQLite.TEXT
+)

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperator.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperator.kt
@@ -1,7 +1,10 @@
 package taboolib.expansion
 
+import taboolib.module.database.Action
+import taboolib.module.database.ActionSelect
 import taboolib.module.database.Filter
 import taboolib.module.database.Table
+import java.sql.ResultSet
 import java.util.*
 import javax.sql.DataSource
 
@@ -181,6 +184,61 @@ abstract class ContainerOperator {
     }
 
     /**
+     * 通过 @Id + @Key 查询数据，查多个
+     *
+     * 从数据对象中提取 @Id 和 @Key 字段值作为 WHERE 条件。
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    inline fun <reified T> findByKey(data: Any, usePrimaryKey: Boolean = true): List<T> {
+        return findByKey(T::class.java, data, usePrimaryKey)
+    }
+
+    /**
+     * 通过 @Id + @Key 查询数据，查一个
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    inline fun <reified T> findOneByKey(data: Any, usePrimaryKey: Boolean = true): T? {
+        return findOneByKey(T::class.java, data, usePrimaryKey)
+    }
+
+    /**
+     * 通过 @Id + @Key 检查数据是否存在
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    inline fun <reified T> hasByKey(data: Any, usePrimaryKey: Boolean = true): Boolean {
+        return hasByKey(T::class.java, data, usePrimaryKey)
+    }
+
+    /**
+     * 通过自增行 ID 查询数据（用于无 @Id 字段的数据类）
+     *
+     * @param rowId 框架自动生成的 `id` 列的值
+     */
+    inline fun <reified T> findByRowId(rowId: Long): T? {
+        return findByRowId(T::class.java, rowId)
+    }
+
+    /**
+     * 批量查询，通过多个 @Id 值查询
+     */
+    inline fun <reified T> findByIds(ids: List<Any>): List<T> {
+        return findByIds(T::class.java, ids)
+    }
+
+    /**
+     * 批量删除，通过多个 @Id 值删除
+     */
+    inline fun <reified T> deleteByIds(ids: List<Any>) {
+        return deleteByIds(T::class.java, ids)
+    }
+
+    /**
      * 获取数据，获取一个，有多个仅返回第一个（默认不经过任何条件判断）
      */
     abstract fun <T> getOne(type: Class<T>, filter: Filter.() -> Unit = {}): T?
@@ -245,6 +303,35 @@ abstract class ContainerOperator {
     abstract fun insert(dataList: List<Any>)
 
     /**
+     * 插入数据并返回自增主键
+     *
+     * @return 生成的自增主键列表
+     */
+    abstract fun insertAndGetKeys(dataList: List<Any>): List<Long>
+
+    /**
+     * 批量查询，通过多个 @Id 值查询（使用 IN 子句）
+     *
+     * @param ids @Id 字段值列表
+     */
+    abstract fun <T> findByIds(type: Class<T>, ids: List<Any>): List<T>
+
+    /**
+     * 批量删除，通过多个 @Id 值删除（使用 IN 子句）
+     *
+     * @param ids @Id 字段值列表
+     */
+    abstract fun <T> deleteByIds(type: Class<T>, ids: List<Any>)
+
+    /**
+     * 批量更新，通过 @Id + @Key 定位并更新 var 字段
+     * 在单个事务中使用 batch PreparedStatement 执行，保证原子性和性能。
+     *
+     * @param dataList 数据列表
+     */
+    abstract fun updateBatch(dataList: List<Any>)
+
+    /**
      * 检查数据
      */
     abstract fun <T> has(type: Class<T>, id: Any, filter: Filter.() -> Unit = {}): Boolean
@@ -258,6 +345,76 @@ abstract class ContainerOperator {
      * 删除数据
      */
     abstract fun <T> delete(type: Class<T>, id: Any, filter: Filter.() -> Unit = {})
+
+    /**
+     * 按条件删除数据
+     *
+     * @param filter 条件过滤器
+     */
+    abstract fun deleteWhere(filter: Filter.() -> Unit)
+
+    /**
+     * 统计数据数量
+     *
+     * @param filter 条件过滤器
+     */
+    abstract fun count(filter: Filter.() -> Unit = {}): Long
+
+    /**
+     * 通过 @Id + @Key 查询数据，查多个
+     *
+     * 从数据对象中提取 @Id 和所有 @Key 字段值构建 WHERE 条件。
+     */
+    abstract fun <T> findByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean = true): List<T>
+
+    /**
+     * 通过 @Id + @Key 查询数据，查一个，有多个仅返回第一个
+     */
+    abstract fun <T> findOneByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean = true): T?
+
+    /**
+     * 通过 @Id + @Key 检查数据是否存在
+     */
+    abstract fun <T> hasByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean = true): Boolean
+
+    /**
+     * 通过 @Id + @Key 删除数据
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    abstract fun deleteByKey(data: Any, usePrimaryKey: Boolean = true)
+
+    /**
+     * 通过自增行 ID 查询数据（用于无 @Id 字段的数据类）
+     *
+     * 当数据类没有定义 @Id 字段时，框架会自动生成一个名为 `id` 的自增主键列。
+     * 此方法通过该自增列的值查询数据。
+     */
+    abstract fun <T> findByRowId(type: Class<T>, rowId: Long): T?
+
+    /**
+     * 通过自增行 ID 删除数据（用于无 @Id 字段的数据类）
+     */
+    abstract fun deleteByRowId(rowId: Long)
+
+    // === 自定义 SQL ===
+
+    /**
+     * 执行自定义 SELECT 查询
+     *
+     * @param action 查询动作
+     * @param handler 结果集处理器
+     */
+    abstract fun <R> select(action: ActionSelect, handler: (ResultSet) -> R): R
+
+    /**
+     * 执行自定义更新操作（UPDATE / DELETE / INSERT）
+     *
+     * @param action 操作动作
+     * @return 受影响的行数
+     */
+    abstract fun execute(action: Action): Int
 
     /**
      * 内部函数

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
@@ -136,6 +136,24 @@ class ContainerOperatorImpl(
         executeUpdate(action)
     }
 
+    override fun insertAndGetKeys(dataList: List<Any>): List<Long> {
+        if (dataList.isEmpty()) return emptyList()
+        val typeClass = AnalyzedClass.of(dataList.first().javaClass)
+        val action = ActionInsert(table.name, typeClass.members.map { it.name }.toTypedArray()).apply {
+            dataList.forEach { data ->
+                values(typeClass.members.map { member -> typeClass.getValue(data, member)?.value() })
+            }
+        }
+        return withConnection { conn ->
+            conn.executePrepared(action.query, action.elements, Statement.RETURN_GENERATED_KEYS) {
+                executeUpdate()
+                generatedKeys.use { rs ->
+                    buildList { while (rs.next()) add(rs.getLong(1)) }
+                }
+            }
+        }
+    }
+
     override fun update(data: Any, usePrimaryKey: Boolean, filter: Filter.() -> Unit) {
         val typeClass = AnalyzedClass.of(data::class.java)
         if (typeClass.members.none { !it.isFinal }) {
@@ -314,6 +332,144 @@ class ContainerOperatorImpl(
         executeUpdate(action)
     }
 
+    override fun deleteWhere(filter: Filter.() -> Unit) {
+        val action = ActionDelete(table.name).apply {
+            where(filter)
+        }
+        executeUpdate(action)
+    }
+
+    override fun count(filter: Filter.() -> Unit): Long {
+        val action = ActionSelect(table.name).apply {
+            rows("COUNT(*)")
+            where(filter)
+        }
+        return executeQuery(action) { rs -> if (rs.next()) rs.getLong(1) else 0L }
+    }
+
+    override fun <T> findByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        val action = selectByKey(typeClass, data, usePrimaryKey)
+        return executeQuery(action) { rs ->
+            buildList {
+                while (rs.next()) {
+                    add(typeClass.createInstance<T>(typeClass.read(rs)))
+                }
+            }
+        }
+    }
+
+    override fun <T> findOneByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): T? {
+        val typeClass = AnalyzedClass.of(type)
+        val action = selectByKey(typeClass, data, usePrimaryKey) { limit(1) }
+        return executeQuery(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun <T> hasByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): Boolean {
+        val typeClass = AnalyzedClass.of(type)
+        val action = selectByKey(typeClass, data, usePrimaryKey) { limit(1) }
+        return executeQuery(action) { it.next() }
+    }
+
+    override fun deleteByKey(data: Any, usePrimaryKey: Boolean) {
+        val typeClass = AnalyzedClass.of(data::class.java)
+        val action = ActionDelete(table.name).apply {
+            if (usePrimaryKey) {
+                val name = typeClass.primaryMemberName ?: error("No primary id found.")
+                val value = typeClass.getPrimaryMemberValue(data)
+                where(name eq value?.value())
+            }
+            typeClass.members.filter { it.isKey }.forEach { member ->
+                where(member.name eq typeClass.getValue(data, member)?.value())
+            }
+        }
+        executeUpdate(action)
+    }
+
+    override fun <T> findByRowId(type: Class<T>, rowId: Long): T? {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(table.name).apply {
+            where("id" eq rowId)
+            limit(1)
+        }
+        return executeQuery(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun deleteByRowId(rowId: Long) {
+        val action = ActionDelete(table.name).apply {
+            where("id" eq rowId)
+        }
+        executeUpdate(action)
+    }
+
+    // === 批量操作 ===
+
+    override fun <T> findByIds(type: Class<T>, ids: List<Any>): List<T> {
+        if (ids.isEmpty()) return emptyList()
+        val typeClass = AnalyzedClass.of(type)
+        val name = typeClass.primaryMemberName ?: error("No primary id found.")
+        val action = ActionSelect(table.name).apply {
+            where { name inside ids.map { it.value() }.toTypedArray() }
+        }
+        return executeQuery(action) { rs ->
+            buildList {
+                while (rs.next()) {
+                    add(typeClass.createInstance<T>(typeClass.read(rs)))
+                }
+            }
+        }
+    }
+
+    override fun <T> deleteByIds(type: Class<T>, ids: List<Any>) {
+        if (ids.isEmpty()) return
+        val typeClass = AnalyzedClass.of(type)
+        val name = typeClass.primaryMemberName ?: error("No primary id found.")
+        val action = ActionDelete(table.name).apply {
+            where { name inside ids.map { it.value() }.toTypedArray() }
+        }
+        executeUpdate(action)
+    }
+
+    override fun updateBatch(dataList: List<Any>) {
+        if (dataList.isEmpty()) return
+        val typeClass = AnalyzedClass.of(dataList.first().javaClass)
+        val mutableMembers = typeClass.members.filter { !it.isFinal }
+        if (mutableMembers.isEmpty()) error("No mutable field found.")
+        val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
+        val keyMembers = typeClass.members.filter { it.isKey }
+        val updateSql = buildUpdateSql(typeClass, primaryName, keyMembers)
+        withTransaction { conn ->
+            conn.prepareStatement(updateSql).use { stmt ->
+                dataList.forEach { data ->
+                    var idx = 1
+                    mutableMembers.forEach { member ->
+                        stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
+                    }
+                    stmt.setObject(idx++, typeClass.getPrimaryMemberValue(data)?.value())
+                    keyMembers.forEach { member ->
+                        stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
+                    }
+                    stmt.addBatch()
+                }
+                stmt.executeBatch()
+            }
+        }
+    }
+
+    // === 自定义 SQL ===
+
+    override fun <R> select(action: ActionSelect, handler: (ResultSet) -> R): R {
+        return executeQuery(action, handler)
+    }
+
+    override fun execute(action: Action): Int {
+        return executeUpdate(action)
+    }
+
     /**
      * 构建基于 @Id 的查询
      */
@@ -327,6 +483,28 @@ class ContainerOperatorImpl(
         return ActionSelect(table.name).apply {
             where(name eq id.value())
             where(filter)
+            extra()
+        }
+    }
+
+    /**
+     * 构建基于 @Id + @Key 的查询
+     */
+    private fun selectByKey(
+        typeClass: AnalyzedClass,
+        data: Any,
+        usePrimaryKey: Boolean,
+        extra: ActionSelect.() -> Unit = {}
+    ): ActionSelect {
+        return ActionSelect(table.name).apply {
+            if (usePrimaryKey) {
+                val name = typeClass.primaryMemberName ?: error("No primary id found.")
+                val value = typeClass.getPrimaryMemberValue(data)
+                where(name eq value?.value())
+            }
+            typeClass.members.filter { it.isKey }.forEach { member ->
+                where(member.name eq typeClass.getValue(data, member)?.value())
+            }
             extra()
         }
     }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
@@ -30,6 +30,12 @@ class ContainerSQL(
             }
             type.members.forEach { member ->
                 when {
+                    // 自定义列类型
+                    member.hasColumnType -> add(member.name) {
+                        val colType = member.columnTypeSQL!!
+                        if (colType.isRequired) type(colType, member.length) { options(member) }
+                        else type(colType) { options(member) }
+                    }
                     // 字符串
                     member.isString || member.isEnum -> add(member.name) {
                         // length == -1 时使用longtext

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
@@ -21,6 +21,10 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
             }
             type.members.forEach { member ->
                 when {
+                    // 自定义列类型
+                    member.hasColumnType -> add(member.name) {
+                        type(member.columnTypeSQLite!!, member.length) { options(member) }
+                    }
                     // 字符串
                     member.isString || member.isEnum -> add(member.name) {
                         type(ColumnTypeSQLite.TEXT, member.length) { options(member) }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapper.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapper.kt
@@ -1,0 +1,154 @@
+package taboolib.expansion
+
+import taboolib.module.database.Action
+import taboolib.module.database.ActionDelete
+import taboolib.module.database.ActionSelect
+import taboolib.module.database.ActionUpdate
+import taboolib.module.database.Filter
+import java.sql.ResultSet
+
+/**
+ * 数据映射器接口，提供类型安全的 CRUD 操作入口。
+ *
+ * 通过 Kotlin by 委托使用：
+ * ```
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db"))
+ * ```
+ */
+interface DataMapper<T> {
+
+    // === 插入 ===
+    fun insert(data: T)
+    fun insertBatch(dataList: List<T>)
+    fun insertAndGetKey(data: T): Long
+    fun insertBatchAndGetKeys(dataList: List<T>): List<Long>
+
+    // === 查询 ===
+    fun findById(id: Any, filter: Filter.() -> Unit = {}): T?
+    fun findAll(id: Any, filter: Filter.() -> Unit = {}): List<T>
+    fun findOne(filter: Filter.() -> Unit = {}): T?
+    fun findAll(filter: Filter.() -> Unit = {}): List<T>
+    /** 批量查询，通过多个 @Id 值查询（IN 子句） */
+    fun findByIds(ids: List<Any>): List<T>
+
+    // === 基于 @Key 的查询 ===
+    /** 通过 @Id + @Key 查询，返回所有匹配记录 */
+    fun findByKey(data: T): List<T>
+    /** 通过 @Id + @Key 查询，返回第一条匹配记录 */
+    fun findOneByKey(data: T): T?
+    /** 通过 @Id + @Key 检查记录是否存在 */
+    fun existsByKey(data: T): Boolean
+    /** 通过 @Id + @Key 删除匹配记录 */
+    fun deleteByKey(data: T)
+
+    // === 基于自增行 ID 的操作（用于无 @Id 字段的数据类）===
+    /** 通过框架自动生成的 `id` 列查询 */
+    fun findByRowId(rowId: Long): T?
+    /** 通过框架自动生成的 `id` 列删除 */
+    fun deleteByRowId(rowId: Long)
+
+    // === 排序 ===
+    fun sort(row: String, limit: Int = 10, filter: Filter.() -> Unit = {}): List<T>
+    fun sortDescending(row: String, limit: Int = 10, filter: Filter.() -> Unit = {}): List<T>
+
+    // === 更新 ===
+    fun update(data: T, filter: Filter.() -> Unit = {})
+    fun updateByKey(data: T)
+    fun insertOrUpdate(data: T, filter: Filter.() -> Unit = {})
+    fun upsertBatch(dataList: List<T>)
+    /** 批量更新，通过 @Id + @Key 定位，使用 batch PreparedStatement */
+    fun updateBatch(dataList: List<T>)
+
+    // === 删除 ===
+    fun deleteById(id: Any, filter: Filter.() -> Unit = {})
+    fun deleteWhere(filter: Filter.() -> Unit)
+    /** 批量删除，通过多个 @Id 值删除（IN 子句） */
+    fun deleteByIds(ids: List<Any>)
+
+    // === 检查 ===
+    fun exists(id: Any, filter: Filter.() -> Unit = {}): Boolean
+    fun exists(filter: Filter.() -> Unit): Boolean
+
+    // === 计数 ===
+    fun count(filter: Filter.() -> Unit = {}): Long
+
+    // === 自定义 SQL ===
+
+    /** 表名 */
+    val tableName: String
+
+    /**
+     * 自定义 SELECT 查询，结果自动映射为 T
+     *
+     * ```kotlin
+     * homeTable.query { where { "world" eq "world_nether" }; limit(10) }
+     * ```
+     */
+    fun query(builder: ActionSelect.() -> Unit): List<T>
+
+    /**
+     * 自定义 SELECT 查询单条，结果自动映射为 T
+     */
+    fun queryOne(builder: ActionSelect.() -> Unit): T?
+
+    /**
+     * 自定义 SELECT 查询，自定义结果处理
+     *
+     * ```kotlin
+     * homeTable.rawQuery({ rows("world"); groupBy("world") }) { rs ->
+     *     buildList { while (rs.next()) add(rs.getString(1)) }
+     * }
+     * ```
+     */
+    fun <R> rawQuery(builder: ActionSelect.() -> Unit, handler: (ResultSet) -> R): R
+
+    /**
+     * 自定义 UPDATE 操作
+     *
+     * ```kotlin
+     * homeTable.rawUpdate { set("active", false); where { "world" eq "world_nether" } }
+     * ```
+     * @return 受影响的行数
+     */
+    fun rawUpdate(builder: ActionUpdate.() -> Unit): Int
+
+    /**
+     * 自定义 DELETE 操作
+     *
+     * ```kotlin
+     * homeTable.rawDelete { where { "active" eq false } }
+     * ```
+     * @return 受影响的行数
+     */
+    fun rawDelete(builder: ActionDelete.() -> Unit): Int
+
+    /**
+     * 执行任意 Action
+     *
+     * @return 受影响的行数
+     */
+    fun rawExecute(action: Action): Int
+
+    // === 多表联查 ===
+
+    /**
+     * 发起多表联查，主表自动填充为当前 DataMapper 对应的表
+     *
+     * ```kotlin
+     * homeTable.join {
+     *     innerJoin<PlayerStats> {
+     *         on("player_home.username" eq pre("player_stats.username"))
+     *     }
+     *     where { "player_home.active" eq true }
+     *     limit(10)
+     * }.mapTo<PlayerSummary>()
+     * ```
+     */
+    fun join(builder: JoinQuery.() -> Unit): JoinQuery
+
+    // === 事务 ===
+    fun <R> transaction(block: DataMapper<T>.() -> R): Result<R>
+
+    // === 生命周期 ===
+    fun close()
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapperImpl.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapperImpl.kt
@@ -1,0 +1,325 @@
+package taboolib.expansion
+
+import taboolib.expansion.AnalyzedClassMember.Companion.toColumnName
+import taboolib.module.database.*
+import java.sql.ResultSet
+
+/**
+ * DataMapper 的标准实现
+ *
+ * 封装 ContainerOperator，提供类型安全的 CRUD 操作。
+ * 支持可选的数据缓存，写入操作会按策略精确失效受影响的缓存。
+ *
+ * ### 缓存失效策略
+ *
+ * 缓存条目分为两类：
+ * - **ID 定向缓存**：`findById`、`findAllById`、`exists` — 以特定 ID 为键
+ * - **集合缓存**：`findAll`、`findOne`、`count`、`sort` 等 — 结果跨多条记录
+ *
+ * | 操作类型 | ID 定向缓存 | 集合缓存 |
+ * |---------|-----------|---------|
+ * | 单条更新/删除 | 仅失效该 ID | 全部失效 |
+ * | 插入 | 保留 | 全部失效 |
+ * | 批量/不确定范围 | 全部失效 | 全部失效 |
+ *
+ * @param type 数据类的 Class 对象
+ * @param container 持久化容器
+ * @param cache 数据缓存（可选）
+ */
+class DataMapperImpl<T>(
+    private val type: Class<T>,
+    private val container: PersistentContainer,
+    private val cache: DataCache?
+) : DataMapper<T> {
+
+    private val operator: ContainerOperator
+        get() = container[type.simpleName.toColumnName()]
+
+    private val analyzedClass by lazy { AnalyzedClass.of(type) }
+
+    // === 插入 ===
+
+    override fun insert(data: T) {
+        operator.insert(listOf(data as Any))
+        invalidateCollections()
+    }
+
+    override fun insertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.insert(dataList as List<Any>)
+        invalidateCollections()
+    }
+
+    override fun insertAndGetKey(data: T): Long {
+        val keys = operator.insertAndGetKeys(listOf(data as Any))
+        invalidateCollections()
+        return keys.firstOrNull() ?: -1L
+    }
+
+    override fun insertBatchAndGetKeys(dataList: List<T>): List<Long> {
+        if (dataList.isEmpty()) return emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val keys = operator.insertAndGetKeys(dataList as List<Any>)
+        invalidateCollections()
+        return keys
+    }
+
+    // === 查询 ===
+
+    override fun findById(id: Any, filter: Filter.() -> Unit): T? {
+        return cached("findById", id, filter) { operator.findOne(type, id, filter) }
+    }
+
+    override fun findAll(id: Any, filter: Filter.() -> Unit): List<T> {
+        return cached("findAllById", id, filter) { operator.find(type, id, filter) }
+    }
+
+    override fun findOne(filter: Filter.() -> Unit): T? {
+        return cached("findOne", filter) { operator.getOne(type, filter) }
+    }
+
+    override fun findAll(filter: Filter.() -> Unit): List<T> {
+        return cached("findAll", filter) { operator.get(type, filter) }
+    }
+
+    override fun findByIds(ids: List<Any>): List<T> {
+        if (ids.isEmpty()) return emptyList()
+        return cached("findByIds", ids) { operator.findByIds(type, ids) }
+    }
+
+    // === 基于 @Key 的查询 ===
+
+    override fun findByKey(data: T): List<T> {
+        return cached("findByKey", data) { operator.findByKey(type, data as Any) }
+    }
+
+    override fun findOneByKey(data: T): T? {
+        return cached("findOneByKey", data) { operator.findOneByKey(type, data as Any) }
+    }
+
+    override fun existsByKey(data: T): Boolean {
+        return cached("existsByKey", data) { operator.hasByKey(type, data as Any) }
+    }
+
+    override fun deleteByKey(data: T) {
+        operator.deleteByKey(data as Any)
+        invalidateForData(data as Any)
+    }
+
+    // === 基于自增行 ID 的操作 ===
+
+    override fun findByRowId(rowId: Long): T? {
+        return cached("findByRowId", rowId) { operator.findByRowId(type, rowId) }
+    }
+
+    override fun deleteByRowId(rowId: Long) {
+        operator.deleteByRowId(rowId)
+        invalidateForRowId(rowId)
+    }
+
+    // === 排序 ===
+
+    override fun sort(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return cached("sort", row, limit, filter) { operator.sort(type, row, limit, filter) }
+    }
+
+    override fun sortDescending(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return cached("sortDescending", row, limit, filter) { operator.sortDescending(type, row, limit, filter) }
+    }
+
+    // === 更新 ===
+
+    override fun update(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateForData(data as Any)
+    }
+
+    override fun updateByKey(data: T) {
+        operator.updateByKey(data as Any)
+        invalidateForData(data as Any)
+    }
+
+    override fun insertOrUpdate(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateForData(data as Any)
+    }
+
+    override fun upsertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.upsert(dataList as List<Any>)
+        cache?.invalidateAll()
+    }
+
+    override fun updateBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.updateBatch(dataList as List<Any>)
+        cache?.invalidateAll()
+    }
+
+    // === 删除 ===
+
+    override fun deleteById(id: Any, filter: Filter.() -> Unit) {
+        operator.delete(type, id, filter)
+        invalidateForId(id)
+    }
+
+    override fun deleteWhere(filter: Filter.() -> Unit) {
+        operator.deleteWhere(filter)
+        cache?.invalidateAll()
+    }
+
+    override fun deleteByIds(ids: List<Any>) {
+        if (ids.isEmpty()) return
+        operator.deleteByIds(type, ids)
+        cache?.invalidateAll()
+    }
+
+    // === 检查 ===
+
+    override fun exists(id: Any, filter: Filter.() -> Unit): Boolean {
+        return cached("exists", id, filter) { operator.has(type, id, filter) }
+    }
+
+    override fun exists(filter: Filter.() -> Unit): Boolean {
+        return cached("existsFilter", filter) { operator.has(filter) }
+    }
+
+    // === 计数 ===
+
+    override fun count(filter: Filter.() -> Unit): Long {
+        return cached("count", filter) { operator.count(filter) }
+    }
+
+    // === 事务 ===
+
+    override fun <R> transaction(block: DataMapper<T>.() -> R): Result<R> {
+        return container.transaction {
+            val txOperator = operator(type.simpleName.toColumnName())
+            val txMapper = TransactionalDataMapper(type, txOperator, cache, connection)
+            txMapper.block()
+        }
+    }
+
+    // === 自定义 SQL ===
+
+    override val tableName: String
+        get() = operator.table.name
+
+    override fun query(builder: ActionSelect.() -> Unit): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action) { rs ->
+            buildList {
+                while (rs.next()) { add(typeClass.createInstance<T>(typeClass.read(rs))) }
+            }
+        }
+    }
+
+    override fun queryOne(builder: ActionSelect.() -> Unit): T? {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply { builder(); limit(1) }
+        return operator.select(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun <R> rawQuery(builder: ActionSelect.() -> Unit, handler: (ResultSet) -> R): R {
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action, handler)
+    }
+
+    override fun rawUpdate(builder: ActionUpdate.() -> Unit): Int {
+        val action = ActionUpdate(tableName).apply(builder)
+        val result = operator.execute(action)
+        cache?.invalidateAll()
+        return result
+    }
+
+    override fun rawDelete(builder: ActionDelete.() -> Unit): Int {
+        val action = ActionDelete(tableName).apply(builder)
+        val result = operator.execute(action)
+        cache?.invalidateAll()
+        return result
+    }
+
+    override fun rawExecute(action: Action): Int {
+        val result = operator.execute(action)
+        cache?.invalidateAll()
+        return result
+    }
+
+    // === 多表联查 ===
+
+    override fun join(builder: JoinQuery.() -> Unit): JoinQuery {
+        return container.join {
+            from(tableName)
+            builder()
+        }
+    }
+
+    // === 生命周期 ===
+
+    override fun close() = container.close()
+
+    // === 缓存辅助 ===
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <R> cached(method: String, vararg args: Any?, query: () -> R): R {
+        if (cache == null) return query()
+        val key = buildCacheKey(method, *args)
+        return cache.get(key) { query() } as R
+    }
+
+    private fun buildCacheKey(method: String, vararg args: Any?): String {
+        return "$method:${args.joinToString(",") { it?.toString() ?: "null" }}"
+    }
+
+    // === 缓存失效策略 ===
+
+    companion object {
+        /** 集合缓存前缀 — 任何数据变更都可能影响这些查询结果 */
+        internal val COLLECTION_PREFIXES = arrayOf(
+            "findOne:", "findAll:", "findByIds:",
+            "findByKey:", "findOneByKey:", "existsByKey:", "existsFilter:",
+            "sort:", "sortDescending:", "count:"
+        )
+    }
+
+    /** 失效所有集合缓存，保留其他 ID 的定向缓存 */
+    private fun invalidateCollections() {
+        if (cache == null) return
+        for (prefix in COLLECTION_PREFIXES) {
+            cache.invalidateByPrefix(prefix)
+        }
+    }
+
+    /** 失效指定 ID 的定向缓存 + 所有集合缓存 */
+    private fun invalidateForId(id: Any) {
+        if (cache == null) return
+        cache.invalidateByPrefix("findById:$id")
+        cache.invalidateByPrefix("findAllById:$id")
+        cache.invalidateByPrefix("exists:$id")
+        invalidateCollections()
+    }
+
+    /** 从数据对象提取 @Id 值，失效该 ID 的定向缓存 + 所有集合缓存 */
+    private fun invalidateForData(data: Any) {
+        if (cache == null) return
+        val id = analyzedClass.getPrimaryMemberValue(data)
+        if (id != null) {
+            invalidateForId(id)
+        } else {
+            cache.invalidateAll()
+        }
+    }
+
+    /** 失效指定行 ID 的缓存 + 所有集合缓存 */
+    private fun invalidateForRowId(rowId: Long) {
+        if (cache == null) return
+        cache.invalidate(buildCacheKey("findByRowId", rowId))
+        invalidateCollections()
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/JoinQuery.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/JoinQuery.kt
@@ -98,6 +98,37 @@ class JoinQuery internal constructor(
         return this
     }
 
+    /**
+     * 指定查询列并设置别名
+     *
+     * 解决多表联查中同名列冲突问题。别名将作为 BundleMap 的 key，
+     * 同时也是 mapTo 匹配 data class 字段名的依据。
+     *
+     * ```kotlin
+     * homeTable.join {
+     *     innerJoin<PlayerStats> {
+     *         on("player_home.username" eq pre("player_stats.username"))
+     *     }
+     *     selectAs(
+     *         "player_home.username" to "username",
+     *         "player_home.world" to "world",
+     *         "player_stats.level" to "level",
+     *         "player_stats.username" to "stats_username"
+     *     )
+     * }.mapTo<PlayerSummary>()
+     * // PlayerSummary(val username: String, val world: String, val level: Int, val statsUsername: String)
+     * ```
+     *
+     * @param pairs 列名 to 别名
+     */
+    fun selectAs(vararg pairs: Pair<String, String>): JoinQuery {
+        columns = pairs.map { (col, alias) ->
+            val formattedCol = col.split(".").joinToString(".") { "`$it`" }
+            "$formattedCol AS `$alias`"
+        }.toTypedArray()
+        return this
+    }
+
     /** WHERE 条件 */
     fun where(filter: Filter.() -> Unit): JoinQuery {
         filterFunc = filter

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
@@ -42,14 +42,23 @@ class MapperConfig<T> {
 /**
  * 创建 DataMapper 属性委托
  *
+ * 缓存默认关闭，需要显式调用 `cache {}` 或 `cache(myCache)` 开启。
+ *
  * ```kotlin
+ * // 不带缓存（默认）
  * val homeTable by mapper<PlayerHome>(dbFile("data.db"))
  *
+ * // 使用内置缓存
  * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
  *     cache {
- *         enabled = true
  *         maximumSize = 1000
+ *         expireAfterWrite = 300
  *     }
+ * }
+ *
+ * // 使用自定义缓存
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache(MyCaffeineCache())
  * }
  * ```
  */

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
@@ -1,0 +1,94 @@
+package taboolib.expansion
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Mapper 配置
+ */
+class MapperConfig<T> {
+    internal var cacheInstance: DataCache? = null
+
+    /**
+     * 使用内置 ConcurrentHashMap 缓存
+     *
+     * ```kotlin
+     * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+     *     cache {
+     *         maximumSize = 1000
+     *         expireAfterWrite = 300
+     *     }
+     * }
+     * ```
+     */
+    fun cache(block: QueryCacheConfig.() -> Unit) {
+        cacheInstance = QueryCache(QueryCacheConfig().apply(block))
+    }
+
+    /**
+     * 使用自定义缓存实现
+     *
+     * ```kotlin
+     * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+     *     cache(MyCaffeineCache())
+     * }
+     * ```
+     */
+    fun cache(cache: DataCache) {
+        cacheInstance = cache
+    }
+}
+
+/**
+ * 创建 DataMapper 属性委托
+ *
+ * ```kotlin
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db"))
+ *
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache {
+ *         enabled = true
+ *         maximumSize = 1000
+ *     }
+ * }
+ * ```
+ */
+inline fun <reified T> mapper(
+    source: Any = db(),
+    flags: List<String> = emptyList(),
+    clearFlags: Boolean = false,
+    ssl: String? = null,
+    noinline config: MapperConfig<T>.() -> Unit = {}
+): ReadOnlyProperty<Any?, DataMapper<T>> {
+    return MapperDelegate(T::class.java, source, flags, clearFlags, ssl, config)
+}
+
+/**
+ * 属性委托实现，懒加载创建容器和 DataMapper
+ */
+class MapperDelegate<T>(
+    private val type: Class<T>,
+    private val source: Any,
+    private val flags: List<String>,
+    private val clearFlags: Boolean,
+    private val ssl: String?,
+    private val config: MapperConfig<T>.() -> Unit
+) : ReadOnlyProperty<Any?, DataMapper<T>> {
+
+    @Volatile
+    private var instance: DataMapper<T>? = null
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): DataMapper<T> {
+        return instance ?: synchronized(this) {
+            instance ?: createMapper().also { instance = it }
+        }
+    }
+
+    private fun createMapper(): DataMapper<T> {
+        val mapperConfig = MapperConfig<T>().apply(config)
+        val container = persistentContainer(source, flags, clearFlags, ssl) {
+            new(type)
+        }
+        return DataMapperImpl(type, container, mapperConfig.cacheInstance)
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/PersistentContainer.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/PersistentContainer.kt
@@ -151,6 +151,15 @@ class PersistentContainer {
     }
 
     /**
+     * 创建 DataMapper（用于已有容器场景）
+     *
+     * @param cache 可选的自定义缓存实现
+     */
+    inline fun <reified T> mapper(cache: DataCache? = null): DataMapper<T> {
+        return DataMapperImpl(T::class.java, this, cache)
+    }
+
+    /**
      * 关闭容器
      */
     fun close() {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/QueryCache.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/QueryCache.kt
@@ -1,0 +1,137 @@
+package taboolib.expansion
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * 数据缓存接口
+ *
+ * 用户可实现此接口来自定义缓存策略（如 Redis、Caffeine 等）。
+ *
+ * ```kotlin
+ * // 使用自定义缓存
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache(MyCaffeineCache())
+ * }
+ *
+ * // 自定义实现示例
+ * class MyCaffeineCache : DataCache {
+ *     private val caffeine = Caffeine.newBuilder().maximumSize(1000).build<String, Any?>()
+ *     override fun get(key: String, loader: () -> Any?) = caffeine.get(key) { loader() }
+ *     override fun invalidate(key: String) = caffeine.invalidate(key)
+ *     override fun invalidateByPrefix(prefix: String) {
+ *         caffeine.asMap().keys.removeIf { it.startsWith(prefix) }
+ *     }
+ *     override fun invalidateAll() = caffeine.invalidateAll()
+ * }
+ * ```
+ *
+ * ### 缓存键格式
+ *
+ * DataMapper 自动构建缓存键，格式为 `"方法名:参数1,参数2,..."`，例如：
+ * - `findById:550e8400-e29b-41d4-a716-446655440000,...`
+ * - `findAll:...`
+ * - `count:...`
+ *
+ * ### 失效策略
+ *
+ * DataMapper 在写入操作后会调用以下方法进行缓存失效：
+ * - **单条写入**（update/deleteById 等）：调用 [invalidateByPrefix] 精确失效受影响的 ID 缓存 + 集合缓存
+ * - **批量/不确定范围写入**（deleteWhere/rawUpdate 等）：调用 [invalidateAll] 全量失效
+ */
+interface DataCache {
+
+    /**
+     * 从缓存中获取值，未命中时调用 loader 加载并写入缓存
+     *
+     * @param key 缓存键（由方法名+参数自动构建）
+     * @param loader 缓存未命中时的加载函数
+     * @return 缓存值或 loader 返回值
+     */
+    fun get(key: String, loader: () -> Any?): Any?
+
+    /**
+     * 使指定 key 的缓存失效
+     */
+    fun invalidate(key: String)
+
+    /**
+     * 使所有以指定前缀开头的缓存失效
+     *
+     * 例如 `invalidateByPrefix("findAll:")` 会清除所有 `findAll:*` 缓存
+     */
+    fun invalidateByPrefix(prefix: String)
+
+    /**
+     * 清除所有缓存条目
+     */
+    fun invalidateAll()
+}
+
+/**
+ * 内置缓存配置
+ */
+class QueryCacheConfig {
+    var maximumSize: Int = 256
+    var expireAfterWrite: Long = 0   // 秒，0 = 不过期
+    var expireAfterAccess: Long = 0  // 秒，0 = 不过期
+}
+
+/**
+ * 基于 ConcurrentHashMap 的内置缓存实现
+ *
+ * - 查询时：以方法名+参数构建 key，命中则返回缓存值
+ * - 写入时：按前缀或精确 key 失效受影响的缓存
+ * - 支持 TTL 过期和最大容量限制
+ */
+class QueryCache(private val config: QueryCacheConfig) : DataCache {
+
+    private data class CacheEntry(val value: Any?, val writeTime: Long, var accessTime: Long)
+
+    private val store = ConcurrentHashMap<String, CacheEntry>()
+
+    override fun get(key: String, loader: () -> Any?): Any? {
+        val entry = store[key]
+        if (entry != null && !isExpired(entry)) {
+            entry.accessTime = System.currentTimeMillis()
+            return entry.value
+        }
+        val value = loader()
+        put(key, value)
+        return value
+    }
+
+    override fun invalidate(key: String) {
+        store.remove(key)
+    }
+
+    override fun invalidateByPrefix(prefix: String) {
+        store.keys.removeIf { it.startsWith(prefix) }
+    }
+
+    override fun invalidateAll() {
+        store.clear()
+    }
+
+    private fun put(key: String, value: Any?) {
+        evictIfNeeded()
+        val now = System.currentTimeMillis()
+        store[key] = CacheEntry(value, now, now)
+    }
+
+    private fun isExpired(entry: CacheEntry): Boolean {
+        val now = System.currentTimeMillis()
+        if (config.expireAfterWrite > 0 && now - entry.writeTime > config.expireAfterWrite * 1000) return true
+        if (config.expireAfterAccess > 0 && now - entry.accessTime > config.expireAfterAccess * 1000) return true
+        return false
+    }
+
+    private fun evictIfNeeded() {
+        // 先清除过期条目
+        store.entries.removeIf { isExpired(it.value) }
+        // 超出容量则移除最旧的
+        while (store.size >= config.maximumSize) {
+            val oldest = store.entries.minByOrNull { it.value.accessTime } ?: break
+            store.remove(oldest.key)
+        }
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionContext.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionContext.kt
@@ -56,6 +56,27 @@ class TransactionContext internal constructor(
     }
 
     /**
+     * 在事务中插入单条数据
+     */
+    inline fun <reified T> insert(data: T) {
+        get<T>().insert(listOf(data as Any))
+    }
+
+    /**
+     * 在事务中更新数据
+     */
+    inline fun <reified T> update(data: T) {
+        get<T>().update(data as Any)
+    }
+
+    /**
+     * 在事务中删除数据
+     */
+    inline fun <reified T> delete(id: Any) {
+        get<T>().delete(T::class.java, id)
+    }
+
+    /**
      * 标记事务回滚
      *
      * 调用此方法后，事务将在 block 执行完毕后回滚，

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionalDataMapper.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionalDataMapper.kt
@@ -1,0 +1,261 @@
+package taboolib.expansion
+
+import taboolib.module.database.*
+import java.sql.Connection
+import java.sql.ResultSet
+
+/**
+ * 事务内的 DataMapper 实现
+ *
+ * 使用事务感知的 ContainerOperator，所有操作共享同一个数据库连接。
+ * 不支持嵌套事务，调用 transaction() 会抛出异常。
+ *
+ * 事务内不使用缓存读取（保证事务一致性），但写入操作会失效外层缓存。
+ */
+class TransactionalDataMapper<T>(
+    private val type: Class<T>,
+    private val operator: ContainerOperator,
+    private val cache: DataCache?,
+    private val sharedConnection: Connection? = null
+) : DataMapper<T> {
+
+    private val analyzedClass by lazy { AnalyzedClass.of(type) }
+
+    // === 插入 ===
+
+    override fun insert(data: T) {
+        operator.insert(listOf(data as Any))
+        invalidateCollections()
+    }
+
+    override fun insertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.insert(dataList as List<Any>)
+        invalidateCollections()
+    }
+
+    override fun insertAndGetKey(data: T): Long {
+        val keys = operator.insertAndGetKeys(listOf(data as Any))
+        invalidateCollections()
+        return keys.firstOrNull() ?: -1L
+    }
+
+    override fun insertBatchAndGetKeys(dataList: List<T>): List<Long> {
+        if (dataList.isEmpty()) return emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val keys = operator.insertAndGetKeys(dataList as List<Any>)
+        invalidateCollections()
+        return keys
+    }
+
+    // === 查询（事务内不使用缓存，直接查库）===
+
+    override fun findById(id: Any, filter: Filter.() -> Unit): T? = operator.findOne(type, id, filter)
+    override fun findAll(id: Any, filter: Filter.() -> Unit): List<T> = operator.find(type, id, filter)
+    override fun findOne(filter: Filter.() -> Unit): T? = operator.getOne(type, filter)
+    override fun findAll(filter: Filter.() -> Unit): List<T> = operator.get(type, filter)
+
+    override fun findByIds(ids: List<Any>): List<T> {
+        if (ids.isEmpty()) return emptyList()
+        return operator.findByIds(type, ids)
+    }
+
+    // === 基于 @Key 的查询 ===
+
+    override fun findByKey(data: T): List<T> = operator.findByKey(type, data as Any)
+    override fun findOneByKey(data: T): T? = operator.findOneByKey(type, data as Any)
+    override fun existsByKey(data: T): Boolean = operator.hasByKey(type, data as Any)
+
+    override fun deleteByKey(data: T) {
+        operator.deleteByKey(data as Any)
+        invalidateForData(data as Any)
+    }
+
+    // === 基于自增行 ID 的操作 ===
+
+    override fun findByRowId(rowId: Long): T? = operator.findByRowId(type, rowId)
+
+    override fun deleteByRowId(rowId: Long) {
+        operator.deleteByRowId(rowId)
+        invalidateForRowId(rowId)
+    }
+
+    // === 排序 ===
+
+    override fun sort(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return operator.sort(type, row, limit, filter)
+    }
+
+    override fun sortDescending(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return operator.sortDescending(type, row, limit, filter)
+    }
+
+    // === 更新 ===
+
+    override fun update(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateForData(data as Any)
+    }
+
+    override fun updateByKey(data: T) {
+        operator.updateByKey(data as Any)
+        invalidateForData(data as Any)
+    }
+
+    override fun insertOrUpdate(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateForData(data as Any)
+    }
+
+    override fun upsertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.upsert(dataList as List<Any>)
+        cache?.invalidateAll()
+    }
+
+    override fun updateBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.updateBatch(dataList as List<Any>)
+        cache?.invalidateAll()
+    }
+
+    // === 删除 ===
+
+    override fun deleteById(id: Any, filter: Filter.() -> Unit) {
+        operator.delete(type, id, filter)
+        invalidateForId(id)
+    }
+
+    override fun deleteWhere(filter: Filter.() -> Unit) {
+        operator.deleteWhere(filter)
+        cache?.invalidateAll()
+    }
+
+    override fun deleteByIds(ids: List<Any>) {
+        if (ids.isEmpty()) return
+        operator.deleteByIds(type, ids)
+        cache?.invalidateAll()
+    }
+
+    // === 检查 ===
+
+    override fun exists(id: Any, filter: Filter.() -> Unit): Boolean = operator.has(type, id, filter)
+    override fun exists(filter: Filter.() -> Unit): Boolean = operator.has(filter)
+
+    // === 计数 ===
+
+    override fun count(filter: Filter.() -> Unit): Long = operator.count(filter)
+
+    // === 事务 ===
+
+    override fun <R> transaction(block: DataMapper<T>.() -> R): Result<R> {
+        error("Nested transactions are not supported")
+    }
+
+    // === 自定义 SQL ===
+
+    override val tableName: String
+        get() = operator.table.name
+
+    override fun query(builder: ActionSelect.() -> Unit): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action) { rs ->
+            buildList {
+                while (rs.next()) { add(typeClass.createInstance<T>(typeClass.read(rs))) }
+            }
+        }
+    }
+
+    override fun queryOne(builder: ActionSelect.() -> Unit): T? {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply { builder(); limit(1) }
+        return operator.select(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun <R> rawQuery(builder: ActionSelect.() -> Unit, handler: (ResultSet) -> R): R {
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action, handler)
+    }
+
+    override fun rawUpdate(builder: ActionUpdate.() -> Unit): Int {
+        val action = ActionUpdate(tableName).apply(builder)
+        val result = operator.execute(action)
+        cache?.invalidateAll()
+        return result
+    }
+
+    override fun rawDelete(builder: ActionDelete.() -> Unit): Int {
+        val action = ActionDelete(tableName).apply(builder)
+        val result = operator.execute(action)
+        cache?.invalidateAll()
+        return result
+    }
+
+    override fun rawExecute(action: Action): Int {
+        val result = operator.execute(action)
+        cache?.invalidateAll()
+        return result
+    }
+
+    // === 多表联查 ===
+
+    override fun join(builder: JoinQuery.() -> Unit): JoinQuery {
+        return JoinQuery(operator.dataSource, sharedConnection).also {
+            it.from(tableName)
+            builder(it)
+        }
+    }
+
+    // === 生命周期 ===
+
+    override fun close() {
+        error("Cannot close container within a transaction")
+    }
+
+    // === 缓存失效策略 ===
+
+    private fun buildCacheKey(method: String, vararg args: Any?): String {
+        return "$method:${args.joinToString(",") { it?.toString() ?: "null" }}"
+    }
+
+    /** 失效所有集合缓存，保留其他 ID 的定向缓存 */
+    private fun invalidateCollections() {
+        if (cache == null) return
+        for (prefix in DataMapperImpl.COLLECTION_PREFIXES) {
+            cache.invalidateByPrefix(prefix)
+        }
+    }
+
+    /** 失效指定 ID 的定向缓存 + 所有集合缓存 */
+    private fun invalidateForId(id: Any) {
+        if (cache == null) return
+        cache.invalidateByPrefix("findById:$id")
+        cache.invalidateByPrefix("findAllById:$id")
+        cache.invalidateByPrefix("exists:$id")
+        invalidateCollections()
+    }
+
+    /** 从数据对象提取 @Id 值，失效该 ID 的定向缓存 + 所有集合缓存 */
+    private fun invalidateForData(data: Any) {
+        if (cache == null) return
+        val id = analyzedClass.getPrimaryMemberValue(data)
+        if (id != null) {
+            invalidateForId(id)
+        } else {
+            cache.invalidateAll()
+        }
+    }
+
+    /** 失效指定行 ID 的缓存 + 所有集合缓存 */
+    private fun invalidateForRowId(rowId: Long) {
+        if (cache == null) return
+        cache.invalidate(buildCacheKey("findByRowId", rowId))
+        invalidateCollections()
+    }
+}


### PR DESCRIPTION
## 概述

为 `database-ptc-object` 模块新增快捷操作工具，简化数据库 CRUD 操作流程。

## 主要改动

### 新增功能

- **`@ColumnType` 注解** — 显式指定数据库列类型（LONGTEXT、TEXT 等）
- **`mapper<T>()` 属性委托** — 一行代码懒加载创建容器 + 表 + 操作器
- **`DataMapper<T>` 接口** — 类型安全的 CRUD 入口（insert/find/update/delete/count/exists/sort 等）
- **`DataCache` 接口** — 可扩展的查询缓存，支持自定义实现（Redis、Caffeine 等），内置 ConcurrentHashMap 实现
- **精确缓存失效策略** — 单条写入仅失效受影响 ID 的缓存，保留其他 ID 的定向缓存
- **批量操作优化** — `findByIds`、`deleteByIds`、`updateBatch`（IN 子句 + batch PreparedStatement）
- **自定义 SQL** — `query`、`rawQuery`、`rawUpdate`、`rawDelete`、`rawExecute`
- **多表联查** — `join {}` + `selectAs()` 解决同名列冲突
- **事务支持** — `transaction {}` 块内共享连接
- **自增 ID 获取** — `insertAndGetKey` / `insertBatchAndGetKeys`
- **@Key 相关操作** — `findByKey`、`deleteByKey`、`existsByKey`
- **自增行 ID 操作** — `findByRowId`、`deleteByRowId`（用于无 @Id 的数据类）

### 补充 ContainerOperator

- 新增 `count()`、`deleteWhere()`、`insertAndGetKeys()`、`findByIds()`、`deleteByIds()`、`updateBatch()`、`findByKey()`、`deleteByKey()` 等方法

### 修改的文件

- `Annotations.kt` — 新增 `@ColumnType`，补充注解文档
- `AnalyzedClassMember.kt` — 解析 `@ColumnType`
- `ContainerSQL.kt` / `ContainerSQLite.kt` — 支持 `@ColumnType` 建表
- `ContainerOperator.kt` / `ContainerOperatorImpl.kt` — 新增基础方法
- `JoinQuery.kt` — 新增 `selectAs()`
- `PersistentContainer.kt` — 新增 `mapper()`
- `TransactionContext.kt` — 新增快捷方法

### 新建的文件

- `DataMapper.kt` — CRUD 接口定义
- `DataMapperImpl.kt` — 标准实现（含精确缓存失效）
- `TransactionalDataMapper.kt` — 事务实现
- `QueryCache.kt` — `DataCache` 接口 + 内置 ConcurrentHashMap 缓存
- `MapperDelegate.kt` — `mapper<T>()` 属性委托工厂

## 用法示例

```kotlin
val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
    cache { maximumSize = 1000; expireAfterWrite = 300 }
}

homeTable.insert(home)
homeTable.findById(uuid)
homeTable.findAll { "world" eq "world_nether" }
homeTable.update(home)
homeTable.deleteById(uuid)
homeTable.count { "active" eq true }
```

Closes TabooLib/taboolib#656