### PR TITLE
[feat] 拓展 database-ptc-object 增加快捷操作工具

### DIFF
--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
@@ -1,6 +1,7 @@
 package taboolib.expansion
 
 import org.tabooproject.reflex.Reflex.Companion.getProperty
+import taboolib.common.platform.function.warning
 import taboolib.common.util.t
 import taboolib.common5.*
 import java.lang.reflect.Parameter
@@ -53,6 +54,15 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
     /** 主成员名称 */
     val primaryMemberName = primaryMember?.name
 
+    /** 实际映射到列的成员（排除 @LinkTable 成员） */
+    val columnMembers = members.filter { !it.isLinkTable }
+
+    /** @LinkTable 成员列表 */
+    val linkMembers = members.filter { it.isLinkTable }
+
+    /** 是否存在 @LinkTable 成员 */
+    val hasLinkMembers = linkMembers.isNotEmpty()
+
     /** 反序列化所在伴生类实例 */
     val wrapperObjectInstance = runCatching { clazz.getProperty<Any>("Companion", isStatic = true) }.getOrNull()
 
@@ -73,6 +83,19 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
                         """.t()
                     )
                 }
+            }
+        }
+        // 验证 @LinkTable 成员的关联类必须有 @Id 字段
+        linkMembers.forEach { member ->
+            val linkClass = member.linkTableClass!!
+            val linkedClass = AnalyzedClass.of(linkClass)
+            if (linkedClass.primaryMember == null) {
+                error(
+                    """
+                        在 ${clazz.simpleName} 类中，@LinkTable 成员 ${member.propertyName} 的关联类 ${linkClass.simpleName} 没有 @Id 字段。
+                        Linked class ${linkClass.simpleName} for @LinkTable member ${member.propertyName} in ${clazz.simpleName} has no @Id field.
+                    """.t()
+                )
             }
         }
         if (members.count { it.isPrimary } > 1) {
@@ -109,46 +132,103 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
         return property.get(data)
     }
 
-    /** 读取数据 */
+    /** 读取数据（不含 @LinkTable 成员） */
     fun read(result: ResultSet): Map<String, Any?> {
         val map = hashMapOf<String, Any?>()
         members.forEach { member ->
+            // 跳过 @LinkTable 成员，它们没有对应的列
+            if (member.isLinkTable) return@forEach
             val obj: Any? = result.getObject(member.name)
             if (obj == null) {
                 map[member.name] = null
             } else {
-                map[member.name] = when {
-                    member.isBoolean -> obj.cbool
-                    member.isByte -> obj.cbyte
-                    member.isShort -> obj.cshort
-                    member.isInt -> obj.cint
-                    member.isLong -> obj.clong
-                    member.isFloat -> obj.cfloat
-                    member.isDouble -> obj.cdouble
-                    member.isChar -> obj.cint.toChar()
-                    member.isString -> obj.toString()
-                    member.isUUID -> UUID.fromString(obj.toString())
-                    member.isEnum -> member.returnType.enumConstants.firstOrNull { (it as Enum<*>).name == obj.toString() }
-                        ?: error(
-                            """
-                            在 $clazz 类中，成员 ${member.name} 的枚举值 "$obj" 不存在。
-                            Enum value "$obj" not found for ${member.name} in $clazz
-                            """.t()
-                        )
-                    member.isByteArray -> obj.cByteArray
-                    else -> {
-                        val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType) ?: error(
-                            """
-                            在 $clazz 类中，成员 ${member.name} 的类型 ${member.returnType} 不受支持。
-                            Unsupported type ${member.returnType} for ${member.name} in $clazz
-                            """.t()
-                        )
-                        customType.deserialize(obj)
-                    }
-                }
+                map[member.name] = readMemberValue(member, obj)
             }
         }
         return map
+    }
+
+    /**
+     * 从带 JOIN 的 ResultSet 中读取数据（含 @LinkTable 成员，支持无限嵌套）
+     *
+     * @param result JOIN 查询的 ResultSet
+     * @param prefix 列别名前缀链，每深一层追加 `__link__{fk}__`（默认空字符串，向后兼容）
+     */
+    fun readWithLinks(result: ResultSet, prefix: String = ""): Map<String, Any?> {
+        val map = hashMapOf<String, Any?>()
+        // 读取本类的非 @LinkTable 列
+        columnMembers.forEach { member ->
+            val obj: Any? = result.getObject("${prefix}${member.name}")
+            if (obj == null) {
+                map[member.name] = null
+            } else {
+                map[member.name] = readMemberValue(member, obj)
+            }
+        }
+        // 递归读取 @LinkTable 关联对象
+        linkMembers.forEach { member ->
+            val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+            val childPrefix = "${prefix}__link__${member.linkTableColumn}__"
+            val idColumn = "${childPrefix}${linkedClass.primaryMemberName}"
+            val linkedIdValue: Any? = try {
+                result.getObject(idColumn)
+            } catch (ex: Exception) {
+                warning("@LinkTable read failed: column '$idColumn' not found in ResultSet for ${clazz.simpleName}.${member.propertyName} -> ${member.linkTableClass?.simpleName}")
+                warning("  Cause: ${ex.message}")
+                null
+            }
+            if (linkedIdValue == null) {
+                map[member.name] = null
+            } else {
+                // 递归：linkedClass 可能也有 linkMembers
+                val linkedMap = linkedClass.readWithLinks(result, childPrefix)
+                map[member.name] = linkedClass.createInstance(linkedMap)
+            }
+        }
+        return map
+    }
+
+    /** 读取单个成员的值 */
+    private fun readMemberValue(member: AnalyzedClassMember, obj: Any): Any? {
+        return when {
+            member.isBoolean -> obj.cbool
+            member.isByte -> obj.cbyte
+            member.isShort -> obj.cshort
+            member.isInt -> obj.cint
+            member.isLong -> obj.clong
+            member.isFloat -> obj.cfloat
+            member.isDouble -> obj.cdouble
+            member.isChar -> obj.cint.toChar()
+            member.isString -> obj.toString()
+            member.isUUID -> UUID.fromString(obj.toString())
+            member.isIndexedEnum -> {
+                val idx = obj.clong
+                member.returnType.enumConstants.firstOrNull { (it as IndexedEnum).index == idx }
+                    ?: error(
+                        """
+                        在 $clazz 类中，成员 ${member.name} 的 IndexedEnum 索引值 "$obj" 不存在。
+                        IndexedEnum index "$obj" not found for ${member.name} in $clazz
+                        """.t()
+                    )
+            }
+            member.isEnum -> member.returnType.enumConstants.firstOrNull { (it as Enum<*>).name == obj.toString() }
+                ?: error(
+                    """
+                    在 $clazz 类中，成员 ${member.name} 的枚举值 "$obj" 不存在。
+                    Enum value "$obj" not found for ${member.name} in $clazz
+                    """.t()
+                )
+            member.isByteArray -> obj.cByteArray
+            else -> {
+                val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType) ?: error(
+                    """
+                    在 $clazz 类中，成员 ${member.name} 的类型 ${member.returnType} 不受支持。
+                    Unsupported type ${member.returnType} for ${member.name} in $clazz
+                    """.t()
+                )
+                customType.deserialize(obj)
+            }
+        }
     }
 
     /** 创建实例 */
@@ -194,7 +274,9 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
         val cached = ConcurrentHashMap<Class<*>, AnalyzedClass>()
 
         fun of(clazz: Class<*>): AnalyzedClass {
-            return cached.computeIfAbsent(clazz) { AnalyzedClass(it) }
+            cached[clazz]?.let { return it }
+            val instance = AnalyzedClass(clazz)
+            return cached.putIfAbsent(clazz, instance) ?: instance
         }
     }
 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
@@ -1,6 +1,8 @@
 package taboolib.expansion
 
 import taboolib.common.reflect.getAnnotationIfPresent
+import taboolib.module.database.ColumnTypeSQL
+import taboolib.module.database.ColumnTypeSQLite
 import java.lang.reflect.Parameter
 
 /**
@@ -35,6 +37,24 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
 
     /** 长度 */
     val length = root.findAnnotation<Length>()?.value ?: 64
+
+    /** 自定义 SQL 列类型 */
+    val columnTypeSQL: ColumnTypeSQL? = root.findAnnotation<ColumnType>()?.sql
+
+    /** 自定义 SQLite 列类型 */
+    val columnTypeSQLite: ColumnTypeSQLite? = root.findAnnotation<ColumnType>()?.sqlite
+
+    /** 是否指定了自定义列类型 */
+    val hasColumnType: Boolean = root.findAnnotation<ColumnType>() != null
+
+    /** 是否为关联表引用 */
+    val isLinkTable: Boolean = root.findAnnotation<LinkTable>() != null
+
+    /** 关联表外键列名（下划线命名） */
+    val linkTableColumn: String? = root.findAnnotation<LinkTable>()?.value?.toColumnName()
+
+    /** 关联的 data class 类型 */
+    val linkTableClass: Class<*>? = if (isLinkTable) returnType else null
 
     /** 是否为基础类型（Boolean） */
     val isBoolean: Boolean
@@ -84,13 +104,17 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
     val isEnum: Boolean
         get() = Enum::class.java.isAssignableFrom(returnType)
 
+    /** 是否为实现了 [IndexedEnum] 接口的枚举（数据库中以数值存储） */
+    val isIndexedEnum: Boolean
+        get() = isEnum && IndexedEnum::class.java.isAssignableFrom(returnType)
+
     /** 是否为自定义对象 */
     val isCustomObject: Boolean
-        get() = !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID && !isByteArray
+        get() = !isLinkTable && !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID && !isByteArray
 
     /** 是否可以转换成字符串类型 */
     fun canConvertedString(): Boolean {
-        return isString || isEnum || isUUID
+        return isString || (isEnum && !isIndexedEnum) || isUUID
     }
 
     /** 是否可以转化为数字类型 */
@@ -100,7 +124,7 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
 
     /** 是否可以转化为整数类型 */
     fun canConvertedInteger(): Boolean {
-        return isBoolean || isByte || isShort || isInt || isLong || isChar
+        return isBoolean || isByte || isShort || isInt || isLong || isChar || isIndexedEnum
     }
 
     /** 是否可以转化为小数类型 */

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
@@ -1,19 +1,204 @@
 package taboolib.expansion
 
+import taboolib.module.database.ColumnTypeSQL
+import taboolib.module.database.ColumnTypeSQLite
+
+/**
+ * 标记数据类的逻辑主键字段。
+ *
+ * 框架的 CRUD 操作（find、update、delete、has）均通过 @Id 字段定位记录。
+ *
+ * **建表行为：**
+ * - 若数据类中存在 @Id 字段，该字段在 SQL 中会被设置为 KEY（索引），在 SQLite 中会被设置为 PRIMARY KEY
+ * - 若数据类中不存在 @Id 字段，框架会自动添加一个名为 `id` 的自增主键列
+ *
+ * **⚠ SQLite 与 SQL 的行为差异：**
+ * - SQL（MySQL）中 @Id 仅创建 KEY（普通索引），**不强制唯一**，允许同一 @Id 值存在多条记录
+ * - SQLite 中 @Id 创建 PRIMARY KEY，**强制唯一**，同一 @Id 值只能存在一条记录
+ * - 因此，@Key 复合定位模式（同一 @Id + 不同 @Key 区分多条记录）仅在 SQL 模式下可用；
+ *   在 SQLite 模式下，插入相同 @Id 值的第二条记录会抛出 UNIQUE constraint failed 异常
+ *
+ * **CRUD 行为：**
+ * - `find(id)` / `findOne(id)` — 以 @Id 字段值作为 WHERE 条件查询
+ * - `update(data)` — 以 @Id 字段值定位记录并更新 var 字段
+ * - `delete(id)` — 以 @Id 字段值定位记录并删除
+ * - `has(id)` — 以 @Id 字段值检查记录是否存在
+ * - `upsert` — 以 @Id（+ @Key）判断记录是否存在，存在则更新，不存在则插入
+ *
+ * **约束：** 每个数据类最多标记一个 @Id 字段。
+ *
+ * ```kotlin
+ * data class PlayerHome(
+ *     @Id val username: UUID,   // 逻辑主键，用于定位记录
+ *     var world: String,
+ * )
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Id
 
+/**
+ * 标记数据类的索引字段，同时作为 updateByKey / upsert 的复合定位条件。
+ *
+ * **建表行为：**
+ * - SQL：为该列创建 KEY（普通索引），加速查询
+ * - SQLite：通过 `CREATE INDEX` 为该列创建索引
+ *
+ * **CRUD 行为：**
+ * - `updateByKey(data)` — 在 @Id 的基础上，追加所有 @Key 字段作为 WHERE 条件，精确定位记录
+ * - `upsert(dataList)` — 以 @Id + 所有 @Key 字段的组合值判断记录是否存在
+ *
+ * **典型场景：** 当 @Id 不唯一时（如同一玩家在多个服务器有数据），
+ * 用 @Key 补充定位条件，形成复合键。
+ *
+ * **⚠ SQLite 限制：** 此复合定位模式（同一 @Id + 不同 @Key）仅在 SQL（MySQL）模式下可用。
+ * SQLite 中 @Id 是 PRIMARY KEY（唯一约束），不允许同一 @Id 值存在多条记录。
+ *
+ * 允许标记多个 @Key 字段。
+ *
+ * ```kotlin
+ * data class PlayerHome(
+ *     @Id val username: UUID,
+ *     @Key @Length(32) val serverName: String,  // 索引 + 复合定位
+ *     var world: String,
+ * )
+ * // updateByKey(home) → WHERE username = ? AND server_name = ?
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Key
 
+/**
+ * 标记数据类的唯一索引字段。
+ *
+ * **建表行为：**
+ * - SQL：为该列创建 UNIQUE KEY（唯一索引）
+ * - SQLite：为该列添加 UNIQUE 约束
+ *
+ * **注意：** 这是纯数据库层面的约束，框架的 CRUD 操作不会使用 @UniqueKey 进行定位。
+ * 如果需要在 updateByKey / upsert 中参与定位，请使用 [@Key]。
+ *
+ * ```kotlin
+ * data class PlayerProfile(
+ *     @Id val id: Int,
+ *     @UniqueKey @Length(16) val nickname: String,  // 数据库保证昵称不重复
+ *     var level: Int,
+ * )
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class UniqueKey
 
+/**
+ * 标记字段不允许为空。
+ *
+ * **建表行为：**
+ * - SQL：为该列添加 NOT NULL 约束
+ * - SQLite：为该列添加 NOT NULL 约束
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class NotNull
 
+/**
+ * 指定字段在数据库中的存储长度。
+ *
+ * 主要影响 VARCHAR 类型的列长度，默认值为 64。
+ * 当 value 为 -1 时，SQL 模式下字符串字段会使用 LONGTEXT 类型。
+ *
+ * ```kotlin
+ * data class Player(
+ *     @Id @Length(36) val uuid: String,
+ *     @Length(128) var displayName: String,
+ *     @Length(-1) var jsonData: String,  // SQL: LONGTEXT
+ * )
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Length(val value: Int = 64)
 
+/**
+ * 为字段指定数据库中的列名别名。
+ *
+ * 默认情况下，框架会将驼峰命名转换为下划线命名（如 serverName → server_name）。
+ * 使用 @Alias 可以覆盖这一行为，指定自定义列名。
+ *
+ * ```kotlin
+ * data class Player(
+ *     @Id val id: Int,
+ *     @Alias("display_name") var name: String,  // 列名为 display_name 而非 name
+ * )
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Alias(val value: String)
+
+/**
+ * 显式指定字段的数据库列类型。
+ *
+ * 当框架的自动类型推断不满足需求时（如需要 LONGTEXT、MEDIUMINT 等特定类型），
+ * 可以通过此注解手动指定 SQL 和 SQLite 的列类型。
+ *
+ * 此注解的优先级高于框架的自动类型推断，会跳过默认的类型映射逻辑。
+ *
+ * ```kotlin
+ * data class Article(
+ *     @Id val id: Int,
+ *     @ColumnType(sql = ColumnTypeSQL.LONGTEXT) var content: String,
+ *     @ColumnType(sql = ColumnTypeSQL.MEDIUMINT) var viewCount: Int,
+ * )
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ColumnType(
+    val sql: ColumnTypeSQL = ColumnTypeSQL.VARCHAR,
+    val sqlite: ColumnTypeSQLite = ColumnTypeSQLite.TEXT
+)
+
+/**
+ * 标记字段为关联表引用。
+ *
+ * 当数据类的某个字段类型是另一个数据类时，使用 @LinkTable 声明关联关系。
+ * 框架会在主表中创建一个外键列，查询时自动使用 LEFT JOIN 关联查询，
+ * 写入时自动提取关联对象的 @Id 值存入外键列。
+ *
+ * **支持多层嵌套关联**（A→B→C→D→...），框架自动递归展开 JOIN 和级联保存。
+ * 框架自动检测循环引用（A→B→A）并跳过，防止无限递归。
+ *
+ * **建表行为：**
+ * - 主表中创建一个外键列（列名由 value 参数指定，自动转为下划线命名）
+ * - 外键列的类型与关联类的 @Id 字段类型一致
+ *
+ * **查询行为：**
+ * - 自动生成 LEFT JOIN 查询，关联表的所有列以 `__link__{memberColumnName}__{column}` 为别名
+ * - 嵌套关联时前缀链叠加，如 `__link__{fk1}____link__{fk2}__{column}`
+ * - 关联对象可能为 null（LEFT JOIN 语义）
+ *
+ * **写入行为（级联保存）：**
+ * - 写入主对象时，自动对非空关联对象执行深度优先级联保存：
+ *   - 先保存最深层的关联对象，确保外键引用完整
+ *   - 关联对象不存在 → 自动插入到关联表
+ *   - 关联对象已存在 → 自动更新关联表中的记录
+ * - 主表的外键列存储关联对象的 @Id 值
+ *
+ * **约束：**
+ * - 关联类必须有 @Id 字段
+ *
+ * ```kotlin
+ * data class Guild(@Id val id: String, val name: String, @LinkTable("leaderId") val leader: Player?)
+ * data class Player(@Id val id: String, val name: String, @LinkTable("homeId") val home: Home?)
+ * data class Home(@Id val id: String, val world: String, var x: Double, var y: Double)
+ * // 查询 Guild 时自动 LEFT JOIN player 和 home，递归读取完整对象树
+ * ```
+ *
+ * @param value 外键列的属性名（驼峰命名），框架自动转为下划线列名
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LinkTable(val value: String)

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Container.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Container.kt
@@ -1,6 +1,7 @@
 package taboolib.expansion
 
 import org.tabooproject.reflex.Reflex.Companion.invokeMethod
+import taboolib.expansion.AnalyzedClassMember.Companion.toColumnName
 import taboolib.module.database.ColumnBuilder
 import taboolib.module.database.Host
 import taboolib.module.database.Table
@@ -11,12 +12,30 @@ abstract class Container<T : ColumnBuilder>(val host: Host<T>) {
     val map = ConcurrentHashMap<String, ContainerOperator>()
     val dataSource = host.createDataSource(autoRelease = false)
 
+    /** class → 表名映射（用于 @LinkTable 关联查询） */
+    val classTableMap = ConcurrentHashMap<Class<*>, String>()
+
+    /** class → ContainerOperator 映射（用于 @LinkTable 级联保存） */
+    val classOperatorMap = ConcurrentHashMap<Class<*>, ContainerOperator>()
+
     /** 创建表 */
     protected abstract fun createTableObject(type: AnalyzedClass, name: String): Table<*, *>
 
     /** 创建表 */
     open fun createTable(type: AnalyzedClass, name: String) {
-        map[name] = ContainerOperatorImpl(createTableObject(type, name), dataSource)
+        // 先注册 @LinkTable 关联类的表（确保关联类的 operator 在主类之前就绑定）
+        for (member in type.linkMembers) {
+            val linkClass = member.linkTableClass ?: continue
+            if (!classOperatorMap.containsKey(linkClass)) {
+                val linkType = AnalyzedClass.of(linkClass)
+                val linkName = linkClass.simpleName.toColumnName()
+                createTable(linkType, linkName)
+            }
+        }
+        classTableMap[type.clazz] = name
+        val operator = ContainerOperatorImpl(createTableObject(type, name), dataSource, classTableMap = classTableMap, classOperatorMap = classOperatorMap)
+        map[name] = operator
+        classOperatorMap[type.clazz] = operator
     }
 
     /** 初始化所有表 */

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperator.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperator.kt
@@ -1,7 +1,10 @@
 package taboolib.expansion
 
+import taboolib.module.database.Action
+import taboolib.module.database.ActionSelect
 import taboolib.module.database.Filter
 import taboolib.module.database.Table
+import java.sql.ResultSet
 import java.util.*
 import javax.sql.DataSource
 
@@ -161,6 +164,73 @@ abstract class ContainerOperator {
     }
 
     /**
+     * 分页获取数据
+     *
+     * @param page 页码（从 1 开始）
+     * @param size 每页大小
+     * @param filter 条件过滤器
+     */
+    inline fun <reified T> getPage(page: Int, size: Int, noinline filter: Filter.() -> Unit = {}): List<T> {
+        return getPage(T::class.java, page, size, filter)
+    }
+
+    /**
+     * 分页正序排序
+     *
+     * @param row 排序的列
+     * @param page 页码（从 1 开始）
+     * @param size 每页大小
+     * @param filter 条件过滤器
+     */
+    inline fun <reified T> sortPage(row: String, page: Int, size: Int, noinline filter: Filter.() -> Unit = {}): List<T> {
+        return sortPage(T::class.java, row, page, size, filter)
+    }
+
+    /**
+     * 分页倒序排序
+     *
+     * @param row 排序的列
+     * @param page 页码（从 1 开始）
+     * @param size 每页大小
+     * @param filter 条件过滤器
+     */
+    inline fun <reified T> sortDescendingPage(row: String, page: Int, size: Int, noinline filter: Filter.() -> Unit = {}): List<T> {
+        return sortDescendingPage(T::class.java, row, page, size, filter)
+    }
+
+    /**
+     * 游标查询，逐行读取数据，避免大量数据导致内存溢出。
+     * 必须在事务中使用。
+     *
+     * @param filter 条件过滤器
+     */
+    inline fun <reified T> selectCursor(noinline filter: Filter.() -> Unit = {}): Cursor<T> {
+        return selectCursor(T::class.java, filter)
+    }
+
+    /**
+     * 游标查询（正序排序），逐行读取数据。
+     * 必须在事务中使用。
+     *
+     * @param row 排序的列
+     * @param filter 条件过滤器
+     */
+    inline fun <reified T> sortCursor(row: String, noinline filter: Filter.() -> Unit = {}): Cursor<T> {
+        return sortCursor(T::class.java, row, filter)
+    }
+
+    /**
+     * 游标查询（倒序排序），逐行读取数据。
+     * 必须在事务中使用。
+     *
+     * @param row 排序的列
+     * @param filter 条件过滤器
+     */
+    inline fun <reified T> sortDescendingCursor(row: String, noinline filter: Filter.() -> Unit = {}): Cursor<T> {
+        return sortDescendingCursor(T::class.java, row, filter)
+    }
+
+    /**
      * 检查数据是否存在
      *
      * @param id 数据类中的 @Id
@@ -178,6 +248,61 @@ abstract class ContainerOperator {
      */
     inline fun <reified T> delete(id: Any, noinline filter: Filter.() -> Unit = {}) {
         return delete(T::class.java, id, filter)
+    }
+
+    /**
+     * 通过 @Id + @Key 查询数据，查多个
+     *
+     * 从数据对象中提取 @Id 和 @Key 字段值作为 WHERE 条件。
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    inline fun <reified T> findByKey(data: Any, usePrimaryKey: Boolean = true): List<T> {
+        return findByKey(T::class.java, data, usePrimaryKey)
+    }
+
+    /**
+     * 通过 @Id + @Key 查询数据，查一个
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    inline fun <reified T> findOneByKey(data: Any, usePrimaryKey: Boolean = true): T? {
+        return findOneByKey(T::class.java, data, usePrimaryKey)
+    }
+
+    /**
+     * 通过 @Id + @Key 检查数据是否存在
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    inline fun <reified T> hasByKey(data: Any, usePrimaryKey: Boolean = true): Boolean {
+        return hasByKey(T::class.java, data, usePrimaryKey)
+    }
+
+    /**
+     * 通过自增行 ID 查询数据（用于无 @Id 字段的数据类）
+     *
+     * @param rowId 框架自动生成的 `id` 列的值
+     */
+    inline fun <reified T> findByRowId(rowId: Long): T? {
+        return findByRowId(T::class.java, rowId)
+    }
+
+    /**
+     * 批量查询，通过多个 @Id 值查询
+     */
+    inline fun <reified T> findByIds(ids: List<Any>): List<T> {
+        return findByIds(T::class.java, ids)
+    }
+
+    /**
+     * 批量删除，通过多个 @Id 值删除
+     */
+    inline fun <reified T> deleteByIds(ids: List<Any>) {
+        return deleteByIds(T::class.java, ids)
     }
 
     /**
@@ -209,6 +334,61 @@ abstract class ContainerOperator {
      * 倒序排序
      */
     abstract fun <T> sortDescending(type: Class<T>, row: String, limit: Int = 10, filter: Filter.() -> Unit = {}): List<T>
+
+    /**
+     * 分页获取数据
+     *
+     * @param page 页码（从 1 开始）
+     * @param size 每页大小
+     * @param filter 条件过滤器
+     */
+    abstract fun <T> getPage(type: Class<T>, page: Int, size: Int, filter: Filter.() -> Unit = {}): List<T>
+
+    /**
+     * 分页正序排序
+     *
+     * @param row 排序的列
+     * @param page 页码（从 1 开始）
+     * @param size 每页大小
+     * @param filter 条件过滤器
+     */
+    abstract fun <T> sortPage(type: Class<T>, row: String, page: Int, size: Int, filter: Filter.() -> Unit = {}): List<T>
+
+    /**
+     * 分页倒序排序
+     *
+     * @param row 排序的列
+     * @param page 页码（从 1 开始）
+     * @param size 每页大小
+     * @param filter 条件过滤器
+     */
+    abstract fun <T> sortDescendingPage(type: Class<T>, row: String, page: Int, size: Int, filter: Filter.() -> Unit = {}): List<T>
+
+    /**
+     * 游标查询，逐行读取数据，避免大量数据导致内存溢出。
+     * 必须在事务模式下调用（sharedConnection 不为 null）。
+     *
+     * @param filter 条件过滤器
+     */
+    abstract fun <T> selectCursor(type: Class<T>, filter: Filter.() -> Unit = {}): Cursor<T>
+
+    /**
+     * 游标查询（正序排序），逐行读取数据。
+     * 必须在事务模式下调用。
+     *
+     * @param row 排序的列
+     * @param filter 条件过滤器
+     */
+    abstract fun <T> sortCursor(type: Class<T>, row: String, filter: Filter.() -> Unit = {}): Cursor<T>
+
+    /**
+     * 游标查询（倒序排序），逐行读取数据。
+     * 必须在事务模式下调用。
+     *
+     * @param row 排序的列
+     * @param filter 条件过滤器
+     */
+    abstract fun <T> sortDescendingCursor(type: Class<T>, row: String, filter: Filter.() -> Unit = {}): Cursor<T>
 
     /**
      * 更新数据，借助 @Id 定位数据并更新
@@ -245,6 +425,35 @@ abstract class ContainerOperator {
     abstract fun insert(dataList: List<Any>)
 
     /**
+     * 插入数据并返回自增主键
+     *
+     * @return 生成的自增主键列表
+     */
+    abstract fun insertAndGetKeys(dataList: List<Any>): List<Long>
+
+    /**
+     * 批量查询，通过多个 @Id 值查询（使用 IN 子句）
+     *
+     * @param ids @Id 字段值列表
+     */
+    abstract fun <T> findByIds(type: Class<T>, ids: List<Any>): List<T>
+
+    /**
+     * 批量删除，通过多个 @Id 值删除（使用 IN 子句）
+     *
+     * @param ids @Id 字段值列表
+     */
+    abstract fun <T> deleteByIds(type: Class<T>, ids: List<Any>)
+
+    /**
+     * 批量更新，通过 @Id + @Key 定位并更新 var 字段
+     * 在单个事务中使用 batch PreparedStatement 执行，保证原子性和性能。
+     *
+     * @param dataList 数据列表
+     */
+    abstract fun updateBatch(dataList: List<Any>)
+
+    /**
      * 检查数据
      */
     abstract fun <T> has(type: Class<T>, id: Any, filter: Filter.() -> Unit = {}): Boolean
@@ -260,10 +469,81 @@ abstract class ContainerOperator {
     abstract fun <T> delete(type: Class<T>, id: Any, filter: Filter.() -> Unit = {})
 
     /**
+     * 按条件删除数据
+     *
+     * @param filter 条件过滤器
+     */
+    abstract fun deleteWhere(filter: Filter.() -> Unit)
+
+    /**
+     * 统计数据数量
+     *
+     * @param filter 条件过滤器
+     */
+    abstract fun count(filter: Filter.() -> Unit = {}): Long
+
+    /**
+     * 通过 @Id + @Key 查询数据，查多个
+     *
+     * 从数据对象中提取 @Id 和所有 @Key 字段值构建 WHERE 条件。
+     */
+    abstract fun <T> findByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean = true): List<T>
+
+    /**
+     * 通过 @Id + @Key 查询数据，查一个，有多个仅返回第一个
+     */
+    abstract fun <T> findOneByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean = true): T?
+
+    /**
+     * 通过 @Id + @Key 检查数据是否存在
+     */
+    abstract fun <T> hasByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean = true): Boolean
+
+    /**
+     * 通过 @Id + @Key 删除数据
+     *
+     * @param data 数据对象（用于提取 @Id 和 @Key 值）
+     * @param usePrimaryKey 是否使用 @Id 定位
+     */
+    abstract fun deleteByKey(data: Any, usePrimaryKey: Boolean = true)
+
+    /**
+     * 通过自增行 ID 查询数据（用于无 @Id 字段的数据类）
+     *
+     * 当数据类没有定义 @Id 字段时，框架会自动生成一个名为 `id` 的自增主键列。
+     * 此方法通过该自增列的值查询数据。
+     */
+    abstract fun <T> findByRowId(type: Class<T>, rowId: Long): T?
+
+    /**
+     * 通过自增行 ID 删除数据（用于无 @Id 字段的数据类）
+     */
+    abstract fun deleteByRowId(rowId: Long)
+
+    // === 自定义 SQL ===
+
+    /**
+     * 执行自定义 SELECT 查询
+     *
+     * @param action 查询动作
+     * @param handler 结果集处理器
+     */
+    abstract fun <R> select(action: ActionSelect, handler: (ResultSet) -> R): R
+
+    /**
+     * 执行自定义更新操作（UPDATE / DELETE / INSERT）
+     *
+     * @param action 操作动作
+     * @return 受影响的行数
+     */
+    abstract fun execute(action: Action): Int
+
+    /**
      * 内部函数
      */
     protected fun Any.value(): Any {
         return when (this) {
+            is IndexedEnum -> this.index
             is Enum<*> -> this.name
             is UUID -> this.toString()
             is Char -> this.code

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
@@ -22,14 +22,16 @@ import javax.sql.DataSource
 class ContainerOperatorImpl(
     override val table: Table<*, *>,
     override val dataSource: DataSource,
-    private val sharedConnection: Connection? = null
+    private val sharedConnection: Connection? = null,
+    private val classTableMap: Map<Class<*>, String>? = null,
+    private val classOperatorMap: Map<Class<*>, ContainerOperator>? = null
 ) : ContainerOperator() {
 
     /**
      * 创建事务模式的操作器（共享 Connection）
      */
     fun withConnection(connection: Connection): ContainerOperatorImpl {
-        return ContainerOperatorImpl(table, dataSource, connection)
+        return ContainerOperatorImpl(table, dataSource, connection, classTableMap, classOperatorMap)
     }
 
     /**
@@ -40,6 +42,15 @@ class ContainerOperatorImpl(
 
     override fun <T> getOne(type: Class<T>, filter: Filter.() -> Unit): T? {
         val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) {
+                limit(1)
+                where(filter)
+            }
+            return executeQuery(action) { rs ->
+                if (rs.next()) readJoinResult<T>(typeClass, rs) else null
+            }
+        }
         val action = ActionSelect(table.name).apply {
             limit(1)
             where(filter)
@@ -51,6 +62,18 @@ class ContainerOperatorImpl(
 
     override fun <T> get(type: Class<T>, filter: Filter.() -> Unit): List<T> {
         val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) {
+                where(filter)
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
         val action = ActionSelect(table.name).apply {
             where(filter)
         }
@@ -65,6 +88,18 @@ class ContainerOperatorImpl(
 
     override fun <T> findOne(type: Class<T>, id: Any, filter: Filter.() -> Unit): T? {
         val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
+            val tableName = table.name
+            val action = buildJoinSelect(typeClass) {
+                where("`$tableName`.`$primaryName`" eq id.value())
+                where(filter)
+                limit(1)
+            }
+            return executeQuery(action) { rs ->
+                if (rs.next()) readJoinResult<T>(typeClass, rs) else null
+            }
+        }
         return executeQuery(selectById(typeClass, id, filter) { limit(1) }) { rs ->
             if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
         }
@@ -72,6 +107,21 @@ class ContainerOperatorImpl(
 
     override fun <T> find(type: Class<T>, id: Any, filter: Filter.() -> Unit): List<T> {
         val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
+            val tableName = table.name
+            val action = buildJoinSelect(typeClass) {
+                where("`$tableName`.`$primaryName`" eq id.value())
+                where(filter)
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
         return executeQuery(selectById(typeClass, id, filter)) { rs ->
             buildList {
                 while (rs.next()) {
@@ -83,6 +133,20 @@ class ContainerOperatorImpl(
 
     override fun <T> sort(type: Class<T>, row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
         val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) {
+                where(filter)
+                limit(limit)
+                orderBy(row)
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
         val action = ActionSelect(table.name).apply {
             where(filter)
             limit(limit)
@@ -99,6 +163,20 @@ class ContainerOperatorImpl(
 
     override fun <T> sortDescending(type: Class<T>, row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
         val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) {
+                where(filter)
+                limit(limit)
+                orderBy(row, Order.Type.DESC)
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
         val action = ActionSelect(table.name).apply {
             where(filter)
             limit(limit)
@@ -111,6 +189,130 @@ class ContainerOperatorImpl(
                 }
             }
         }
+    }
+
+    override fun <T> getPage(type: Class<T>, page: Int, size: Int, filter: Filter.() -> Unit): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) {
+                where(filter)
+                limit(size)
+                offset((page - 1) * size)
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
+        val action = ActionSelect(table.name).apply {
+            where(filter)
+            limit(size)
+            offset((page - 1) * size)
+        }
+        return executeQuery(action) { rs ->
+            buildList {
+                while (rs.next()) {
+                    add(typeClass.createInstance<T>(typeClass.read(rs)))
+                }
+            }
+        }
+    }
+
+    override fun <T> sortPage(type: Class<T>, row: String, page: Int, size: Int, filter: Filter.() -> Unit): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) {
+                where(filter)
+                orderBy(row)
+                limit(size)
+                offset((page - 1) * size)
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
+        val action = ActionSelect(table.name).apply {
+            where(filter)
+            orderBy(row)
+            limit(size)
+            offset((page - 1) * size)
+        }
+        return executeQuery(action) { rs ->
+            buildList {
+                while (rs.next()) {
+                    add(typeClass.createInstance<T>(typeClass.read(rs)))
+                }
+            }
+        }
+    }
+
+    override fun <T> sortDescendingPage(type: Class<T>, row: String, page: Int, size: Int, filter: Filter.() -> Unit): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) {
+                where(filter)
+                orderBy(row, Order.Type.DESC)
+                limit(size)
+                offset((page - 1) * size)
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
+        val action = ActionSelect(table.name).apply {
+            where(filter)
+            orderBy(row, Order.Type.DESC)
+            limit(size)
+            offset((page - 1) * size)
+        }
+        return executeQuery(action) { rs ->
+            buildList {
+                while (rs.next()) {
+                    add(typeClass.createInstance<T>(typeClass.read(rs)))
+                }
+            }
+        }
+    }
+
+    override fun <T> selectCursor(type: Class<T>, filter: Filter.() -> Unit): Cursor<T> {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) { where(filter) }
+            return openCursor(action) { rs -> readJoinResult<T>(typeClass, rs) }
+        }
+        val action = ActionSelect(table.name).apply { where(filter) }
+        return openCursor(action) { rs -> typeClass.createInstance<T>(typeClass.read(rs)) }
+    }
+
+    override fun <T> sortCursor(type: Class<T>, row: String, filter: Filter.() -> Unit): Cursor<T> {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) { where(filter); orderBy(row) }
+            return openCursor(action) { rs -> readJoinResult<T>(typeClass, rs) }
+        }
+        val action = ActionSelect(table.name).apply { where(filter); orderBy(row) }
+        return openCursor(action) { rs -> typeClass.createInstance<T>(typeClass.read(rs)) }
+    }
+
+    override fun <T> sortDescendingCursor(type: Class<T>, row: String, filter: Filter.() -> Unit): Cursor<T> {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val action = buildJoinSelect(typeClass) { where(filter); orderBy(row, Order.Type.DESC) }
+            return openCursor(action) { rs -> readJoinResult<T>(typeClass, rs) }
+        }
+        val action = ActionSelect(table.name).apply { where(filter); orderBy(row, Order.Type.DESC) }
+        return openCursor(action) { rs -> typeClass.createInstance<T>(typeClass.read(rs)) }
     }
 
     override fun <T> has(type: Class<T>, id: Any, filter: Filter.() -> Unit): Boolean {
@@ -128,19 +330,45 @@ class ContainerOperatorImpl(
     override fun insert(dataList: List<Any>) {
         if (dataList.isEmpty()) return
         val typeClass = AnalyzedClass.of(dataList.first().javaClass)
-        val action = ActionInsert(table.name, typeClass.members.map { it.name }.toTypedArray()).apply {
+        cascadeSaveLinkedObjects(typeClass, dataList)
+        val columnNames = getColumnNames(typeClass)
+        val action = ActionInsert(table.name, columnNames.toTypedArray()).apply {
             dataList.forEach { data ->
-                values(typeClass.members.map { member -> typeClass.getValue(data, member)?.value() })
+                values(getColumnValues(typeClass, data))
             }
         }
         executeUpdate(action)
     }
 
+    override fun insertAndGetKeys(dataList: List<Any>): List<Long> {
+        if (dataList.isEmpty()) return emptyList()
+        val typeClass = AnalyzedClass.of(dataList.first().javaClass)
+        cascadeSaveLinkedObjects(typeClass, dataList)
+        val columnNames = getColumnNames(typeClass)
+        val action = ActionInsert(table.name, columnNames.toTypedArray()).apply {
+            dataList.forEach { data ->
+                values(getColumnValues(typeClass, data))
+            }
+        }
+        // ⚠ SQLite 限制：批量插入时 generatedKeys 仅返回最后一条记录的自增 ID，
+        // 而非所有记录的 ID 列表。因此在 SQLite 模式下，返回的 List 长度可能为 1 而非 dataList.size。
+        // MySQL 不受此限制，会正确返回所有生成的 key。
+        return withConnection { conn ->
+            conn.executePrepared(action.query, action.elements, Statement.RETURN_GENERATED_KEYS) {
+                executeUpdate()
+                generatedKeys.use { rs ->
+                    buildList { while (rs.next()) add(rs.getLong(1)) }
+                }
+            }
+        }
+    }
+
     override fun update(data: Any, usePrimaryKey: Boolean, filter: Filter.() -> Unit) {
         val typeClass = AnalyzedClass.of(data::class.java)
-        if (typeClass.members.none { !it.isFinal }) {
+        if (typeClass.members.none { !it.isFinal || it.isLinkTable }) {
             error("No mutable field found.")
         }
+        cascadeSaveLinkedObjects(typeClass, listOf(data))
         val name = if (usePrimaryKey) typeClass.primaryMemberName ?: error("No primary id found.") else null
         val value = if (usePrimaryKey) typeClass.getPrimaryMemberValue(data) else null
         // check-then-act 包裹在事务中，防止并发双重 INSERT
@@ -155,15 +383,25 @@ class ContainerOperatorImpl(
                 val updateAction = ActionUpdate(table.name).apply {
                     if (name != null) where(name eq value?.value())
                     where(filter)
-                    typeClass.members.filter { !it.isFinal }.forEach { member ->
-                        set(member.name, typeClass.getValue(data, member)?.value())
+                    typeClass.members.filter { !it.isFinal || it.isLinkTable }.forEach { member ->
+                        if (member.isLinkTable) {
+                            val linkedObj = typeClass.getValue(data, member)
+                            val fkValue = if (linkedObj != null) {
+                                val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+                                linkedClass.getPrimaryMemberValue(linkedObj)?.value()
+                            } else null
+                            set(member.linkTableColumn!!, fkValue)
+                        } else {
+                            set(member.name, typeClass.getValue(data, member)?.value())
+                        }
                     }
                 }
                 conn.executePrepared(updateAction.query, updateAction.elements, Statement.RETURN_GENERATED_KEYS) { executeUpdate() }
             } else {
                 val insertTypeClass = AnalyzedClass.of(data.javaClass)
-                val insertAction = ActionInsert(table.name, insertTypeClass.members.map { it.name }.toTypedArray()).apply {
-                    values(insertTypeClass.members.map { member -> insertTypeClass.getValue(data, member)?.value() })
+                val columnNames = getColumnNames(insertTypeClass)
+                val insertAction = ActionInsert(table.name, columnNames.toTypedArray()).apply {
+                    values(getColumnValues(insertTypeClass, data))
                 }
                 conn.executePrepared(insertAction.query, insertAction.elements, Statement.RETURN_GENERATED_KEYS) { executeUpdate() }
             }
@@ -172,7 +410,7 @@ class ContainerOperatorImpl(
 
     override fun updateByKey(data: Any, usePrimaryKey: Boolean) {
         val typeClass = AnalyzedClass.of(data::class.java)
-        if (typeClass.members.none { !it.isFinal }) {
+        if (typeClass.members.none { !it.isFinal || it.isLinkTable }) {
             error("No mutable field found.")
         }
         update(data, usePrimaryKey) {
@@ -185,12 +423,13 @@ class ContainerOperatorImpl(
     override fun upsert(dataList: List<Any>) {
         if (dataList.isEmpty()) return
         val typeClass = AnalyzedClass.of(dataList.first().javaClass)
-        if (typeClass.members.none { !it.isFinal }) {
+        if (typeClass.members.none { !it.isFinal || it.isLinkTable }) {
             error("No mutable field found.")
         }
+        cascadeSaveLinkedObjects(typeClass, dataList)
         val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
         val keyMembers = typeClass.members.filter { it.isKey }
-        val mutableMembers = typeClass.members.filter { !it.isFinal }
+        val mutableMembers = typeClass.members.filter { !it.isFinal || it.isLinkTable }
         // 构建唯一标识：@Id + @Key 的值
         fun buildKey(data: Any): String {
             val id = typeClass.getPrimaryMemberValue(data)?.value().toString()
@@ -247,8 +486,8 @@ class ContainerOperatorImpl(
                 val insertSql = buildInsertSql(typeClass)
                 conn.prepareStatement(insertSql).use { stmt ->
                     toInsert.forEach { data ->
-                        typeClass.members.forEachIndexed { i, member ->
-                            stmt.setObject(i + 1, typeClass.getValue(data, member)?.value())
+                        getColumnValues(typeClass, data).forEachIndexed { i, v ->
+                            stmt.setObject(i + 1, v)
                         }
                         stmt.addBatch()
                     }
@@ -263,7 +502,16 @@ class ContainerOperatorImpl(
                         var idx = 1
                         // SET 子句的值
                         mutableMembers.forEach { member ->
-                            stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
+                            if (member.isLinkTable) {
+                                val linkedObj = typeClass.getValue(data, member)
+                                val fkValue = if (linkedObj != null) {
+                                    val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+                                    linkedClass.getPrimaryMemberValue(linkedObj)?.value()
+                                } else null
+                                stmt.setObject(idx++, fkValue)
+                            } else {
+                                stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
+                            }
                         }
                         // WHERE 子句的值
                         stmt.setObject(idx++, typeClass.getPrimaryMemberValue(data)?.value())
@@ -282,8 +530,9 @@ class ContainerOperatorImpl(
      * 构建 INSERT SQL
      */
     private fun buildInsertSql(typeClass: AnalyzedClass): String {
-        val columns = typeClass.members.joinToString(", ") { "`${it.name}`" }
-        val placeholders = typeClass.members.joinToString(", ") { "?" }
+        val columnNames = getColumnNames(typeClass)
+        val columns = columnNames.joinToString(", ") { "`$it`" }
+        val placeholders = columnNames.joinToString(", ") { "?" }
         return "INSERT INTO `${table.name}` ($columns) VALUES ($placeholders)"
     }
 
@@ -295,8 +544,10 @@ class ContainerOperatorImpl(
         primaryName: String,
         keyMembers: List<AnalyzedClassMember>
     ): String {
-        val mutableMembers = typeClass.members.filter { !it.isFinal }
-        val setClause = mutableMembers.joinToString(", ") { "`${it.name}` = ?" }
+        val mutableMembers = typeClass.members.filter { !it.isFinal || it.isLinkTable }
+        val setClause = mutableMembers.joinToString(", ") { member ->
+            if (member.isLinkTable) "`${member.linkTableColumn}` = ?" else "`${member.name}` = ?"
+        }
         val whereClause = buildString {
             append("`$primaryName` = ?")
             keyMembers.forEach { append(" AND `${it.name}` = ?") }
@@ -314,6 +565,376 @@ class ContainerOperatorImpl(
         executeUpdate(action)
     }
 
+    override fun deleteWhere(filter: Filter.() -> Unit) {
+        val action = ActionDelete(table.name).apply {
+            where(filter)
+        }
+        executeUpdate(action)
+    }
+
+    override fun count(filter: Filter.() -> Unit): Long {
+        val action = ActionSelect(table.name).apply {
+            rows("COUNT(*)")
+            where(filter)
+        }
+        return executeQuery(action) { rs -> if (rs.next()) rs.getLong(1) else 0L }
+    }
+
+    override fun <T> findByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val tableName = table.name
+            val action = buildJoinSelect(typeClass) {
+                if (usePrimaryKey) {
+                    val pName = typeClass.primaryMemberName ?: error("No primary id found.")
+                    val pValue = typeClass.getPrimaryMemberValue(data)
+                    where("`$tableName`.`$pName`" eq pValue?.value())
+                }
+                typeClass.members.filter { it.isKey }.forEach { member ->
+                    where("`$tableName`.`${member.name}`" eq typeClass.getValue(data, member)?.value())
+                }
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
+        val action = selectByKey(typeClass, data, usePrimaryKey)
+        return executeQuery(action) { rs ->
+            buildList {
+                while (rs.next()) {
+                    add(typeClass.createInstance<T>(typeClass.read(rs)))
+                }
+            }
+        }
+    }
+
+    override fun <T> findOneByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): T? {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val tableName = table.name
+            val action = buildJoinSelect(typeClass) {
+                if (usePrimaryKey) {
+                    val pName = typeClass.primaryMemberName ?: error("No primary id found.")
+                    val pValue = typeClass.getPrimaryMemberValue(data)
+                    where("`$tableName`.`$pName`" eq pValue?.value())
+                }
+                typeClass.members.filter { it.isKey }.forEach { member ->
+                    where("`$tableName`.`${member.name}`" eq typeClass.getValue(data, member)?.value())
+                }
+                limit(1)
+            }
+            return executeQuery(action) { rs ->
+                if (rs.next()) readJoinResult<T>(typeClass, rs) else null
+            }
+        }
+        val action = selectByKey(typeClass, data, usePrimaryKey) { limit(1) }
+        return executeQuery(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun <T> hasByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): Boolean {
+        val typeClass = AnalyzedClass.of(type)
+        val action = selectByKey(typeClass, data, usePrimaryKey) { limit(1) }
+        return executeQuery(action) { it.next() }
+    }
+
+    override fun deleteByKey(data: Any, usePrimaryKey: Boolean) {
+        val typeClass = AnalyzedClass.of(data::class.java)
+        val action = ActionDelete(table.name).apply {
+            if (usePrimaryKey) {
+                val name = typeClass.primaryMemberName ?: error("No primary id found.")
+                val value = typeClass.getPrimaryMemberValue(data)
+                where(name eq value?.value())
+            }
+            typeClass.members.filter { it.isKey }.forEach { member ->
+                where(member.name eq typeClass.getValue(data, member)?.value())
+            }
+        }
+        executeUpdate(action)
+    }
+
+    override fun <T> findByRowId(type: Class<T>, rowId: Long): T? {
+        val typeClass = AnalyzedClass.of(type)
+        if (typeClass.hasLinkMembers) {
+            val tableName = table.name
+            val action = buildJoinSelect(typeClass) {
+                where("`$tableName`.`id`" eq rowId)
+                limit(1)
+            }
+            return executeQuery(action) { rs ->
+                if (rs.next()) readJoinResult<T>(typeClass, rs) else null
+            }
+        }
+        val action = ActionSelect(table.name).apply {
+            where("id" eq rowId)
+            limit(1)
+        }
+        return executeQuery(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun deleteByRowId(rowId: Long) {
+        val action = ActionDelete(table.name).apply {
+            where("id" eq rowId)
+        }
+        executeUpdate(action)
+    }
+
+    // === 批量操作 ===
+
+    override fun <T> findByIds(type: Class<T>, ids: List<Any>): List<T> {
+        if (ids.isEmpty()) return emptyList()
+        val typeClass = AnalyzedClass.of(type)
+        val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
+        if (typeClass.hasLinkMembers) {
+            val tableName = table.name
+            val action = buildJoinSelect(typeClass) {
+                where { "`$tableName`.`$primaryName`" inside ids.map { it.value() }.toTypedArray() }
+            }
+            return executeQuery(action) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(readJoinResult<T>(typeClass, rs))
+                    }
+                }
+            }
+        }
+        val action = ActionSelect(table.name).apply {
+            where { primaryName inside ids.map { it.value() }.toTypedArray() }
+        }
+        return executeQuery(action) { rs ->
+            buildList {
+                while (rs.next()) {
+                    add(typeClass.createInstance<T>(typeClass.read(rs)))
+                }
+            }
+        }
+    }
+
+    override fun <T> deleteByIds(type: Class<T>, ids: List<Any>) {
+        if (ids.isEmpty()) return
+        val typeClass = AnalyzedClass.of(type)
+        val name = typeClass.primaryMemberName ?: error("No primary id found.")
+        val action = ActionDelete(table.name).apply {
+            where { name inside ids.map { it.value() }.toTypedArray() }
+        }
+        executeUpdate(action)
+    }
+
+    override fun updateBatch(dataList: List<Any>) {
+        if (dataList.isEmpty()) return
+        val typeClass = AnalyzedClass.of(dataList.first().javaClass)
+        val mutableMembers = typeClass.members.filter { !it.isFinal || it.isLinkTable }
+        if (mutableMembers.isEmpty()) error("No mutable field found.")
+        cascadeSaveLinkedObjects(typeClass, dataList)
+        val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
+        val keyMembers = typeClass.members.filter { it.isKey }
+        val updateSql = buildUpdateSql(typeClass, primaryName, keyMembers)
+        withTransaction { conn ->
+            conn.prepareStatement(updateSql).use { stmt ->
+                dataList.forEach { data ->
+                    var idx = 1
+                    mutableMembers.forEach { member ->
+                        if (member.isLinkTable) {
+                            val linkedObj = typeClass.getValue(data, member)
+                            val fkValue = if (linkedObj != null) {
+                                val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+                                linkedClass.getPrimaryMemberValue(linkedObj)?.value()
+                            } else null
+                            stmt.setObject(idx++, fkValue)
+                        } else {
+                            stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
+                        }
+                    }
+                    stmt.setObject(idx++, typeClass.getPrimaryMemberValue(data)?.value())
+                    keyMembers.forEach { member ->
+                        stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
+                    }
+                    stmt.addBatch()
+                }
+                stmt.executeBatch()
+            }
+        }
+    }
+
+    // === 自定义 SQL ===
+
+    override fun <R> select(action: ActionSelect, handler: (ResultSet) -> R): R {
+        return executeQuery(action, handler)
+    }
+
+    override fun execute(action: Action): Int {
+        return executeUpdate(action)
+    }
+
+    // === @LinkTable 级联保存 ===
+
+    /**
+     * 级联保存关联对象：存在则更新，不存在则插入（支持无限嵌套）
+     *
+     * 在主对象写入之前调用，确保关联表中的记录已就绪。
+     * 深度优先递归：先保存最深层的关联对象，确保外键引用完整。
+     * - 关联类有可变字段 → upsert（存在则更新，不存在则插入）
+     * - 关联类全为 val → 仅在不存在时插入
+     *
+     * @param visited 祖先链集合，用于环检测（A→B→A 跳过）
+     */
+    private fun cascadeSaveLinkedObjects(
+        typeClass: AnalyzedClass,
+        dataList: List<Any>,
+        visited: MutableSet<Class<*>> = mutableSetOf()
+    ) {
+        if (!typeClass.hasLinkMembers || classOperatorMap == null) return
+        visited.add(typeClass.clazz)
+        for (member in typeClass.linkMembers) {
+            val linkClass = member.linkTableClass ?: continue
+            if (linkClass in visited) continue
+            val operator = classOperatorMap[linkClass] ?: continue
+            val linkedObjects = dataList.mapNotNull { typeClass.getValue(it, member) }
+            if (linkedObjects.isEmpty()) continue
+            val linkedTypeClass = AnalyzedClass.of(linkClass)
+            // 深度优先：先保存更深层的关联对象
+            cascadeSaveLinkedObjects(linkedTypeClass, linkedObjects, visited)
+            // 再保存当前层
+            val hasMutableFields = linkedTypeClass.members.any { !it.isFinal }
+            if (hasMutableFields) {
+                operator.upsert(linkedObjects)
+            } else {
+                val primaryName = linkedTypeClass.primaryMemberName ?: continue
+                linkedObjects.forEach { obj ->
+                    val id = linkedTypeClass.getPrimaryMemberValue(obj) ?: return@forEach
+                    if (!operator.has { primaryName eq id.value() }) {
+                        operator.insert(listOf(obj))
+                    }
+                }
+            }
+        }
+        visited.remove(typeClass.clazz)
+    }
+
+    // === @LinkTable 辅助方法 ===
+
+    /**
+     * 获取实际列名列表（@LinkTable 用 FK 列名）
+     */
+    private fun getColumnNames(typeClass: AnalyzedClass): List<String> {
+        return typeClass.members.map { member ->
+            if (member.isLinkTable) member.linkTableColumn!! else member.name
+        }
+    }
+
+    /**
+     * 获取实际列值列表（@LinkTable 提取 FK 值）
+     */
+    private fun getColumnValues(typeClass: AnalyzedClass, data: Any): List<Any?> {
+        return typeClass.members.map { member ->
+            if (member.isLinkTable) {
+                val linkedObj = typeClass.getValue(data, member)
+                if (linkedObj != null) {
+                    val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+                    linkedClass.getPrimaryMemberValue(linkedObj)?.value()
+                } else {
+                    null
+                }
+            } else {
+                typeClass.getValue(data, member)?.value()
+            }
+        }
+    }
+
+    /**
+     * JOIN 树节点，描述一个 @LinkTable 关联的递归结构
+     */
+    private data class LinkJoinNode(
+        val analyzedClass: AnalyzedClass,
+        val tableAlias: String,
+        val realTableName: String,
+        val columnPrefix: String,
+        val member: AnalyzedClassMember,
+        val parentAlias: String,
+        val children: List<LinkJoinNode>
+    )
+
+    /**
+     * 递归构建 JOIN 树（支持无限嵌套）
+     *
+     * @param typeClass 当前类的分析结果
+     * @param parentAlias 父表的别名（用于 ON 子句）
+     * @param prefixChain 列别名前缀链，每深一层追加 `__link__{fk}__`
+     * @param aliasCounter 单元素数组，全局递增的表别名计数器
+     * @param visited 祖先链集合，用于环检测（A→B→A 跳过）
+     */
+    private fun buildLinkTree(
+        typeClass: AnalyzedClass,
+        parentAlias: String,
+        prefixChain: String,
+        aliasCounter: IntArray,
+        visited: MutableSet<Class<*>>
+    ): List<LinkJoinNode> {
+        val nodes = mutableListOf<LinkJoinNode>()
+        for (member in typeClass.linkMembers) {
+            val linkClass = member.linkTableClass ?: continue
+            if (linkClass in visited) continue
+            val linkedAnalyzed = AnalyzedClass.of(linkClass)
+            val realTableName = classTableMap?.get(linkClass) ?: error(
+                "关联类 ${linkClass.simpleName} 未注册表名。请确保关联类的表已在容器中创建。"
+            )
+            val alias = "__t${aliasCounter[0]++}"
+            val prefix = "${prefixChain}__link__${member.linkTableColumn}__"
+            visited.add(linkClass)
+            val children = buildLinkTree(linkedAnalyzed, alias, prefix, aliasCounter, visited)
+            visited.remove(linkClass)
+            nodes.add(LinkJoinNode(linkedAnalyzed, alias, realTableName, prefix, member, parentAlias, children))
+        }
+        return nodes
+    }
+
+    /**
+     * 构建带 JOIN 的 ActionSelect（支持无限嵌套关联）
+     */
+    private fun buildJoinSelect(typeClass: AnalyzedClass, extra: ActionSelect.() -> Unit = {}): ActionSelect {
+        val tableName = table.name
+        val aliasCounter = intArrayOf(0)
+        val visited = mutableSetOf(typeClass.clazz)
+        val linkTree = buildLinkTree(typeClass, tableName, "", aliasCounter, visited)
+        return ActionSelect(tableName).apply {
+            val selectRows = mutableListOf<String>()
+            // 主表列
+            typeClass.columnMembers.forEach { member ->
+                selectRows += "`$tableName`.`${member.name}` AS `${member.name}`"
+            }
+            // 递归展开 JOIN 树
+            fun processNodes(nodes: List<LinkJoinNode>) {
+                for (node in nodes) {
+                    node.analyzedClass.columnMembers.forEach { linkedMember ->
+                        selectRows += "`${node.tableAlias}`.`${linkedMember.name}` AS `${node.columnPrefix}${linkedMember.name}`"
+                    }
+                    leftJoin("`${node.realTableName}` AS `${node.tableAlias}`") {
+                        on("`${node.parentAlias}`.`${node.member.linkTableColumn}`" eq
+                            pre("`${node.tableAlias}`.`${node.analyzedClass.primaryMemberName}`"))
+                    }
+                    processNodes(node.children)
+                }
+            }
+            processNodes(linkTree)
+            rows(*selectRows.toTypedArray())
+            extra()
+        }
+    }
+
+    /**
+     * 从 JOIN ResultSet 读取完整对象
+     */
+    private fun <T> readJoinResult(typeClass: AnalyzedClass, rs: ResultSet): T {
+        return typeClass.createInstance(typeClass.readWithLinks(rs))
+    }
+
     /**
      * 构建基于 @Id 的查询
      */
@@ -327,6 +948,28 @@ class ContainerOperatorImpl(
         return ActionSelect(table.name).apply {
             where(name eq id.value())
             where(filter)
+            extra()
+        }
+    }
+
+    /**
+     * 构建基于 @Id + @Key 的查询
+     */
+    private fun selectByKey(
+        typeClass: AnalyzedClass,
+        data: Any,
+        usePrimaryKey: Boolean,
+        extra: ActionSelect.() -> Unit = {}
+    ): ActionSelect {
+        return ActionSelect(table.name).apply {
+            if (usePrimaryKey) {
+                val name = typeClass.primaryMemberName ?: error("No primary id found.")
+                val value = typeClass.getPrimaryMemberValue(data)
+                where(name eq value?.value())
+            }
+            typeClass.members.filter { it.isKey }.forEach { member ->
+                where(member.name eq typeClass.getValue(data, member)?.value())
+            }
             extra()
         }
     }
@@ -390,6 +1033,36 @@ class ContainerOperatorImpl(
     }
 
     /**
+     * 打开游标查询（不关闭 PreparedStatement 和 ResultSet，由 Cursor 管理生命周期）
+     * 必须在事务模式下调用。
+     */
+    private fun <T> openCursor(action: ActionSelect, mapper: (ResultSet) -> T): Cursor<T> {
+        val conn = sharedConnection ?: error("游标查询必须在事务中使用")
+        val stmt = try {
+            conn.prepareStatement(
+                action.query,
+                ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY
+            ).also { s ->
+                action.elements.forEachIndexed { i, v -> s.setObject(i + 1, convertParam(v)) }
+            }
+        } catch (ex: SQLException) {
+            warning("Query: ${action.query}")
+            warning("Parameters (${action.elements.size}): ${action.elements}")
+            throw ex
+        }
+        val rs = try {
+            stmt.executeQuery()
+        } catch (ex: SQLException) {
+            stmt.close()
+            warning("Query: ${action.query}")
+            warning("Parameters (${action.elements.size}): ${action.elements}")
+            throw ex
+        }
+        return Cursor(stmt, rs, mapper)
+    }
+
+    /**
      * 执行 PreparedStatement 的通用包装，处理参数绑定和错误日志
      */
     private inline fun <T> Connection.executePrepared(
@@ -400,13 +1073,28 @@ class ContainerOperatorImpl(
     ): T {
         return try {
             (if (flags != 0) prepareStatement(query, flags) else prepareStatement(query)).use { stmt ->
-                elements.forEachIndexed { i, v -> stmt.setObject(i + 1, v) }
+                elements.forEachIndexed { i, v -> stmt.setObject(i + 1, convertParam(v)) }
                 stmt.block()
             }
         } catch (ex: SQLException) {
             warning("Query: $query")
             warning("Parameters (${elements.size}): $elements")
             throw ex
+        }
+    }
+
+    /**
+     * 转换 SQL 参数值：将枚举类型转换为数据库可识别的值
+     *
+     * - [IndexedEnum] → [IndexedEnum.index]（数值）
+     * - 普通 [Enum] → [Enum.name]（字符串）
+     * - 其他类型原样返回
+     */
+    private fun convertParam(value: Any?): Any? {
+        return when (value) {
+            is IndexedEnum -> value.index
+            is Enum<*> -> value.name
+            else -> value
         }
     }
 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
@@ -29,7 +29,39 @@ class ContainerSQL(
                 add { id() }
             }
             type.members.forEach { member ->
+                // @LinkTable 成员：创建外键列而非展开关联类
+                if (member.isLinkTable) {
+                    val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+                    val linkedPrimary = linkedClass.primaryMember!!
+                    val fkColumnName = member.linkTableColumn!!
+                    add(fkColumnName) {
+                        when {
+                            linkedPrimary.hasColumnType -> {
+                                val colType = linkedPrimary.columnTypeSQL!!
+                                if (colType.isRequired) type(colType, linkedPrimary.length) else type(colType)
+                            }
+                            linkedPrimary.isIndexedEnum -> type(ColumnTypeSQL.BIGINT)
+                            linkedPrimary.isString || linkedPrimary.isEnum -> {
+                                if (linkedPrimary.length < 0) type(ColumnTypeSQL.LONGTEXT)
+                                else type(ColumnTypeSQL.VARCHAR, linkedPrimary.length)
+                            }
+                            linkedPrimary.isUUID -> type(ColumnTypeSQL.CHAR, 36)
+                            else -> type(linkedPrimary.type())
+                        }
+                    }
+                    return@forEach
+                }
                 when {
+                    // 自定义列类型
+                    member.hasColumnType -> add(member.name) {
+                        val colType = member.columnTypeSQL!!
+                        if (colType.isRequired) type(colType, member.length) { options(member) }
+                        else type(colType) { options(member) }
+                    }
+                    // IndexedEnum（数值存储）
+                    member.isIndexedEnum -> add(member.name) {
+                        type(ColumnTypeSQL.BIGINT) { options(member) }
+                    }
                     // 字符串
                     member.isString || member.isEnum -> add(member.name) {
                         // length == -1 时使用longtext

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
@@ -20,7 +20,33 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
                 add { id() }
             }
             type.members.forEach { member ->
+                // @LinkTable 成员：创建外键列而非展开关联类
+                if (member.isLinkTable) {
+                    val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+                    val linkedPrimary = linkedClass.primaryMember!!
+                    val fkColumnName = member.linkTableColumn!!
+                    add(fkColumnName) {
+                        when {
+                            linkedPrimary.hasColumnType -> type(linkedPrimary.columnTypeSQLite!!, linkedPrimary.length)
+                            linkedPrimary.isIndexedEnum -> type(ColumnTypeSQLite.INTEGER)
+                            linkedPrimary.isString || linkedPrimary.isEnum -> type(ColumnTypeSQLite.TEXT, linkedPrimary.length)
+                            linkedPrimary.isUUID -> type(ColumnTypeSQLite.TEXT, 36)
+                            linkedPrimary.canConvertedInteger() -> type(ColumnTypeSQLite.INTEGER)
+                            linkedPrimary.canConvertedDecimal() -> type(ColumnTypeSQLite.REAL)
+                            else -> type(ColumnTypeSQLite.TEXT)
+                        }
+                    }
+                    return@forEach
+                }
                 when {
+                    // 自定义列类型
+                    member.hasColumnType -> add(member.name) {
+                        type(member.columnTypeSQLite!!, member.length) { options(member) }
+                    }
+                    // IndexedEnum（数值存储）
+                    member.isIndexedEnum -> add(member.name) {
+                        type(ColumnTypeSQLite.INTEGER) { options(member) }
+                    }
                     // 字符串
                     member.isString || member.isEnum -> add(member.name) {
                         type(ColumnTypeSQLite.TEXT, member.length) { options(member) }
@@ -69,6 +95,8 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
 
     private fun ColumnSQLite.options(member: AnalyzedClassMember) {
         if (member.isPrimary) {
+            // ⚠ SQLite 的 PRIMARY KEY 强制唯一，与 SQL（MySQL）的 KEY（普通索引，不唯一）行为不同。
+            // 这导致 @Id + @Key 复合定位模式（同一 @Id 值多条记录）在 SQLite 下不可用。
             options(ColumnOptionSQLite.PRIMARY_KEY)
         }
         if (member.isUniqueKey) {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Cursor.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Cursor.kt
@@ -1,0 +1,102 @@
+package taboolib.expansion
+
+import java.io.Closeable
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+
+/**
+ * 游标查询结果，逐行从数据库读取数据，避免大量数据导致内存溢出。
+ *
+ * **必须在事务中使用**，以保证数据库连接不被断开：
+ * ```kotlin
+ * homeMapper.transaction {
+ *     selectCursor { "world" eq "overworld" }.use { cursor ->
+ *         for (home in cursor) {
+ *             // 逐条处理，内存中始终只有一条数据
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * 也可以使用 [forEach] 便捷方法，自动管理资源释放：
+ * ```kotlin
+ * homeMapper.transaction {
+ *     selectCursor { "world" eq "overworld" }.forEach { home ->
+ *         // 处理每条数据
+ *     }
+ * }
+ * ```
+ *
+ * @param statement 底层 PreparedStatement，游标关闭时释放
+ * @param resultSet 底层 ResultSet，逐行读取
+ * @param mapper 将 ResultSet 当前行映射为 T 的函数
+ */
+class Cursor<T>(
+    private val statement: PreparedStatement,
+    private val resultSet: ResultSet,
+    private val mapper: (ResultSet) -> T
+) : Iterable<T>, Closeable {
+
+    private var closed = false
+    private var iteratorCreated = false
+
+    override fun iterator(): Iterator<T> {
+        check(!closed) { "Cursor 已关闭" }
+        check(!iteratorCreated) { "Cursor 只能迭代一次" }
+        iteratorCreated = true
+        return CursorIterator()
+    }
+
+    override fun close() {
+        if (!closed) {
+            closed = true
+            runCatching { resultSet.close() }
+            runCatching { statement.close() }
+        }
+    }
+
+    /**
+     * 逐条处理游标数据，处理完毕后自动关闭游标。
+     *
+     * ```kotlin
+     * selectCursor { "world" eq "overworld" }.forEach { home ->
+     *     println(home)
+     * }
+     * ```
+     */
+    inline fun forEach(action: (T) -> Unit) {
+        use { cursor ->
+            for (item in cursor) {
+                action(item)
+            }
+        }
+    }
+
+    private inner class CursorIterator : Iterator<T> {
+
+        private var hasNextCalled = false
+        private var hasNextResult = false
+
+        override fun hasNext(): Boolean {
+            if (!hasNextCalled) {
+                hasNextResult = resultSet.next()
+                hasNextCalled = true
+                if (!hasNextResult) {
+                    close()
+                }
+            }
+            return hasNextResult
+        }
+
+        override fun next(): T {
+            if (!hasNextCalled) {
+                if (!resultSet.next()) {
+                    close()
+                    throw NoSuchElementException()
+                }
+            }
+            hasNextCalled = false
+            return mapper(resultSet)
+        }
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapper.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapper.kt
@@ -1,0 +1,186 @@
+package taboolib.expansion
+
+import taboolib.module.database.Action
+import taboolib.module.database.ActionDelete
+import taboolib.module.database.ActionSelect
+import taboolib.module.database.ActionUpdate
+import taboolib.module.database.Filter
+import java.sql.ResultSet
+
+/**
+ * 数据映射器接口，提供类型安全的 CRUD 操作入口。
+ *
+ * 通过 Kotlin by 委托使用：
+ * ```
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db"))
+ * ```
+ */
+interface DataMapper<T> {
+
+    // === 插入 ===
+    fun insert(data: T)
+    fun insertBatch(dataList: List<T>)
+    fun insertAndGetKey(data: T): Long
+    /** ⚠ SQLite 限制：批量插入时仅返回最后一条记录的自增 ID，返回列表长度可能为 1 而非 dataList.size */
+    fun insertBatchAndGetKeys(dataList: List<T>): List<Long>
+
+    // === 查询 ===
+    fun findById(id: Any, filter: Filter.() -> Unit = {}): T?
+    fun findAll(id: Any, filter: Filter.() -> Unit = {}): List<T>
+    fun findOne(filter: Filter.() -> Unit = {}): T?
+    fun findAll(filter: Filter.() -> Unit = {}): List<T>
+    /** 批量查询，通过多个 @Id 值查询（IN 子句） */
+    fun findByIds(ids: List<Any>): List<T>
+
+    // === 基于 @Key 的查询 ===
+    /** 通过 @Id + @Key 查询，返回所有匹配记录 */
+    fun findByKey(data: T): List<T>
+    /** 通过 @Id + @Key 查询，返回第一条匹配记录 */
+    fun findOneByKey(data: T): T?
+    /** 通过 @Id + @Key 检查记录是否存在 */
+    fun existsByKey(data: T): Boolean
+    /** 通过 @Id + @Key 删除匹配记录 */
+    fun deleteByKey(data: T)
+
+    // === 基于自增行 ID 的操作（用于无 @Id 字段的数据类）===
+    /** 通过框架自动生成的 `id` 列查询 */
+    fun findByRowId(rowId: Long): T?
+    /** 通过框架自动生成的 `id` 列删除 */
+    fun deleteByRowId(rowId: Long)
+
+    // === 排序 ===
+    fun sort(row: String, limit: Int = 10, filter: Filter.() -> Unit = {}): List<T>
+    fun sortDescending(row: String, limit: Int = 10, filter: Filter.() -> Unit = {}): List<T>
+
+    // === 分页 ===
+    /** 分页获取数据，返回包含总数信息的 [Page] 对象 */
+    fun findPage(page: Int, size: Int, filter: Filter.() -> Unit = {}): Page<T>
+    /** 分页正序排序，返回包含总数信息的 [Page] 对象 */
+    fun sortPage(row: String, page: Int, size: Int, filter: Filter.() -> Unit = {}): Page<T>
+    /** 分页倒序排序，返回包含总数信息的 [Page] 对象 */
+    fun sortDescendingPage(row: String, page: Int, size: Int, filter: Filter.() -> Unit = {}): Page<T>
+
+    // === 游标查询（必须在 transaction {} 中使用）===
+
+    /**
+     * 游标查询，逐行读取数据，避免大量数据导致内存溢出。
+     *
+     * **必须在 [transaction] 中使用**，否则抛出异常。
+     *
+     * ```kotlin
+     * homeMapper.transaction {
+     *     selectCursor { "world" eq "overworld" }.forEach { home ->
+     *         // 逐条处理
+     *     }
+     * }
+     * ```
+     */
+    fun selectCursor(filter: Filter.() -> Unit = {}): Cursor<T>
+
+    /** 游标查询（正序排序），必须在 [transaction] 中使用 */
+    fun sortCursor(row: String, filter: Filter.() -> Unit = {}): Cursor<T>
+
+    /** 游标查询（倒序排序），必须在 [transaction] 中使用 */
+    fun sortDescendingCursor(row: String, filter: Filter.() -> Unit = {}): Cursor<T>
+
+    // === 更新 ===
+    fun update(data: T, filter: Filter.() -> Unit = {})
+    fun updateByKey(data: T)
+    fun insertOrUpdate(data: T, filter: Filter.() -> Unit = {})
+    fun upsertBatch(dataList: List<T>)
+    /** 批量更新，通过 @Id + @Key 定位，使用 batch PreparedStatement */
+    fun updateBatch(dataList: List<T>)
+
+    // === 删除 ===
+    fun deleteById(id: Any, filter: Filter.() -> Unit = {})
+    fun deleteWhere(filter: Filter.() -> Unit)
+    /** 批量删除，通过多个 @Id 值删除（IN 子句） */
+    fun deleteByIds(ids: List<Any>)
+
+    // === 检查 ===
+    fun exists(id: Any, filter: Filter.() -> Unit = {}): Boolean
+    fun exists(filter: Filter.() -> Unit): Boolean
+
+    // === 计数 ===
+    fun count(filter: Filter.() -> Unit = {}): Long
+
+    // === 自定义 SQL ===
+
+    /** 表名 */
+    val tableName: String
+
+    /**
+     * 自定义 SELECT 查询，结果自动映射为 T
+     *
+     * ```kotlin
+     * homeTable.query { where { "world" eq "world_nether" }; limit(10) }
+     * ```
+     */
+    fun query(builder: ActionSelect.() -> Unit): List<T>
+
+    /**
+     * 自定义 SELECT 查询单条，结果自动映射为 T
+     */
+    fun queryOne(builder: ActionSelect.() -> Unit): T?
+
+    /**
+     * 自定义 SELECT 查询，自定义结果处理
+     *
+     * ```kotlin
+     * homeTable.rawQuery({ rows("world"); groupBy("world") }) { rs ->
+     *     buildList { while (rs.next()) add(rs.getString(1)) }
+     * }
+     * ```
+     */
+    fun <R> rawQuery(builder: ActionSelect.() -> Unit, handler: (ResultSet) -> R): R
+
+    /**
+     * 自定义 UPDATE 操作
+     *
+     * ```kotlin
+     * homeTable.rawUpdate { set("active", false); where { "world" eq "world_nether" } }
+     * ```
+     * @return 受影响的行数
+     */
+    fun rawUpdate(builder: ActionUpdate.() -> Unit): Int
+
+    /**
+     * 自定义 DELETE 操作
+     *
+     * ```kotlin
+     * homeTable.rawDelete { where { "active" eq false } }
+     * ```
+     * @return 受影响的行数
+     */
+    fun rawDelete(builder: ActionDelete.() -> Unit): Int
+
+    /**
+     * 执行任意 Action
+     *
+     * @return 受影响的行数
+     */
+    fun rawExecute(action: Action): Int
+
+    // === 多表联查 ===
+
+    /**
+     * 发起多表联查，主表自动填充为当前 DataMapper 对应的表
+     *
+     * ```kotlin
+     * homeTable.join {
+     *     innerJoin<PlayerStats> {
+     *         on("player_home.username" eq pre("player_stats.username"))
+     *     }
+     *     where { "player_home.active" eq true }
+     *     limit(10)
+     * }.mapTo<PlayerSummary>()
+     * ```
+     */
+    fun join(builder: JoinQuery.() -> Unit): JoinQuery
+
+    // === 事务 ===
+    fun <R> transaction(block: DataMapper<T>.() -> R): Result<R>
+
+    // === 生命周期 ===
+    fun close()
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapperImpl.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapperImpl.kt
@@ -1,0 +1,360 @@
+package taboolib.expansion
+
+import taboolib.expansion.AnalyzedClassMember.Companion.toColumnName
+import taboolib.module.database.*
+import java.sql.ResultSet
+
+/**
+ * DataMapper 的标准实现
+ *
+ * 封装 ContainerOperator，提供类型安全的 CRUD 操作。
+ * 支持可选的 L2 双层缓存。
+ *
+ * ### L2 缓存架构
+ *
+ * - **Bean Cache**：按实体 ID 存储，细粒度失效（更新/删除只影响特定 ID）
+ * - **Query Cache**：按查询哈希存储，粗粒度失效（任何写操作清空整个 Query Cache）
+ *
+ * ### 缓存失效策略
+ *
+ * | 操作类型 | Bean Cache | Query Cache |
+ * |---------|-----------|-------------|
+ * | 插入 | 不影响 | 全部清空 |
+ * | 单条更新/删除 | 仅失效该 ID | 全部清空 |
+ * | 批量/不确定范围 | 全部清空 | 全部清空 |
+ *
+ * @param type 数据类的 Class 对象
+ * @param container 持久化容器
+ * @param cache L2 双层缓存（可选）
+ */
+class DataMapperImpl<T>(
+    private val type: Class<T>,
+    private val container: PersistentContainer,
+    private val cache: L2Cache?
+) : DataMapper<T> {
+
+    private val operator: ContainerOperator
+        get() = container[type.simpleName.toColumnName()]
+
+    private val analyzedClass by lazy { AnalyzedClass.of(type) }
+
+    // === 插入 ===
+
+    override fun insert(data: T) {
+        operator.insert(listOf(data as Any))
+        invalidateOnInsert()
+    }
+
+    override fun insertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.insert(dataList as List<Any>)
+        invalidateOnInsert()
+    }
+
+    override fun insertAndGetKey(data: T): Long {
+        val keys = operator.insertAndGetKeys(listOf(data as Any))
+        invalidateOnInsert()
+        return keys.firstOrNull() ?: -1L
+    }
+
+    override fun insertBatchAndGetKeys(dataList: List<T>): List<Long> {
+        if (dataList.isEmpty()) return emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val keys = operator.insertAndGetKeys(dataList as List<Any>)
+        invalidateOnInsert()
+        return keys
+    }
+
+    // === 查询 ===
+
+    override fun findById(id: Any, filter: Filter.() -> Unit): T? {
+        return cachedBean("findById", id, filter) { operator.findOne(type, id, filter) }
+    }
+
+    override fun findAll(id: Any, filter: Filter.() -> Unit): List<T> {
+        return cachedBean("findAllById", id, filter) { operator.find(type, id, filter) }
+    }
+
+    override fun findOne(filter: Filter.() -> Unit): T? {
+        return cachedQuery("findOne", filter) { operator.getOne(type, filter) }
+    }
+
+    override fun findAll(filter: Filter.() -> Unit): List<T> {
+        return cachedQuery("findAll", filter) { operator.get(type, filter) }
+    }
+
+    override fun findByIds(ids: List<Any>): List<T> {
+        if (ids.isEmpty()) return emptyList()
+        return cachedQuery("findByIds", ids) { operator.findByIds(type, ids) }
+    }
+
+    // === 基于 @Key 的查询 ===
+
+    override fun findByKey(data: T): List<T> {
+        return cachedQuery("findByKey", data) { operator.findByKey(type, data as Any) }
+    }
+
+    override fun findOneByKey(data: T): T? {
+        return cachedQuery("findOneByKey", data) { operator.findOneByKey(type, data as Any) }
+    }
+
+    override fun existsByKey(data: T): Boolean {
+        return cachedQuery("existsByKey", data) { operator.hasByKey(type, data as Any) }
+    }
+
+    override fun deleteByKey(data: T) {
+        operator.deleteByKey(data as Any)
+        invalidateOnMutation(data as Any)
+    }
+
+    // === 基于自增行 ID 的操作 ===
+
+    override fun findByRowId(rowId: Long): T? {
+        return cachedBean("findByRowId", rowId) { operator.findByRowId(type, rowId) }
+    }
+
+    override fun deleteByRowId(rowId: Long) {
+        operator.deleteByRowId(rowId)
+        invalidateOnRowIdMutation(rowId)
+    }
+
+    // === 排序 ===
+
+    override fun sort(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return cachedQuery("sort", row, limit, filter) { operator.sort(type, row, limit, filter) }
+    }
+
+    override fun sortDescending(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return cachedQuery("sortDescending", row, limit, filter) { operator.sortDescending(type, row, limit, filter) }
+    }
+
+    // === 分页 ===
+
+    override fun findPage(page: Int, size: Int, filter: Filter.() -> Unit): Page<T> {
+        val content = cachedQuery("findPage", page, size, filter) { operator.getPage(type, page, size, filter) }
+        val total = cachedQuery("count", filter) { operator.count(filter) }
+        return Page(content, page, size, total)
+    }
+
+    override fun sortPage(row: String, page: Int, size: Int, filter: Filter.() -> Unit): Page<T> {
+        val content = cachedQuery("sortPage", row, page, size, filter) { operator.sortPage(type, row, page, size, filter) }
+        val total = cachedQuery("count", filter) { operator.count(filter) }
+        return Page(content, page, size, total)
+    }
+
+    override fun sortDescendingPage(row: String, page: Int, size: Int, filter: Filter.() -> Unit): Page<T> {
+        val content = cachedQuery("sortDescendingPage", row, page, size, filter) { operator.sortDescendingPage(type, row, page, size, filter) }
+        val total = cachedQuery("count", filter) { operator.count(filter) }
+        return Page(content, page, size, total)
+    }
+
+    // === 游标查询 ===
+
+    override fun selectCursor(filter: Filter.() -> Unit): Cursor<T> {
+        error("游标查询必须在 transaction {} 中使用")
+    }
+
+    override fun sortCursor(row: String, filter: Filter.() -> Unit): Cursor<T> {
+        error("游标查询必须在 transaction {} 中使用")
+    }
+
+    override fun sortDescendingCursor(row: String, filter: Filter.() -> Unit): Cursor<T> {
+        error("游标查询必须在 transaction {} 中使用")
+    }
+
+    // === 更新 ===
+
+    override fun update(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateOnMutation(data as Any)
+    }
+
+    override fun updateByKey(data: T) {
+        operator.updateByKey(data as Any)
+        invalidateOnMutation(data as Any)
+    }
+
+    override fun insertOrUpdate(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateOnMutation(data as Any)
+    }
+
+    override fun upsertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.upsert(dataList as List<Any>)
+        invalidateAll()
+    }
+
+    override fun updateBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.updateBatch(dataList as List<Any>)
+        invalidateAll()
+    }
+
+    // === 删除 ===
+
+    override fun deleteById(id: Any, filter: Filter.() -> Unit) {
+        operator.delete(type, id, filter)
+        invalidateOnIdMutation(id)
+    }
+
+    override fun deleteWhere(filter: Filter.() -> Unit) {
+        operator.deleteWhere(filter)
+        invalidateAll()
+    }
+
+    override fun deleteByIds(ids: List<Any>) {
+        if (ids.isEmpty()) return
+        operator.deleteByIds(type, ids)
+        invalidateAll()
+    }
+
+    // === 检查 ===
+
+    override fun exists(id: Any, filter: Filter.() -> Unit): Boolean {
+        return cachedBean("exists", id, filter) { operator.has(type, id, filter) }
+    }
+
+    override fun exists(filter: Filter.() -> Unit): Boolean {
+        return cachedQuery("existsFilter", filter) { operator.has(filter) }
+    }
+
+    // === 计数 ===
+
+    override fun count(filter: Filter.() -> Unit): Long {
+        return cachedQuery("count", filter) { operator.count(filter) }
+    }
+
+    // === 事务 ===
+
+    override fun <R> transaction(block: DataMapper<T>.() -> R): Result<R> {
+        return container.transaction {
+            val txOperator = operator(type.simpleName.toColumnName())
+            val txMapper = TransactionalDataMapper(type, txOperator, cache, connection)
+            txMapper.block()
+        }
+    }
+
+    // === 自定义 SQL ===
+
+    override val tableName: String
+        get() = operator.table.name
+
+    override fun query(builder: ActionSelect.() -> Unit): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action) { rs ->
+            buildList {
+                while (rs.next()) { add(typeClass.createInstance<T>(typeClass.read(rs))) }
+            }
+        }
+    }
+
+    override fun queryOne(builder: ActionSelect.() -> Unit): T? {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply { builder(); limit(1) }
+        return operator.select(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun <R> rawQuery(builder: ActionSelect.() -> Unit, handler: (ResultSet) -> R): R {
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action, handler)
+    }
+
+    override fun rawUpdate(builder: ActionUpdate.() -> Unit): Int {
+        val action = ActionUpdate(tableName).apply(builder)
+        val result = operator.execute(action)
+        invalidateAll()
+        return result
+    }
+
+    override fun rawDelete(builder: ActionDelete.() -> Unit): Int {
+        val action = ActionDelete(tableName).apply(builder)
+        val result = operator.execute(action)
+        invalidateAll()
+        return result
+    }
+
+    override fun rawExecute(action: Action): Int {
+        val result = operator.execute(action)
+        invalidateAll()
+        return result
+    }
+
+    // === 多表联查 ===
+
+    override fun join(builder: JoinQuery.() -> Unit): JoinQuery {
+        return container.join {
+            from(tableName)
+            builder()
+        }
+    }
+
+    // === 生命周期 ===
+
+    override fun close() = container.close()
+
+    // === 缓存辅助 ===
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <R> cachedBean(method: String, vararg args: Any?, query: () -> R): R {
+        if (cache == null) return query()
+        val key = buildCacheKey(method, *args)
+        return cache.beanCache.get(key) { query() } as R
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <R> cachedQuery(method: String, vararg args: Any?, query: () -> R): R {
+        if (cache == null) return query()
+        val key = buildCacheKey(method, *args)
+        return cache.queryCache.get(key) { query() } as R
+    }
+
+    private fun buildCacheKey(method: String, vararg args: Any?): String {
+        return "$method:${args.joinToString(",") { it?.toString() ?: "null" }}"
+    }
+
+    // === L2 缓存失效策略 ===
+
+    /** 插入后：仅清空 Query Cache */
+    private fun invalidateOnInsert() {
+        cache?.queryCache?.invalidateAll()
+    }
+
+    /** 单条更新/删除后（按 ID）：失效该 ID 的 Bean Cache + 清空 Query Cache */
+    private fun invalidateOnIdMutation(id: Any) {
+        if (cache == null) return
+        cache.beanCache.invalidateByPrefix("findById:$id")
+        cache.beanCache.invalidateByPrefix("findAllById:$id")
+        cache.beanCache.invalidateByPrefix("exists:$id")
+        cache.queryCache.invalidateAll()
+    }
+
+    /** 从数据对象提取 @Id 值，失效该 ID 的 Bean Cache + 清空 Query Cache */
+    private fun invalidateOnMutation(data: Any) {
+        if (cache == null) return
+        val id = analyzedClass.getPrimaryMemberValue(data)
+        if (id != null) {
+            invalidateOnIdMutation(id)
+        } else {
+            invalidateAll()
+        }
+    }
+
+    /** 失效指定行 ID 的 Bean Cache + 清空 Query Cache */
+    private fun invalidateOnRowIdMutation(rowId: Long) {
+        if (cache == null) return
+        cache.beanCache.invalidate(buildCacheKey("findByRowId", rowId))
+        cache.queryCache.invalidateAll()
+    }
+
+    /** 批量/不确定范围：全部清空 */
+    private fun invalidateAll() {
+        cache?.invalidateAll()
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/IndexedEnum.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/IndexedEnum.kt
@@ -1,0 +1,29 @@
+package taboolib.expansion
+
+/**
+ * 索引枚举接口
+ *
+ * 实现此接口的枚举类在数据库中将以 [index] 数值存储，而非枚举名称字符串。
+ * 读取时自动通过 [index] 值匹配回对应的枚举常量。
+ *
+ * ```kotlin
+ * enum class TypeEnum(override val index: Long, val desc: String) : IndexedEnum {
+ *     TYPE1(1, "类型1"),
+ *     TYPE2(2, "类型2"),
+ *     TYPE3(3, "类型3"),
+ * }
+ * ```
+ *
+ * 数据库列类型：MySQL 使用 `BIGINT`，SQLite 使用 `INTEGER`。
+ *
+ * 在 WHERE 条件中传入枚举值时，自动使用 [index] 进行 SQL 参数拼接：
+ * ```kotlin
+ * homeMapper.findAll { "type_enum" eq TypeEnum.TYPE1 }
+ * // 生成 SQL: SELECT * FROM ... WHERE `type_enum` = 1
+ * ```
+ */
+interface IndexedEnum {
+
+    /** 枚举在数据库中存储的数值索引 */
+    val index: Long
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/JoinQuery.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/JoinQuery.kt
@@ -92,9 +92,76 @@ class JoinQuery internal constructor(
         return this
     }
 
+    /** 内连接（子查询） */
+    fun innerJoin(sub: SubQuery, on: JoinFilter.() -> Unit): JoinQuery {
+        joins += JoinDef(JoinDefType.INNER, sub.sql, on, sub.params)
+        return this
+    }
+
+    /** 左连接（子查询） */
+    fun leftJoin(sub: SubQuery, on: JoinFilter.() -> Unit): JoinQuery {
+        joins += JoinDef(JoinDefType.LEFT, sub.sql, on, sub.params)
+        return this
+    }
+
+    /** 右连接（子查询） */
+    fun rightJoin(sub: SubQuery, on: JoinFilter.() -> Unit): JoinQuery {
+        joins += JoinDef(JoinDefType.RIGHT, sub.sql, on, sub.params)
+        return this
+    }
+
+    /** 内连接（原始 SQL + 参数） */
+    fun innerJoin(name: String, params: List<Any>, on: JoinFilter.() -> Unit): JoinQuery {
+        joins += JoinDef(JoinDefType.INNER, name, on, params)
+        return this
+    }
+
+    /** 左连接（原始 SQL + 参数） */
+    fun leftJoin(name: String, params: List<Any>, on: JoinFilter.() -> Unit): JoinQuery {
+        joins += JoinDef(JoinDefType.LEFT, name, on, params)
+        return this
+    }
+
+    /** 右连接（原始 SQL + 参数） */
+    fun rightJoin(name: String, params: List<Any>, on: JoinFilter.() -> Unit): JoinQuery {
+        joins += JoinDef(JoinDefType.RIGHT, name, on, params)
+        return this
+    }
+
     /** 指定查询列 */
     fun select(vararg rows: String): JoinQuery {
         columns = arrayOf(*rows)
+        return this
+    }
+
+    /**
+     * 指定查询列并设置别名
+     *
+     * 解决多表联查中同名列冲突问题。别名将作为 BundleMap 的 key，
+     * 同时也是 mapTo 匹配 data class 字段名的依据。
+     *
+     * ```kotlin
+     * homeTable.join {
+     *     innerJoin<PlayerStats> {
+     *         on("player_home.username" eq pre("player_stats.username"))
+     *     }
+     *     selectAs(
+     *         "player_home.username" to "username",
+     *         "player_home.world" to "world",
+     *         "player_stats.level" to "level",
+     *         "player_stats.username" to "stats_username"
+     *     )
+     * }.mapTo<PlayerSummary>()
+     * // PlayerSummary(val username: String, val world: String, val level: Int, val statsUsername: String)
+     * ```
+     *
+     * @param pairs 列名 to 别名
+     */
+    fun selectAs(vararg pairs: Pair<String, String>): JoinQuery {
+        columns = pairs.map { (col, alias) ->
+            val formattedCol = col.split(".").joinToString(".") { "`$it`" }
+            "$formattedCol AS `$alias`"
+        }.toTypedArray()
         return this
     }
 
@@ -182,9 +249,9 @@ class JoinQuery internal constructor(
             columns?.also { rows(*it) }
             joins.forEach { def ->
                 when (def.type) {
-                    JoinDefType.INNER -> innerJoin(def.table, def.on)
-                    JoinDefType.LEFT -> leftJoin(def.table, def.on)
-                    JoinDefType.RIGHT -> rightJoin(def.table, def.on)
+                    JoinDefType.INNER -> innerJoin(def.table, def.params, def.on)
+                    JoinDefType.LEFT -> leftJoin(def.table, def.params, def.on)
+                    JoinDefType.RIGHT -> rightJoin(def.table, def.params, def.on)
                 }
             }
             filterFunc?.also { where(it) }
@@ -231,6 +298,10 @@ class JoinQuery internal constructor(
             member.isChar -> raw.cint.toChar()
             member.isString -> raw.toString()
             member.isUUID -> UUID.fromString(raw.toString())
+            member.isIndexedEnum -> {
+                val idx = raw.clong
+                member.returnType.enumConstants.firstOrNull { (it as IndexedEnum).index == idx }
+            }
             member.isEnum -> member.returnType.enumConstants.firstOrNull { (it as Enum<*>).name == raw.toString() }
             member.isByteArray -> raw.cByteArray
             else -> {
@@ -240,7 +311,54 @@ class JoinQuery internal constructor(
         }
     }
 
-    private data class JoinDef(val type: JoinDefType, val table: String, val on: JoinFilter.() -> Unit)
+    private data class JoinDef(val type: JoinDefType, val table: String, val on: JoinFilter.() -> Unit, val params: List<Any> = emptyList())
 
     private enum class JoinDefType { INNER, LEFT, RIGHT }
+}
+
+/**
+ * 子查询定义
+ *
+ * 复用 [ActionSelect] 构建 SQL 和收集参数，用于 [JoinQuery] 的子查询 JOIN。
+ *
+ * @see subQuery
+ */
+class SubQuery(val alias: String, private val action: ActionSelect) {
+
+    /** 生成 `(SELECT ...) AS \`alias\`` 格式的 SQL 片段 */
+    val sql: String get() = "(${action.query}) AS `$alias`"
+
+    /** 子查询中的参数列表 */
+    val params: List<Any> get() = action.elements
+}
+
+/**
+ * 构建子查询 DSL
+ *
+ * 复用 [ActionSelect] 的全部能力（rows/where/groupBy/orderBy/limit 等），
+ * 自动收集参数用于 PreparedStatement 绑定。
+ *
+ * ```kotlin
+ * homeMapper.join {
+ *     from("`player_home` AS `h`")
+ *     innerJoin(
+ *         subQuery("player_stats", "sub") {
+ *             rows("username", "SUM(kills) AS total_kills")
+ *             where { "kills" gt 50 }
+ *             groupBy("username")
+ *         }
+ *     ) {
+ *         on("h.username" eq pre("sub.username"))
+ *     }
+ *     selectAs("h.username" to "username", "sub.total_kills" to "total_kills")
+ *     where { "h.world" eq "world" }
+ * }.execute()
+ * ```
+ *
+ * @param table 子查询的源表名
+ * @param alias 子查询的别名，用于外层 ON/WHERE/selectAs 引用
+ * @param builder ActionSelect DSL
+ */
+fun subQuery(table: String, alias: String, builder: ActionSelect.() -> Unit): SubQuery {
+    return SubQuery(alias, ActionSelect(table).apply(builder))
 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
@@ -1,0 +1,123 @@
+package taboolib.expansion
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Mapper 配置
+ */
+class MapperConfig<T> {
+    internal var cacheInstance: L2Cache? = null
+
+    /**
+     * 使用内置 L2 双层缓存
+     *
+     * ```kotlin
+     * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+     *     cache {
+     *         beanCache { maximumSize = 10000; expireAfterAccess = 600 }
+     *         queryCache { maximumSize = 1000; expireAfterAccess = 600 }
+     *     }
+     * }
+     * ```
+     */
+    fun cache(block: L2CacheConfig.() -> Unit) {
+        cacheInstance = L2Cache(L2CacheConfig().apply(block))
+    }
+
+    /**
+     * 使用自定义 DataCache 实现构建 L2 缓存
+     *
+     * ```kotlin
+     * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+     *     cache(MyCaffeineCache(), MyCaffeineCache())
+     * }
+     * ```
+     */
+    fun cache(beanCache: DataCache, queryCache: DataCache) {
+        cacheInstance = L2Cache(beanCache, queryCache)
+    }
+
+    /**
+     * 使用同一个自定义 DataCache 实现作为 Bean Cache 和 Query Cache
+     *
+     * 适用于用户自行实现 Redis、Caffeine 等缓存后端的场景。
+     *
+     * ```kotlin
+     * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+     *     cache(MyRedisCache())
+     * }
+     * ```
+     */
+    fun cache(cache: DataCache) {
+        cacheInstance = L2Cache(cache, cache)
+    }
+}
+
+/**
+ * 创建 DataMapper 属性委托
+ *
+ * 缓存默认关闭，需要显式调用 `cache {}` 开启。
+ *
+ * ```kotlin
+ * // 不带缓存（默认）
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db"))
+ *
+ * // 使用内置 L2 缓存
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache {
+ *         beanCache { maximumSize = 10000; expireAfterAccess = 600 }
+ *         queryCache { maximumSize = 1000; expireAfterAccess = 600 }
+ *     }
+ * }
+ *
+ * // 使用自定义缓存
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache(MyCaffeineCache(), MyCaffeineCache())
+ * }
+ *
+ * // 使用同一个自定义缓存实现
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache(MyRedisCache())
+ * }
+ * ```
+ */
+inline fun <reified T> mapper(
+    source: Any = db(),
+    flags: List<String> = emptyList(),
+    clearFlags: Boolean = false,
+    ssl: String? = null,
+    noinline config: MapperConfig<T>.() -> Unit = {}
+): ReadOnlyProperty<Any?, DataMapper<T>> {
+    return MapperDelegate(T::class.java, source, flags, clearFlags, ssl, config)
+}
+
+/**
+ * 属性委托实现，懒加载创建容器和 DataMapper
+ */
+class MapperDelegate<T>(
+    private val type: Class<T>,
+    private val source: Any,
+    private val flags: List<String>,
+    private val clearFlags: Boolean,
+    private val ssl: String?,
+    private val config: MapperConfig<T>.() -> Unit
+) : ReadOnlyProperty<Any?, DataMapper<T>> {
+
+    @Volatile
+    private var instance: DataMapper<T>? = null
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): DataMapper<T> {
+        return instance ?: synchronized(this) {
+            instance ?: createMapper().also { instance = it }
+        }
+    }
+
+    private fun createMapper(): DataMapper<T> {
+        val mapperConfig = MapperConfig<T>().apply(config)
+        val container = persistentContainer(source, flags, clearFlags, ssl) {
+            new(type)
+        }
+        return DataMapperImpl(type, container, mapperConfig.cacheInstance)
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Page.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Page.kt
@@ -1,0 +1,29 @@
+package taboolib.expansion
+
+/**
+ * 分页查询结果
+ *
+ * @param content 当前页数据
+ * @param page 当前页码（从 1 开始）
+ * @param size 每页大小
+ * @param total 总记录数
+ */
+data class Page<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val total: Long
+) {
+
+    /** 总页数 */
+    val totalPages: Int
+        get() = if (size > 0) ((total + size - 1) / size).toInt() else 0
+
+    /** 是否有下一页 */
+    val hasNext: Boolean
+        get() = page < totalPages
+
+    /** 是否有上一页 */
+    val hasPrevious: Boolean
+        get() = page > 1
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/PersistentContainer.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/PersistentContainer.kt
@@ -151,6 +151,26 @@ class PersistentContainer {
     }
 
     /**
+     * 创建 DataMapper（用于已有容器场景）
+     *
+     * @param cache 可选的 L2 双层缓存
+     */
+    inline fun <reified T> mapper(cache: L2Cache? = null): DataMapper<T> {
+        return DataMapperImpl(T::class.java, this, cache)
+    }
+
+    /**
+     * 创建 DataMapper，使用自定义 DataCache 实现
+     *
+     * 传入的 DataCache 同时用于 Bean Cache 和 Query Cache。
+     *
+     * @param cache 自定义缓存实现（如 Redis、Caffeine 等）
+     */
+    inline fun <reified T> mapper(cache: DataCache): DataMapper<T> {
+        return DataMapperImpl(T::class.java, this, L2Cache(cache, cache))
+    }
+
+    /**
      * 关闭容器
      */
     fun close() {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/QueryCache.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/QueryCache.kt
@@ -1,0 +1,181 @@
+package taboolib.expansion
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * 数据缓存接口
+ *
+ * 用户可实现此接口来自定义缓存策略（如 Redis、Caffeine 等），
+ * 然后通过 `cache(myCache)` 传入 mapper DSL。
+ *
+ * ```kotlin
+ * // 使用自定义缓存
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache(MyCaffeineCache())
+ * }
+ *
+ * // 为 Bean Cache 和 Query Cache 分别指定不同实现
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache(beanCache = MyRedisCache(), queryCache = MyCaffeineCache())
+ * }
+ * ```
+ *
+ * ### 自定义实现示例
+ *
+ * ```kotlin
+ * class MyCaffeineCache : DataCache {
+ *     private val caffeine = Caffeine.newBuilder().maximumSize(1000).build<String, Any?>()
+ *     override fun get(key: String, loader: () -> Any?) = caffeine.get(key) { loader() }
+ *     override fun put(key: String, value: Any?) = caffeine.put(key, value)
+ *     override fun invalidate(key: String) = caffeine.invalidate(key)
+ *     override fun invalidateByPrefix(prefix: String) {
+ *         caffeine.asMap().keys.removeIf { it.startsWith(prefix) }
+ *     }
+ *     override fun invalidateAll() = caffeine.invalidateAll()
+ * }
+ * ```
+ */
+interface DataCache {
+
+    /**
+     * 从缓存中获取值，未命中时调用 loader 加载并写入缓存
+     *
+     * @param key 缓存键（由方法名+参数自动构建）
+     * @param loader 缓存未命中时的加载函数
+     * @return 缓存值或 loader 返回值
+     */
+    fun get(key: String, loader: () -> Any?): Any?
+
+    /**
+     * 直接写入缓存条目
+     */
+    fun put(key: String, value: Any?)
+
+    /**
+     * 使指定 key 的缓存失效
+     */
+    fun invalidate(key: String)
+
+    /**
+     * 使所有以指定前缀开头的缓存失效
+     *
+     * 例如 `invalidateByPrefix("findAll:")` 会清除所有 `findAll:*` 缓存
+     */
+    fun invalidateByPrefix(prefix: String)
+
+    /**
+     * 清除所有缓存条目
+     */
+    fun invalidateAll()
+}
+
+/**
+ * 通用缓存区域配置
+ */
+class CacheConfig {
+    var maximumSize: Int = 256
+    var expireAfterWrite: Long = 0   // 秒，0 = 不过期
+    var expireAfterAccess: Long = 0  // 秒，0 = 不过期
+}
+
+/**
+ * 基于 ConcurrentHashMap 的内置缓存实现
+ *
+ * - 查询时：以方法名+参数构建 key，命中则返回缓存值
+ * - 写入时：按前缀或精确 key 失效受影响的缓存
+ * - 支持 TTL 过期和最大容量限制
+ */
+class DefaultCache(private val config: CacheConfig) : DataCache {
+
+    private data class CacheEntry(val value: Any?, val writeTime: Long, var accessTime: Long)
+
+    private val store = ConcurrentHashMap<String, CacheEntry>()
+
+    override fun get(key: String, loader: () -> Any?): Any? {
+        val entry = store[key]
+        if (entry != null && !isExpired(entry)) {
+            entry.accessTime = System.currentTimeMillis()
+            return entry.value
+        }
+        val value = loader()
+        put(key, value)
+        return value
+    }
+
+    override fun put(key: String, value: Any?) {
+        evictIfNeeded()
+        val now = System.currentTimeMillis()
+        store[key] = CacheEntry(value, now, now)
+    }
+
+    override fun invalidate(key: String) {
+        store.remove(key)
+    }
+
+    override fun invalidateByPrefix(prefix: String) {
+        store.keys.removeIf { it.startsWith(prefix) }
+    }
+
+    override fun invalidateAll() {
+        store.clear()
+    }
+
+    private fun isExpired(entry: CacheEntry): Boolean {
+        val now = System.currentTimeMillis()
+        if (config.expireAfterWrite > 0 && now - entry.writeTime > config.expireAfterWrite * 1000) return true
+        if (config.expireAfterAccess > 0 && now - entry.accessTime > config.expireAfterAccess * 1000) return true
+        return false
+    }
+
+    private fun evictIfNeeded() {
+        // 先清除过期条目
+        store.entries.removeIf { isExpired(it.value) }
+        // 超出容量则移除最旧的
+        while (store.size >= config.maximumSize) {
+            val oldest = store.entries.minByOrNull { it.value.accessTime } ?: break
+            store.remove(oldest.key)
+        }
+    }
+}
+
+/**
+ * L2 双层缓存配置
+ *
+ * - **beanCache**：按实体 ID 存储，细粒度失效（更新/删除只影响特定 ID）
+ * - **queryCache**：按查询哈希存储，粗粒度失效（任何写操作清空整个 Query Cache）
+ *
+ * ```kotlin
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     cache {
+ *         beanCache { maximumSize = 10000; expireAfterAccess = 600 }
+ *         queryCache { maximumSize = 1000; expireAfterAccess = 600 }
+ *     }
+ * }
+ * ```
+ */
+class L2CacheConfig {
+    val beanCache = CacheConfig().apply { maximumSize = 10000 }
+    val queryCache = CacheConfig().apply { maximumSize = 1000 }
+    fun beanCache(block: CacheConfig.() -> Unit) { beanCache.apply(block) }
+    fun queryCache(block: CacheConfig.() -> Unit) { queryCache.apply(block) }
+}
+
+/**
+ * L2 双层缓存
+ * - **beanCache**：按实体 ID 存储，细粒度失效
+ * - **queryCache**：按查询哈希存储，粗粒度失效
+ */
+class L2Cache(
+    val beanCache: DataCache,
+    val queryCache: DataCache
+) {
+    constructor(config: L2CacheConfig) : this(
+        DefaultCache(config.beanCache),
+        DefaultCache(config.queryCache)
+    )
+
+    fun invalidateAll() {
+        beanCache.invalidateAll()
+        queryCache.invalidateAll()
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionContext.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionContext.kt
@@ -56,6 +56,27 @@ class TransactionContext internal constructor(
     }
 
     /**
+     * 在事务中插入单条数据
+     */
+    inline fun <reified T> insert(data: T) {
+        get<T>().insert(listOf(data as Any))
+    }
+
+    /**
+     * 在事务中更新数据
+     */
+    inline fun <reified T> update(data: T) {
+        get<T>().update(data as Any)
+    }
+
+    /**
+     * 在事务中删除数据
+     */
+    inline fun <reified T> delete(id: Any) {
+        get<T>().delete(T::class.java, id)
+    }
+
+    /**
      * 标记事务回滚
      *
      * 调用此方法后，事务将在 block 执行完毕后回滚，

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionalDataMapper.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionalDataMapper.kt
@@ -1,0 +1,297 @@
+package taboolib.expansion
+
+import taboolib.module.database.*
+import java.sql.Connection
+import java.sql.ResultSet
+
+/**
+ * 事务内的 DataMapper 实现
+ *
+ * 使用事务感知的 ContainerOperator，所有操作共享同一个数据库连接。
+ * 不支持嵌套事务，调用 transaction() 会抛出异常。
+ *
+ * 事务内不使用缓存读取（保证事务一致性），但写入操作会失效外层 L2 缓存。
+ */
+class TransactionalDataMapper<T>(
+    private val type: Class<T>,
+    private val operator: ContainerOperator,
+    private val cache: L2Cache?,
+    private val sharedConnection: Connection? = null
+) : DataMapper<T> {
+
+    private val analyzedClass by lazy { AnalyzedClass.of(type) }
+
+    // === 插入 ===
+
+    override fun insert(data: T) {
+        operator.insert(listOf(data as Any))
+        invalidateOnInsert()
+    }
+
+    override fun insertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.insert(dataList as List<Any>)
+        invalidateOnInsert()
+    }
+
+    override fun insertAndGetKey(data: T): Long {
+        val keys = operator.insertAndGetKeys(listOf(data as Any))
+        invalidateOnInsert()
+        return keys.firstOrNull() ?: -1L
+    }
+
+    override fun insertBatchAndGetKeys(dataList: List<T>): List<Long> {
+        if (dataList.isEmpty()) return emptyList()
+        @Suppress("UNCHECKED_CAST")
+        val keys = operator.insertAndGetKeys(dataList as List<Any>)
+        invalidateOnInsert()
+        return keys
+    }
+
+    // === 查询（事务内不使用缓存，直接查库）===
+
+    override fun findById(id: Any, filter: Filter.() -> Unit): T? = operator.findOne(type, id, filter)
+    override fun findAll(id: Any, filter: Filter.() -> Unit): List<T> = operator.find(type, id, filter)
+    override fun findOne(filter: Filter.() -> Unit): T? = operator.getOne(type, filter)
+    override fun findAll(filter: Filter.() -> Unit): List<T> = operator.get(type, filter)
+
+    override fun findByIds(ids: List<Any>): List<T> {
+        if (ids.isEmpty()) return emptyList()
+        return operator.findByIds(type, ids)
+    }
+
+    // === 基于 @Key 的查询 ===
+
+    override fun findByKey(data: T): List<T> = operator.findByKey(type, data as Any)
+    override fun findOneByKey(data: T): T? = operator.findOneByKey(type, data as Any)
+    override fun existsByKey(data: T): Boolean = operator.hasByKey(type, data as Any)
+
+    override fun deleteByKey(data: T) {
+        operator.deleteByKey(data as Any)
+        invalidateOnMutation(data as Any)
+    }
+
+    // === 基于自增行 ID 的操作 ===
+
+    override fun findByRowId(rowId: Long): T? = operator.findByRowId(type, rowId)
+
+    override fun deleteByRowId(rowId: Long) {
+        operator.deleteByRowId(rowId)
+        invalidateOnRowIdMutation(rowId)
+    }
+
+    // === 排序 ===
+
+    override fun sort(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return operator.sort(type, row, limit, filter)
+    }
+
+    override fun sortDescending(row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
+        return operator.sortDescending(type, row, limit, filter)
+    }
+
+    // === 分页 ===
+
+    override fun findPage(page: Int, size: Int, filter: Filter.() -> Unit): Page<T> {
+        val content = operator.getPage(type, page, size, filter)
+        val total = operator.count(filter)
+        return Page(content, page, size, total)
+    }
+
+    override fun sortPage(row: String, page: Int, size: Int, filter: Filter.() -> Unit): Page<T> {
+        val content = operator.sortPage(type, row, page, size, filter)
+        val total = operator.count(filter)
+        return Page(content, page, size, total)
+    }
+
+    override fun sortDescendingPage(row: String, page: Int, size: Int, filter: Filter.() -> Unit): Page<T> {
+        val content = operator.sortDescendingPage(type, row, page, size, filter)
+        val total = operator.count(filter)
+        return Page(content, page, size, total)
+    }
+
+    // === 游标查询 ===
+
+    override fun selectCursor(filter: Filter.() -> Unit): Cursor<T> {
+        return operator.selectCursor(type, filter)
+    }
+
+    override fun sortCursor(row: String, filter: Filter.() -> Unit): Cursor<T> {
+        return operator.sortCursor(type, row, filter)
+    }
+
+    override fun sortDescendingCursor(row: String, filter: Filter.() -> Unit): Cursor<T> {
+        return operator.sortDescendingCursor(type, row, filter)
+    }
+
+    // === 更新 ===
+
+    override fun update(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateOnMutation(data as Any)
+    }
+
+    override fun updateByKey(data: T) {
+        operator.updateByKey(data as Any)
+        invalidateOnMutation(data as Any)
+    }
+
+    override fun insertOrUpdate(data: T, filter: Filter.() -> Unit) {
+        operator.update(data as Any, true, filter)
+        invalidateOnMutation(data as Any)
+    }
+
+    override fun upsertBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.upsert(dataList as List<Any>)
+        invalidateAll()
+    }
+
+    override fun updateBatch(dataList: List<T>) {
+        if (dataList.isEmpty()) return
+        @Suppress("UNCHECKED_CAST")
+        operator.updateBatch(dataList as List<Any>)
+        invalidateAll()
+    }
+
+    // === 删除 ===
+
+    override fun deleteById(id: Any, filter: Filter.() -> Unit) {
+        operator.delete(type, id, filter)
+        invalidateOnIdMutation(id)
+    }
+
+    override fun deleteWhere(filter: Filter.() -> Unit) {
+        operator.deleteWhere(filter)
+        invalidateAll()
+    }
+
+    override fun deleteByIds(ids: List<Any>) {
+        if (ids.isEmpty()) return
+        operator.deleteByIds(type, ids)
+        invalidateAll()
+    }
+
+    // === 检查 ===
+
+    override fun exists(id: Any, filter: Filter.() -> Unit): Boolean = operator.has(type, id, filter)
+    override fun exists(filter: Filter.() -> Unit): Boolean = operator.has(filter)
+
+    // === 计数 ===
+
+    override fun count(filter: Filter.() -> Unit): Long = operator.count(filter)
+
+    // === 事务 ===
+
+    override fun <R> transaction(block: DataMapper<T>.() -> R): Result<R> {
+        error("Nested transactions are not supported")
+    }
+
+    // === 自定义 SQL ===
+
+    override val tableName: String
+        get() = operator.table.name
+
+    override fun query(builder: ActionSelect.() -> Unit): List<T> {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action) { rs ->
+            buildList {
+                while (rs.next()) { add(typeClass.createInstance<T>(typeClass.read(rs))) }
+            }
+        }
+    }
+
+    override fun queryOne(builder: ActionSelect.() -> Unit): T? {
+        val typeClass = AnalyzedClass.of(type)
+        val action = ActionSelect(tableName).apply { builder(); limit(1) }
+        return operator.select(action) { rs ->
+            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
+        }
+    }
+
+    override fun <R> rawQuery(builder: ActionSelect.() -> Unit, handler: (ResultSet) -> R): R {
+        val action = ActionSelect(tableName).apply(builder)
+        return operator.select(action, handler)
+    }
+
+    override fun rawUpdate(builder: ActionUpdate.() -> Unit): Int {
+        val action = ActionUpdate(tableName).apply(builder)
+        val result = operator.execute(action)
+        invalidateAll()
+        return result
+    }
+
+    override fun rawDelete(builder: ActionDelete.() -> Unit): Int {
+        val action = ActionDelete(tableName).apply(builder)
+        val result = operator.execute(action)
+        invalidateAll()
+        return result
+    }
+
+    override fun rawExecute(action: Action): Int {
+        val result = operator.execute(action)
+        invalidateAll()
+        return result
+    }
+
+    // === 多表联查 ===
+
+    override fun join(builder: JoinQuery.() -> Unit): JoinQuery {
+        return JoinQuery(operator.dataSource, sharedConnection).also {
+            it.from(tableName)
+            builder(it)
+        }
+    }
+
+    // === 生命周期 ===
+
+    override fun close() {
+        error("Cannot close container within a transaction")
+    }
+
+    // === L2 缓存失效策略 ===
+
+    private fun buildCacheKey(method: String, vararg args: Any?): String {
+        return "$method:${args.joinToString(",") { it?.toString() ?: "null" }}"
+    }
+
+    /** 插入后：仅清空 Query Cache */
+    private fun invalidateOnInsert() {
+        cache?.queryCache?.invalidateAll()
+    }
+
+    /** 单条更新/删除后（按 ID）：失效该 ID 的 Bean Cache + 清空 Query Cache */
+    private fun invalidateOnIdMutation(id: Any) {
+        if (cache == null) return
+        cache.beanCache.invalidateByPrefix("findById:$id")
+        cache.beanCache.invalidateByPrefix("findAllById:$id")
+        cache.beanCache.invalidateByPrefix("exists:$id")
+        cache.queryCache.invalidateAll()
+    }
+
+    /** 从数据对象提取 @Id 值，失效该 ID 的 Bean Cache + 清空 Query Cache */
+    private fun invalidateOnMutation(data: Any) {
+        if (cache == null) return
+        val id = analyzedClass.getPrimaryMemberValue(data)
+        if (id != null) {
+            invalidateOnIdMutation(id)
+        } else {
+            invalidateAll()
+        }
+    }
+
+    /** 失效指定行 ID 的 Bean Cache + 清空 Query Cache */
+    private fun invalidateOnRowIdMutation(rowId: Long) {
+        if (cache == null) return
+        cache.beanCache.invalidate(buildCacheKey("findByRowId", rowId))
+        cache.queryCache.invalidateAll()
+    }
+
+    /** 批量/不确定范围：全部清空 */
+    private fun invalidateAll() {
+        cache?.invalidateAll()
+    }
+}

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/LinkTableTest.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/LinkTableTest.kt
@@ -1,0 +1,347 @@
+package taboolib.expansion
+
+import com.zaxxer.hikari.HikariDataSource
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LinkTableTest {
+
+    private lateinit var ds: HikariDataSource
+    private lateinit var container: TestContainer
+
+    @BeforeEach
+    fun setUp() {
+        AnalyzedClass.cached.clear()
+        ds = createTestDataSource()
+        container = TestContainer(ds)
+        // 先创建被关联的表
+        container.new<MultiKeyData>()
+        // 再创建含 @LinkTable 的表
+        container.new<LinkedSimpleData>()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ds.close()
+    }
+
+    @Test
+    fun `insert and find with linked object`() {
+        val linked = MultiKeyData("mk1", "catA", "subA", 100)
+        container.get<MultiKeyData>().insert(listOf(linked))
+
+        val data = LinkedSimpleData("s1", 42, linked)
+        container.get<LinkedSimpleData>().insert(listOf(data))
+
+        val found = container.get<LinkedSimpleData>().findOne(LinkedSimpleData::class.java, "s1")
+        assertNotNull(found)
+        assertEquals("s1", found!!.id)
+        assertEquals(42, found.value)
+        assertNotNull(found.testData)
+        assertEquals("mk1", found.testData!!.id)
+        assertEquals("catA", found.testData!!.category)
+        assertEquals("subA", found.testData!!.subCategory)
+        assertEquals(100, found.testData!!.score)
+    }
+
+    @Test
+    fun `find with null linked object (LEFT JOIN)`() {
+        // 插入一条主表数据，FK 为 null
+        val data = LinkedSimpleData("s2", 10, null)
+        container.get<LinkedSimpleData>().insert(listOf(data))
+
+        val found = container.get<LinkedSimpleData>().findOne(LinkedSimpleData::class.java, "s2")
+        assertNotNull(found)
+        assertEquals("s2", found!!.id)
+        assertEquals(10, found.value)
+        assertNull(found.testData)
+    }
+
+    @Test
+    fun `get all with linked objects`() {
+        val linked1 = MultiKeyData("mk1", "catA", "subA", 100)
+        val linked2 = MultiKeyData("mk2", "catB", "subB", 200)
+        container.get<MultiKeyData>().insert(listOf(linked1, linked2))
+
+        container.get<LinkedSimpleData>().insert(listOf(
+            LinkedSimpleData("s1", 1, linked1),
+            LinkedSimpleData("s2", 2, linked2),
+            LinkedSimpleData("s3", 3, null)
+        ))
+
+        val all = container.get<LinkedSimpleData>().get(LinkedSimpleData::class.java)
+        assertEquals(3, all.size)
+
+        val s1 = all.first { it.id == "s1" }
+        assertNotNull(s1.testData)
+        assertEquals("mk1", s1.testData!!.id)
+
+        val s2 = all.first { it.id == "s2" }
+        assertNotNull(s2.testData)
+        assertEquals("mk2", s2.testData!!.id)
+
+        val s3 = all.first { it.id == "s3" }
+        assertNull(s3.testData)
+    }
+
+    @Test
+    fun `findByIds with linked objects`() {
+        val linked = MultiKeyData("mk1", "catA", "subA", 100)
+        container.get<MultiKeyData>().insert(listOf(linked))
+
+        container.get<LinkedSimpleData>().insert(listOf(
+            LinkedSimpleData("s1", 1, linked),
+            LinkedSimpleData("s2", 2, null)
+        ))
+
+        val results = container.get<LinkedSimpleData>().findByIds(LinkedSimpleData::class.java, listOf("s1", "s2"))
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun `sort with linked objects`() {
+        val linked = MultiKeyData("mk1", "catA", "subA", 100)
+        container.get<MultiKeyData>().insert(listOf(linked))
+
+        container.get<LinkedSimpleData>().insert(listOf(
+            LinkedSimpleData("s1", 10, linked),
+            LinkedSimpleData("s2", 20, null),
+            LinkedSimpleData("s3", 5, linked)
+        ))
+
+        val sorted = container.get<LinkedSimpleData>().sortDescending(LinkedSimpleData::class.java, "value", 3)
+        assertEquals(3, sorted.size)
+        assertEquals("s2", sorted[0].id)
+        assertEquals("s1", sorted[1].id)
+        assertEquals("s3", sorted[2].id)
+    }
+
+    @Test
+    fun `cascade save - auto insert linked object`() {
+        // 不手动插入 MultiKeyData，直接插入带关联对象的 LinkedSimpleData
+        val linked = MultiKeyData("mk_auto", "catX", "subX", 999)
+        val data = LinkedSimpleData("s_auto", 77, linked)
+        container.get<LinkedSimpleData>().insert(listOf(data))
+
+        // 验证关联对象被自动插入到 multi_key_data 表
+        val linkedFound = container.get<MultiKeyData>().findOne(MultiKeyData::class.java, "mk_auto")
+        assertNotNull(linkedFound)
+        assertEquals("catX", linkedFound!!.category)
+        assertEquals(999, linkedFound.score)
+
+        // 验证主对象能通过 JOIN 查到完整关联
+        val found = container.get<LinkedSimpleData>().findOne(LinkedSimpleData::class.java, "s_auto")
+        assertNotNull(found)
+        assertNotNull(found!!.testData)
+        assertEquals("mk_auto", found.testData!!.id)
+        assertEquals(999, found.testData!!.score)
+    }
+
+    @Test
+    fun `cascade save - auto update existing linked object`() {
+        // 先手动插入一条 MultiKeyData
+        val linked = MultiKeyData("mk_upd", "catOld", "subOld", 100)
+        container.get<MultiKeyData>().insert(listOf(linked))
+
+        // 用修改后的关联对象插入主表 → 应自动更新 multi_key_data
+        val updatedLinked = MultiKeyData("mk_upd", "catOld", "subOld", 999)
+        val data = LinkedSimpleData("s_upd", 50, updatedLinked)
+        container.get<LinkedSimpleData>().insert(listOf(data))
+
+        // 验证关联对象的 score 已被更新
+        val linkedFound = container.get<MultiKeyData>().findOne(MultiKeyData::class.java, "mk_upd")
+        assertNotNull(linkedFound)
+        assertEquals(999, linkedFound!!.score)
+    }
+
+    // === 嵌套关联测试 ===
+
+    @Test
+    fun `nested - insert and find three levels`() {
+        val nestedContainer = TestContainer(ds)
+        nestedContainer.new<Level3Data>()
+        nestedContainer.new<Level2Data>()
+        nestedContainer.new<Level1Data>()
+
+        val l3 = Level3Data("l3-1", "deep info")
+        val l2 = Level2Data("l2-1", "middle", l3)
+        val l1 = Level1Data("l1-1", "top", l2)
+
+        nestedContainer.get<Level1Data>().insert(listOf(l1))
+
+        val found = nestedContainer.get<Level1Data>().findOne(Level1Data::class.java, "l1-1")
+        assertNotNull(found)
+        assertEquals("l1-1", found!!.id)
+        assertEquals("top", found.title)
+        assertNotNull(found.level2)
+        assertEquals("l2-1", found.level2!!.id)
+        assertEquals("middle", found.level2!!.name)
+        assertNotNull(found.level2!!.level3)
+        assertEquals("l3-1", found.level2!!.level3!!.id)
+        assertEquals("deep info", found.level2!!.level3!!.info)
+    }
+
+    @Test
+    fun `nested - middle layer null`() {
+        val nestedContainer = TestContainer(ds)
+        nestedContainer.new<Level3Data>()
+        nestedContainer.new<Level2Data>()
+        nestedContainer.new<Level1Data>()
+
+        val l1 = Level1Data("l1-null", "no child", null)
+        nestedContainer.get<Level1Data>().insert(listOf(l1))
+
+        val found = nestedContainer.get<Level1Data>().findOne(Level1Data::class.java, "l1-null")
+        assertNotNull(found)
+        assertEquals("l1-null", found!!.id)
+        assertNull(found.level2)
+    }
+
+    @Test
+    fun `nested - leaf layer null`() {
+        val nestedContainer = TestContainer(ds)
+        nestedContainer.new<Level3Data>()
+        nestedContainer.new<Level2Data>()
+        nestedContainer.new<Level1Data>()
+
+        val l2 = Level2Data("l2-noleaf", "has no leaf", null)
+        val l1 = Level1Data("l1-noleaf", "partial", l2)
+
+        nestedContainer.get<Level1Data>().insert(listOf(l1))
+
+        val found = nestedContainer.get<Level1Data>().findOne(Level1Data::class.java, "l1-noleaf")
+        assertNotNull(found)
+        assertNotNull(found!!.level2)
+        assertEquals("l2-noleaf", found.level2!!.id)
+        assertEquals("has no leaf", found.level2!!.name)
+        assertNull(found.level2!!.level3)
+    }
+
+    @Test
+    fun `nested - cascade save inserts all levels`() {
+        val nestedContainer = TestContainer(ds)
+        nestedContainer.new<Level3Data>()
+        nestedContainer.new<Level2Data>()
+        nestedContainer.new<Level1Data>()
+
+        val l3 = Level3Data("l3-cas", "cascade deep")
+        val l2 = Level2Data("l2-cas", "cascade mid", l3)
+        val l1 = Level1Data("l1-cas", "cascade top", l2)
+
+        // 只插入 Level1Data，Level2Data 和 Level3Data 应被级联保存
+        nestedContainer.get<Level1Data>().insert(listOf(l1))
+
+        // 验证 Level3Data 被自动插入
+        val foundL3 = nestedContainer.get<Level3Data>().findOne(Level3Data::class.java, "l3-cas")
+        assertNotNull(foundL3)
+        assertEquals("cascade deep", foundL3!!.info)
+
+        // 验证 Level2Data 被自动插入
+        val foundL2 = nestedContainer.get<Level2Data>().findOne(Level2Data::class.java, "l2-cas")
+        assertNotNull(foundL2)
+        assertEquals("cascade mid", foundL2!!.name)
+
+        // 验证完整的三层 JOIN 查询
+        val foundL1 = nestedContainer.get<Level1Data>().findOne(Level1Data::class.java, "l1-cas")
+        assertNotNull(foundL1)
+        assertNotNull(foundL1!!.level2)
+        assertNotNull(foundL1.level2!!.level3)
+        assertEquals("l3-cas", foundL1.level2!!.level3!!.id)
+    }
+
+    @Test
+    fun `nested - get all with mixed nesting`() {
+        val nestedContainer = TestContainer(ds)
+        nestedContainer.new<Level3Data>()
+        nestedContainer.new<Level2Data>()
+        nestedContainer.new<Level1Data>()
+
+        val l3 = Level3Data("l3-mix", "deep")
+        val l2Full = Level2Data("l2-full", "full chain", l3)
+        val l2Partial = Level2Data("l2-part", "no leaf", null)
+
+        nestedContainer.get<Level1Data>().insert(listOf(
+            Level1Data("l1-a", "full", l2Full),
+            Level1Data("l1-b", "partial", l2Partial),
+            Level1Data("l1-c", "empty", null)
+        ))
+
+        val all = nestedContainer.get<Level1Data>().get(Level1Data::class.java)
+        assertEquals(3, all.size)
+
+        val a = all.first { it.id == "l1-a" }
+        assertNotNull(a.level2)
+        assertNotNull(a.level2!!.level3)
+        assertEquals("l3-mix", a.level2!!.level3!!.id)
+
+        val b = all.first { it.id == "l1-b" }
+        assertNotNull(b.level2)
+        assertNull(b.level2!!.level3)
+
+        val c = all.first { it.id == "l1-c" }
+        assertNull(c.level2)
+    }
+
+    @Test
+    fun `nested - verify SQL and ResultSet columns`() {
+        val nestedContainer = TestContainer(ds)
+        nestedContainer.new<Level3Data>()
+        nestedContainer.new<Level2Data>()
+        nestedContainer.new<Level1Data>()
+
+        val l3 = Level3Data("l3-sql", "deep")
+        val l2 = Level2Data("l2-sql", "mid", l3)
+        val l1 = Level1Data("l1-sql", "top", l2)
+
+        nestedContainer.get<Level1Data>().insert(listOf(l1))
+
+        // 直接用 raw SQL 验证数据和 JOIN
+        ds.connection.use { conn ->
+            // 验证 level3_data 表有数据
+            conn.prepareStatement("SELECT * FROM level3_data WHERE id = ?").use { stmt ->
+                stmt.setString(1, "l3-sql")
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next(), "level3_data should have l3-sql")
+                    assertEquals("deep", rs.getString("info"))
+                }
+            }
+            // 验证 level2_data 表有数据且 FK 正确
+            conn.prepareStatement("SELECT * FROM level2_data WHERE id = ?").use { stmt ->
+                stmt.setString(1, "l2-sql")
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next(), "level2_data should have l2-sql")
+                    assertEquals("mid", rs.getString("name"))
+                    assertEquals("l3-sql", rs.getString("level3_id"), "FK level3_id should be l3-sql")
+                }
+            }
+            // 验证三层 JOIN SQL
+            val joinSql = """
+                SELECT `level1_data`.`id` AS `id`, `level1_data`.`title` AS `title`,
+                       `__t0`.`id` AS `__link__level2_id__id`, `__t0`.`name` AS `__link__level2_id__name`,
+                       `__t1`.`id` AS `__link__level2_id____link__level3_id__id`,
+                       `__t1`.`info` AS `__link__level2_id____link__level3_id__info`
+                FROM `level1_data`
+                LEFT JOIN `level2_data` AS `__t0` ON `level1_data`.`level2_id` = `__t0`.`id`
+                LEFT JOIN `level3_data` AS `__t1` ON `__t0`.`level3_id` = `__t1`.`id`
+                WHERE `level1_data`.`id` = ?
+            """.trimIndent()
+            conn.prepareStatement(joinSql).use { stmt ->
+                stmt.setString(1, "l1-sql")
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next(), "JOIN query should return a row")
+                    // 验证所有列别名可读
+                    assertEquals("l1-sql", rs.getObject("id"))
+                    assertEquals("top", rs.getObject("title"))
+                    assertEquals("l2-sql", rs.getObject("__link__level2_id__id"))
+                    assertEquals("mid", rs.getObject("__link__level2_id__name"))
+                    assertEquals("l3-sql", rs.getObject("__link__level2_id____link__level3_id__id"),
+                        "Nested link column should be readable")
+                    assertEquals("deep", rs.getObject("__link__level2_id____link__level3_id__info"),
+                        "Nested link column should be readable")
+                }
+            }
+        }
+    }
+}

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TestHelper.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TestHelper.kt
@@ -109,6 +109,37 @@ data class WrapperData(
 
 // endregion
 
+// region @LinkTable 测试用 data class
+
+data class LinkedSimpleData(
+    @Id val id: String,
+    var value: Int,
+    @LinkTable("testDataId") val testData: MultiKeyData?
+)
+
+// endregion
+
+// region @LinkTable 嵌套关联测试用 data class
+
+data class Level3Data(
+    @Id val id: String,
+    var info: String
+)
+
+data class Level2Data(
+    @Id val id: String,
+    var name: String,
+    @LinkTable("level3Id") val level3: Level3Data?
+)
+
+data class Level1Data(
+    @Id val id: String,
+    var title: String,
+    @LinkTable("level2Id") val level2: Level2Data?
+)
+
+// endregion
+
 // region 工具函数
 
 /**
@@ -129,11 +160,20 @@ fun createTestDataSource(): HikariDataSource {
 /**
  * 手动构建 Table + ContainerOperatorImpl，复用 ContainerSQLite 的建表逻辑
  */
-fun createTestOperator(type: Class<*>, name: String, dataSource: DataSource): ContainerOperatorImpl {
+fun createTestOperator(
+    type: Class<*>,
+    name: String,
+    dataSource: DataSource,
+    classTableMap: MutableMap<Class<*>, String>? = null,
+    classOperatorMap: MutableMap<Class<*>, ContainerOperator>? = null
+): ContainerOperatorImpl {
     val analyzedClass = AnalyzedClass.of(type)
     val table = buildSQLiteTable(analyzedClass, name)
     table.createTable(dataSource)
-    return ContainerOperatorImpl(table, dataSource)
+    classTableMap?.put(type, name)
+    val operator = ContainerOperatorImpl(table, dataSource, classTableMap = classTableMap, classOperatorMap = classOperatorMap)
+    classOperatorMap?.put(type, operator)
+    return operator
 }
 
 /**
@@ -146,6 +186,22 @@ private fun buildSQLiteTable(type: AnalyzedClass, name: String): Table<HostSQLit
             add { id() }
         }
         type.members.forEach { member ->
+            // @LinkTable 成员：创建外键列
+            if (member.isLinkTable) {
+                val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
+                val linkedPrimary = linkedClass.primaryMember!!
+                val fkColumnName = member.linkTableColumn!!
+                add(fkColumnName) {
+                    when {
+                        linkedPrimary.isString || linkedPrimary.isEnum -> type(ColumnTypeSQLite.TEXT, linkedPrimary.length)
+                        linkedPrimary.isUUID -> type(ColumnTypeSQLite.TEXT, 36)
+                        linkedPrimary.canConvertedInteger() -> type(ColumnTypeSQLite.INTEGER)
+                        linkedPrimary.canConvertedDecimal() -> type(ColumnTypeSQLite.REAL)
+                        else -> type(ColumnTypeSQLite.TEXT)
+                    }
+                }
+                return@forEach
+            }
             when {
                 member.isString || member.isEnum -> add(member.name) {
                     type(ColumnTypeSQLite.TEXT, member.length) { options(member) }
@@ -186,6 +242,8 @@ private fun ColumnSQLite.options(member: AnalyzedClassMember) {
 class TestContainer(val dataSource: HikariDataSource) {
 
     val operators = mutableMapOf<String, ContainerOperatorImpl>()
+    val classTableMap = mutableMapOf<Class<*>, String>()
+    val classOperatorMap = mutableMapOf<Class<*>, ContainerOperator>()
 
     inline fun <reified T> new(name: String = T::class.java.simpleName.let {
         taboolib.expansion.AnalyzedClassMember.Companion.run { it.toColumnName() }
@@ -194,7 +252,7 @@ class TestContainer(val dataSource: HikariDataSource) {
     }
 
     fun <T> new(type: Class<T>, name: String): ContainerOperatorImpl {
-        val op = createTestOperator(type, name, dataSource)
+        val op = createTestOperator(type, name, dataSource, classTableMap, classOperatorMap)
         operators[name] = op
         return op
     }

--- a/module/database/src/main/kotlin/taboolib/module/database/ActionSelect.kt
+++ b/module/database/src/main/kotlin/taboolib/module/database/ActionSelect.kt
@@ -150,6 +150,13 @@ class ActionSelect(val table: String) : ActionFilterable() {
     }
 
     /**
+     * 内连接（带子查询参数）
+     */
+    fun innerJoin(table: String, params: List<Any>, func: JoinFilter.() -> Unit) {
+        join += Join(JoinType.INNER, table, JoinFilter().also(func), params)
+    }
+
+    /**
      * 左连接（左表的每一行都会加上右表中符合条件的行）
      */
     fun leftJoin(table: String, func: JoinFilter.() -> Unit) {
@@ -157,9 +164,23 @@ class ActionSelect(val table: String) : ActionFilterable() {
     }
 
     /**
+     * 左连接（带子查询参数）
+     */
+    fun leftJoin(table: String, params: List<Any>, func: JoinFilter.() -> Unit) {
+        join += Join(JoinType.LEFT, table, JoinFilter().also(func), params)
+    }
+
+    /**
      * 右连接（右表的每一行都会加上左表中符合条件的行）
      */
     fun rightJoin(table: String, func: JoinFilter.() -> Unit) {
         join += Join(JoinType.RIGHT, table, JoinFilter().also(func))
+    }
+
+    /**
+     * 右连接（带子查询参数）
+     */
+    fun rightJoin(table: String, params: List<Any>, func: JoinFilter.() -> Unit) {
+        join += Join(JoinType.RIGHT, table, JoinFilter().also(func), params)
     }
 }

--- a/module/database/src/main/kotlin/taboolib/module/database/Join.kt
+++ b/module/database/src/main/kotlin/taboolib/module/database/Join.kt
@@ -6,7 +6,7 @@ package taboolib.module.database
  * @author sky
  * @since 2021/6/23 3:32 下午
  */
-class Join(val joinType: JoinType, val tableName: String, val filter: Filter) : Attributes {
+class Join(val joinType: JoinType, val tableName: String, val filter: Filter, val params: List<Any> = emptyList()) : Attributes {
 
     /** 语句 */
     override val query: String
@@ -20,5 +20,5 @@ class Join(val joinType: JoinType, val tableName: String, val filter: Filter) : 
 
     /** 占位符对应的元素 */
     override val elements: List<Any>
-        get() = filter.elements
+        get() = params + filter.elements
 }


### PR DESCRIPTION
## 改动说明

为 `database-ptc-object` 模块进行全面扩展，新增类型安全的 DataMapper 层、关联表查询、分页、游标、IndexedEnum 等功能。

---

### 一、DataMapper 接口与类型安全 CRUD（核心新增）

引入 `DataMapper<T>` 接口及 `DataMapperImpl` 实现，提供类型安全的数据操作层：

- **基础 CRUD**：`find`、`findOne`、`findAll`、`insert`、`update`、`delete`、`has`、`count`
- **基于 @Key 的复合定位**：`findByKey`、`findOneByKey`、`hasByKey`、`updateByKey`
- **批量操作**：`findByIds`、`deleteByIds`、`updateBatch`、`insertBatch`
- **排序查询**：`sort`、`sortDescending`
- **条件操作**：`deleteWhere`（按 Filter 条件删除）
- **自增主键返回**：`insertAndGenerateKey`、`insertBatchAndGenerateKeys`
- **通过自增行 ID 操作**：`findByRowId`、`deleteByRowId`

### 二、MapperDelegate（mapper 委托）

新增 `mapper()` 委托函数，简化 DataMapper 的获取方式：

```kotlin
val playerMapper by container.mapper<PlayerData>(cache = true)
```

### 三、事务支持（TransactionalDataMapper）

新增 `TransactionalDataMapper`，在 `transaction {}` 块中提供完整的 DataMapper 操作，事务内所有操作共享同一数据库连接，不使用缓存。

### 四、QueryCache 缓存系统

新增两级缓存机制：

- **Bean Cache**：按 @Id 值缓存单个对象
- **Query Cache**：按查询条件缓存查询结果列表
- 精确的缓存失效策略：写操作自动清除相关缓存

### 五、@LinkTable 关联表查询

新增 `@LinkTable` 注解，支持数据类之间的关联关系：

- 查询时自动生成 LEFT JOIN，递归展开多层嵌套关联（A→B→C→...）
- 写入时自动级联保存关联对象（深度优先）
- 自动检测循环引用并跳过
- 支持子查询连接（`innerJoin`、`leftJoin`、`rightJoin` 带参数版本）
- 新增 `SubQuery` 类和 `subQuery` DSL 构建子查询

### 六、分页查询（Page）

新增 `Page<T>` 数据类，封装分页结果：

```kotlin
val page = mapper.findPage(page = 1, size = 10) { "level" gte 5 }
// page.content, page.total, page.totalPages, page.hasNext, page.hasPrevious
```

- `findPage`、`sortPage`、`sortDescendingPage`
- 支持 Filter 条件过滤、L2 缓存、`@LinkTable` JOIN 查询

### 七、游标查询（Cursor）

新增 `Cursor<T>` 类，实现 `Iterable<T>` + `Closeable`，流式逐行遍历大数据集：

```kotlin
container.transaction {
    mapper.selectCursor().forEach { item -> /* 逐行处理 */ }
}
```

- `selectCursor`、`sortCursor`、`sortDescendingCursor`
- 必须在 `transaction {}` 块中使用，支持提前终止和自动关闭

### 八、IndexedEnum 接口

新增 `IndexedEnum` 接口，枚举以数值 `index` 存储到数据库：

```kotlin
enum class AccountType(override val index: Long) : IndexedEnum {
    NORMAL(0), VIP(1), ADMIN(2)
}
```

- 自动识别列类型（SQL: `BIGINT`，SQLite: `INTEGER`）
- Filter DSL 中 WHERE 条件自动转换参数（`convertParam`）

### 九、注解增强

- **`@ColumnType`**（新增）：显式指定字段的 SQL / SQLite 列类型
- 所有注解补充完整 KDoc 文档和 `@Target` 约束
- 补充 SQLite 与 SQL 行为差异说明

### 十、ActionSelect 扩展

- 新增带参数的 `innerJoin`、`leftJoin`、`rightJoin` 方法，支持子查询作为 JOIN 条件

---

## 修改文件清单

| 文件 | 操作 | 说明 |
|------|------|------|
| `Annotations.kt` | 修改 | 新增 @ColumnType、@LinkTable，补充 KDoc 和 @Target |
| `ContainerOperator.kt` | 修改 | 新增分页、游标、批量操作等抽象方法 |
| `ContainerOperatorImpl.kt` | 修改 | 实现所有新增方法，含 LinkTable JOIN、convertParam |
| `ContainerSQL.kt` | 修改 | IndexedEnum 列类型映射、@ColumnType 支持 |
| `ContainerSQLite.kt` | 修改 | IndexedEnum 列类型映射、@ColumnType 支持 |
| `Container.kt` | 修改 | 事务上下文支持 |
| `AnalyzedClass.kt` | 修改 | IndexedEnum 序列化/反序列化、LinkTable 递归解析 |
| `AnalyzedClassMember.kt` | 修改 | 新增 isIndexedEnum 属性 |
| `JoinQuery.kt` | 修改 | 子查询连接、selectAs、IndexedEnum 值转换 |
| `PersistentContainer.kt` | 修改 | 事务 API 扩展 |
| `DataMapper.kt` | **新增** | DataMapper 接口定义 |
| `DataMapperImpl.kt` | **新增** | DataMapper 实现（带缓存） |
| `TransactionalDataMapper.kt` | **新增** | 事务内 DataMapper 实现 |
| `TransactionContext.kt` | **新增** | 事务上下文类 |
| `MapperDelegate.kt` | **新增** | mapper() 委托函数 |
| `QueryCache.kt` | **新增** | 两级缓存系统 |
| `Page.kt` | **新增** | 分页结果数据类 |
| `Cursor.kt` | **新增** | 游标查询类 |
| `IndexedEnum.kt` | **新增** | 枚举数值存储接口 |
| `LinkTableTest.kt` | **新增** | LinkTable 关联查询单元测试 |
| `TestHelper.kt` | 修改 | 测试辅助工具扩展 |
| `ActionSelect.kt` | 修改 | 带参数的 JOIN 方法 |
| `Join.kt` | 修改 | params 参数支持 |

Closes TabooLib/taboolib#656