### PR TITLE
[feat] database-ptc-object 容器类型参数关联支持

### DIFF
--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
@@ -54,14 +54,20 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
     /** 主成员名称 */
     val primaryMemberName = primaryMember?.name
 
-    /** 实际映射到列的成员（排除 @LinkTable 成员） */
-    val columnMembers = members.filter { !it.isLinkTable }
+    /** 实际映射到列的成员（排除 @LinkTable 成员和容器成员） */
+    val columnMembers = members.filter { !it.isLinkTable && !it.isCollection }
 
     /** @LinkTable 成员列表 */
     val linkMembers = members.filter { it.isLinkTable }
 
     /** 是否存在 @LinkTable 成员 */
     val hasLinkMembers = linkMembers.isNotEmpty()
+
+    /** 容器类型成员列表（List/Set/Map） */
+    val collectionMembers = members.filter { it.isCollection }
+
+    /** 是否存在容器类型成员 */
+    val hasCollectionMembers = collectionMembers.isNotEmpty()
 
     /** 反序列化所在伴生类实例 */
     val wrapperObjectInstance = runCatching { clazz.getProperty<Any>("Companion", isStatic = true) }.getOrNull()
@@ -98,6 +104,15 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
                 )
             }
         }
+        // 验证容器类型成员
+        collectionMembers.forEach { member ->
+            require(member.parameterizedType != null) {
+                """
+                    在 ${clazz.simpleName} 类中，容器类型成员 ${member.propertyName} 缺少泛型信息。
+                    Collection member ${member.propertyName} in ${clazz.simpleName} is missing generic type information.
+                """.t()
+            }
+        }
         if (members.count { it.isPrimary } > 1) {
             error(
                 """
@@ -132,12 +147,12 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
         return property.get(data)
     }
 
-    /** 读取数据（不含 @LinkTable 成员） */
+    /** 读取数据（不含 @LinkTable 成员和容器成员） */
     fun read(result: ResultSet): Map<String, Any?> {
         val map = hashMapOf<String, Any?>()
         members.forEach { member ->
-            // 跳过 @LinkTable 成员，它们没有对应的列
-            if (member.isLinkTable) return@forEach
+            // 跳过 @LinkTable 成员和容器成员，它们没有对应的列
+            if (member.isLinkTable || member.isCollection) return@forEach
             val obj: Any? = result.getObject(member.name)
             if (obj == null) {
                 map[member.name] = null

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
@@ -5,6 +5,7 @@ import taboolib.module.database.ColumnTypeSQL
 import taboolib.module.database.ColumnTypeSQLite
 import taboolib.module.database.ColumnTypePostgreSQL
 import java.lang.reflect.Parameter
+import java.lang.reflect.ParameterizedType
 
 /**
  * TabooLib
@@ -60,6 +61,47 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
     /** 关联的 data class 类型 */
     val linkTableClass: Class<*>? = if (isLinkTable) returnType else null
 
+    /** 泛型参数化类型 */
+    val parameterizedType: ParameterizedType? = root.parameterizedType.let {
+        it as? ParameterizedType
+    }
+
+    /** 是否为 List 类型 */
+    val isList: Boolean
+        get() = List::class.java.isAssignableFrom(returnType)
+
+    /** 是否为 Set 类型 */
+    val isSet: Boolean
+        get() = Set::class.java.isAssignableFrom(returnType)
+
+    /** 是否为 Map 类型 */
+    val isMap: Boolean
+        get() = Map::class.java.isAssignableFrom(returnType)
+
+    /** 是否为容器类型（List/Set/Map） */
+    val isCollection: Boolean
+        get() = isList || isSet || isMap
+
+    /** 容器元素类型（List<T>/Set<T> 的 T，Map<K,V> 的 V） */
+    val collectionElementType: Class<*>? = when {
+        parameterizedType != null && (List::class.java.isAssignableFrom(returnType) || Set::class.java.isAssignableFrom(returnType)) -> {
+            val arg = parameterizedType.actualTypeArguments.firstOrNull()
+            arg as? Class<*> ?: if (arg is ParameterizedType) arg.rawType as? Class<*> else null
+        }
+        parameterizedType != null && Map::class.java.isAssignableFrom(returnType) -> {
+            val args = parameterizedType.actualTypeArguments
+            val arg = args.getOrNull(1)
+            arg as? Class<*> ?: if (arg is ParameterizedType) arg.rawType as? Class<*> else null
+        }
+        else -> null
+    }
+
+    /** Map 的 Key 类型 */
+    val mapKeyType: Class<*>? = if (parameterizedType != null && Map::class.java.isAssignableFrom(returnType)) {
+        val arg = parameterizedType.actualTypeArguments.firstOrNull()
+        arg as? Class<*> ?: if (arg is ParameterizedType) arg.rawType as? Class<*> else null
+    } else null
+
     /** 是否为基础类型（Boolean） */
     val isBoolean: Boolean
         get() = returnType == Boolean::class.java || returnType == Boolean::class.javaPrimitiveType
@@ -114,7 +156,7 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
 
     /** 是否为自定义对象 */
     val isCustomObject: Boolean
-        get() = !isLinkTable && !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID && !isByteArray
+        get() = !isLinkTable && !isCollection && !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID && !isByteArray
 
     /** 是否可以转换成字符串类型 */
     fun canConvertedString(): Boolean {
@@ -155,6 +197,22 @@ class AnalyzedClassMember(private val root: Parameter, name: String, val isFinal
         /** 获取注解 */
         inline fun <reified T : Annotation> Parameter.findAnnotation(): T? {
             return getAnnotationIfPresent(T::class.java)
+        }
+
+        /** 判断是否为基础类型（可直接映射到数据库列的类型） */
+        fun isPrimitiveOrBasicType(clazz: Class<*>): Boolean {
+            return clazz == Boolean::class.java || clazz == Boolean::class.javaPrimitiveType
+                || clazz == Byte::class.java || clazz == Byte::class.javaPrimitiveType
+                || clazz == Short::class.java || clazz == Short::class.javaPrimitiveType
+                || clazz == Int::class.java || clazz == Int::class.javaPrimitiveType
+                || clazz == Long::class.java || clazz == Long::class.javaPrimitiveType
+                || clazz == Float::class.java || clazz == Float::class.javaPrimitiveType
+                || clazz == Double::class.java || clazz == Double::class.javaPrimitiveType
+                || clazz == Char::class.java || clazz == Char::class.javaPrimitiveType
+                || clazz == String::class.java
+                || clazz == java.util.UUID::class.java
+                || Enum::class.java.isAssignableFrom(clazz)
+                || clazz == ByteArray::class.java
         }
     }
 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CollectionAccessor.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CollectionAccessor.kt
@@ -1,0 +1,429 @@
+package taboolib.expansion
+
+import taboolib.module.database.asFormattedColumnName
+import taboolib.module.database.setupQuoterForHost
+import java.sql.Connection
+import javax.sql.DataSource
+
+/**
+ * 基于数据库子表的 MutableMap 代理。
+ *
+ * 所有操作直接转化为对容器子表的 SQL 操作，不在内存中缓存数据。
+ *
+ * @param dataSource 数据源
+ * @param info 容器子表信息
+ * @param parentId 父记录 ID
+ * @param sharedConnection 事务共享连接（可选）
+ */
+class DatabaseMap(
+    private val dataSource: DataSource,
+    private val info: CollectionTableInfo,
+    private val parentId: Any,
+    private val sharedConnection: Connection? = null
+) : AbstractMutableMap<String, String?>() {
+
+    private val tableName get() = info.tableName.asFormattedColumnName()
+    private val fkColumn get() = info.fkColumnName.asFormattedColumnName()
+    private val mapKeyCol get() = "map_key".asFormattedColumnName()
+    private val mapValueCol get() = "map_value".asFormattedColumnName()
+
+    private inline fun <T> withConn(block: (Connection) -> T): T {
+        setupQuoterForHost(info.table.host)
+        return if (sharedConnection != null) {
+            block(sharedConnection)
+        } else {
+            dataSource.connection.use { block(it) }
+        }
+    }
+
+    override val size: Int
+        get() = withConn { conn ->
+            conn.prepareStatement("SELECT COUNT(*) FROM $tableName WHERE $fkColumn = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.executeQuery().use { rs -> if (rs.next()) rs.getInt(1) else 0 }
+            }
+        }
+
+    override fun containsKey(key: String): Boolean {
+        return withConn { conn ->
+            conn.prepareStatement("SELECT 1 FROM $tableName WHERE $fkColumn = ? AND $mapKeyCol = ? LIMIT 1").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setString(2, key)
+                stmt.executeQuery().use { it.next() }
+            }
+        }
+    }
+
+    override fun get(key: String): String? {
+        return withConn { conn ->
+            conn.prepareStatement("SELECT $mapValueCol FROM $tableName WHERE $fkColumn = ? AND $mapKeyCol = ? LIMIT 1").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setString(2, key)
+                stmt.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else null }
+            }
+        }
+    }
+
+    override fun put(key: String, value: String?): String? {
+        val old = get(key)
+        withConn { conn ->
+            conn.prepareStatement("DELETE FROM $tableName WHERE $fkColumn = ? AND $mapKeyCol = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setString(2, key)
+                stmt.executeUpdate()
+            }
+            conn.prepareStatement("INSERT INTO $tableName ($fkColumn, $mapKeyCol, $mapValueCol) VALUES (?, ?, ?)").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setString(2, key)
+                stmt.setString(3, value)
+                stmt.executeUpdate()
+            }
+        }
+        return old
+    }
+
+    override fun remove(key: String): String? {
+        val old = get(key)
+        if (old != null || containsKey(key)) {
+            withConn { conn ->
+                conn.prepareStatement("DELETE FROM $tableName WHERE $fkColumn = ? AND $mapKeyCol = ?").use { stmt ->
+                    stmt.setObject(1, parentId)
+                    stmt.setString(2, key)
+                    stmt.executeUpdate()
+                }
+            }
+        }
+        return old
+    }
+
+    override fun clear() {
+        withConn { conn ->
+            conn.prepareStatement("DELETE FROM $tableName WHERE $fkColumn = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    override val entries: MutableSet<MutableMap.MutableEntry<String, String?>>
+        get() {
+            val list = withConn { conn ->
+                conn.prepareStatement("SELECT $mapKeyCol, $mapValueCol FROM $tableName WHERE $fkColumn = ?").use { stmt ->
+                    stmt.setObject(1, parentId)
+                    stmt.executeQuery().use { rs ->
+                        buildList {
+                            while (rs.next()) {
+                                add(rs.getString(1) to rs.getString(2))
+                            }
+                        }
+                    }
+                }
+            }
+            return DatabaseMapEntrySet(list)
+        }
+
+    private inner class DatabaseMapEntrySet(
+        pairs: List<Pair<String, String?>>
+    ) : AbstractMutableSet<MutableMap.MutableEntry<String, String?>>() {
+
+        private val snapshot = pairs.map { DatabaseMapEntry(it.first, it.second) }.toMutableList()
+
+        override val size: Int get() = snapshot.size
+
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, String?>> {
+            return object : MutableIterator<MutableMap.MutableEntry<String, String?>> {
+                private val inner = snapshot.iterator()
+                private var last: DatabaseMapEntry? = null
+                override fun hasNext() = inner.hasNext()
+                override fun next(): MutableMap.MutableEntry<String, String?> {
+                    val e = inner.next()
+                    last = e
+                    return e
+                }
+                override fun remove() {
+                    val e = last ?: throw IllegalStateException()
+                    this@DatabaseMap.remove(e.key)
+                    last = null
+                }
+            }
+        }
+
+        override fun add(element: MutableMap.MutableEntry<String, String?>): Boolean {
+            put(element.key, element.value)
+            return true
+        }
+    }
+
+    private inner class DatabaseMapEntry(
+        override val key: String,
+        override var value: String?
+    ) : MutableMap.MutableEntry<String, String?> {
+        override fun setValue(newValue: String?): String? {
+            val old = value
+            value = newValue
+            this@DatabaseMap.put(key, newValue)
+            return old
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (other !is Map.Entry<*, *>) return false
+            return key == other.key && value == other.value
+        }
+
+        override fun hashCode(): Int = key.hashCode() xor (value?.hashCode() ?: 0)
+    }
+}
+
+/**
+ * 基于数据库子表的 MutableList 代理。
+ *
+ * 使用 `sort_order` 列维护元素顺序，所有操作直接转化为 SQL。
+ *
+ * @param dataSource 数据源
+ * @param info 容器子表信息
+ * @param parentId 父记录 ID
+ * @param sharedConnection 事务共享连接（可选）
+ */
+class DatabaseList(
+    private val dataSource: DataSource,
+    private val info: CollectionTableInfo,
+    private val parentId: Any,
+    private val sharedConnection: Connection? = null
+) : AbstractMutableList<String?>() {
+
+    private val tableName get() = info.tableName.asFormattedColumnName()
+    private val fkColumn get() = info.fkColumnName.asFormattedColumnName()
+    private val valueCol get() = "value".asFormattedColumnName()
+    private val sortOrderCol get() = "sort_order".asFormattedColumnName()
+
+    private inline fun <T> withConn(block: (Connection) -> T): T {
+        setupQuoterForHost(info.table.host)
+        return if (sharedConnection != null) {
+            block(sharedConnection)
+        } else {
+            dataSource.connection.use { block(it) }
+        }
+    }
+
+    override val size: Int
+        get() = withConn { conn ->
+            conn.prepareStatement("SELECT COUNT(*) FROM $tableName WHERE $fkColumn = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.executeQuery().use { rs -> if (rs.next()) rs.getInt(1) else 0 }
+            }
+        }
+
+    override fun get(index: Int): String? {
+        return withConn { conn ->
+            conn.prepareStatement("SELECT $valueCol FROM $tableName WHERE $fkColumn = ? ORDER BY $sortOrderCol LIMIT 1 OFFSET ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setInt(2, index)
+                stmt.executeQuery().use { rs ->
+                    if (rs.next()) rs.getString(1) else throw IndexOutOfBoundsException("Index: $index, Size: $size")
+                }
+            }
+        }
+    }
+
+    override fun set(index: Int, element: String?): String? {
+        val old = get(index)
+        withConn { conn ->
+            val sortOrder = conn.prepareStatement(
+                "SELECT $sortOrderCol FROM $tableName WHERE $fkColumn = ? ORDER BY $sortOrderCol LIMIT 1 OFFSET ?"
+            ).use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setInt(2, index)
+                stmt.executeQuery().use { rs ->
+                    if (rs.next()) rs.getInt(1) else throw IndexOutOfBoundsException("Index: $index")
+                }
+            }
+            conn.prepareStatement("UPDATE $tableName SET $valueCol = ? WHERE $fkColumn = ? AND $sortOrderCol = ?").use { stmt ->
+                stmt.setString(1, element)
+                stmt.setObject(2, parentId)
+                stmt.setInt(3, sortOrder)
+                stmt.executeUpdate()
+            }
+        }
+        return old
+    }
+
+    override fun add(index: Int, element: String?) {
+        val currentSize = size
+        if (index < 0 || index > currentSize) throw IndexOutOfBoundsException("Index: $index, Size: $currentSize")
+        withConn { conn ->
+            conn.prepareStatement("UPDATE $tableName SET $sortOrderCol = $sortOrderCol + 1 WHERE $fkColumn = ? AND $sortOrderCol >= ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setInt(2, index)
+                stmt.executeUpdate()
+            }
+            conn.prepareStatement("INSERT INTO $tableName ($fkColumn, $valueCol, $sortOrderCol) VALUES (?, ?, ?)").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setString(2, element)
+                stmt.setInt(3, index)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    override fun removeAt(index: Int): String? {
+        val old = get(index)
+        withConn { conn ->
+            val sortOrder = conn.prepareStatement(
+                "SELECT $sortOrderCol FROM $tableName WHERE $fkColumn = ? ORDER BY $sortOrderCol LIMIT 1 OFFSET ?"
+            ).use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setInt(2, index)
+                stmt.executeQuery().use { rs ->
+                    if (rs.next()) rs.getInt(1) else throw IndexOutOfBoundsException("Index: $index")
+                }
+            }
+            conn.prepareStatement("DELETE FROM $tableName WHERE $fkColumn = ? AND $sortOrderCol = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setInt(2, sortOrder)
+                stmt.executeUpdate()
+            }
+            conn.prepareStatement("UPDATE $tableName SET $sortOrderCol = $sortOrderCol - 1 WHERE $fkColumn = ? AND $sortOrderCol > ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setInt(2, sortOrder)
+                stmt.executeUpdate()
+            }
+        }
+        return old
+    }
+
+    override fun contains(element: String?): Boolean {
+        return withConn { conn ->
+            val sql = if (element == null) {
+                "SELECT 1 FROM $tableName WHERE $fkColumn = ? AND $valueCol IS NULL LIMIT 1"
+            } else {
+                "SELECT 1 FROM $tableName WHERE $fkColumn = ? AND $valueCol = ? LIMIT 1"
+            }
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setObject(1, parentId)
+                if (element != null) stmt.setString(2, element)
+                stmt.executeQuery().use { it.next() }
+            }
+        }
+    }
+}
+
+/**
+ * 基于数据库子表的 MutableSet 代理。
+ *
+ * 所有操作直接转化为对容器子表的 SQL 操作。
+ * 唯一性保证通过 INSERT 前检查实现。
+ *
+ * @param dataSource 数据源
+ * @param info 容器子表信息
+ * @param parentId 父记录 ID
+ * @param sharedConnection 事务共享连接（可选）
+ */
+class DatabaseSet(
+    private val dataSource: DataSource,
+    private val info: CollectionTableInfo,
+    private val parentId: Any,
+    private val sharedConnection: Connection? = null
+) : AbstractMutableSet<String?>() {
+
+    private val tableName get() = info.tableName.asFormattedColumnName()
+    private val fkColumn get() = info.fkColumnName.asFormattedColumnName()
+    private val valueCol get() = "value".asFormattedColumnName()
+
+    private inline fun <T> withConn(block: (Connection) -> T): T {
+        setupQuoterForHost(info.table.host)
+        return if (sharedConnection != null) {
+            block(sharedConnection)
+        } else {
+            dataSource.connection.use { block(it) }
+        }
+    }
+
+    override val size: Int
+        get() = withConn { conn ->
+            conn.prepareStatement("SELECT COUNT(*) FROM $tableName WHERE $fkColumn = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.executeQuery().use { rs -> if (rs.next()) rs.getInt(1) else 0 }
+            }
+        }
+
+    override fun add(element: String?): Boolean {
+        if (contains(element)) return false
+        withConn { conn ->
+            conn.prepareStatement("INSERT INTO $tableName ($fkColumn, $valueCol) VALUES (?, ?)").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.setString(2, element)
+                stmt.executeUpdate()
+            }
+        }
+        return true
+    }
+
+    override fun contains(element: String?): Boolean {
+        return withConn { conn ->
+            val sql = if (element == null) {
+                "SELECT 1 FROM $tableName WHERE $fkColumn = ? AND $valueCol IS NULL LIMIT 1"
+            } else {
+                "SELECT 1 FROM $tableName WHERE $fkColumn = ? AND $valueCol = ? LIMIT 1"
+            }
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setObject(1, parentId)
+                if (element != null) stmt.setString(2, element)
+                stmt.executeQuery().use { it.next() }
+            }
+        }
+    }
+
+    override fun remove(element: String?): Boolean {
+        if (!contains(element)) return false
+        withConn { conn ->
+            val sql = if (element == null) {
+                "DELETE FROM $tableName WHERE $fkColumn = ? AND $valueCol IS NULL"
+            } else {
+                "DELETE FROM $tableName WHERE $fkColumn = ? AND $valueCol = ?"
+            }
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setObject(1, parentId)
+                if (element != null) stmt.setString(2, element)
+                stmt.executeUpdate()
+            }
+        }
+        return true
+    }
+
+    override fun clear() {
+        withConn { conn ->
+            conn.prepareStatement("DELETE FROM $tableName WHERE $fkColumn = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    override fun iterator(): MutableIterator<String?> {
+        val snapshot = withConn { conn ->
+            conn.prepareStatement("SELECT $valueCol FROM $tableName WHERE $fkColumn = ?").use { stmt ->
+                stmt.setObject(1, parentId)
+                stmt.executeQuery().use { rs ->
+                    buildList { while (rs.next()) add(rs.getString(1)) }
+                }
+            }
+        }
+        return object : MutableIterator<String?> {
+            private val inner = snapshot.iterator()
+            private var last: String? = null
+            private var hasLast = false
+            override fun hasNext() = inner.hasNext()
+            override fun next(): String? {
+                val v = inner.next()
+                last = v
+                hasLast = true
+                return v
+            }
+            override fun remove() {
+                if (!hasLast) throw IllegalStateException()
+                this@DatabaseSet.remove(last)
+                hasLast = false
+            }
+        }
+    }
+}

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CollectionTableInfo.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CollectionTableInfo.kt
@@ -1,0 +1,18 @@
+package taboolib.expansion
+
+import taboolib.module.database.Table
+
+/**
+ * 容器类型（List/Set/Map）关联表的元信息
+ *
+ * @param tableName 子表名称
+ * @param fkColumnName 外键列名（引用主表的 @Id 列）
+ * @param member 对应的容器成员
+ * @param table 子表的 Table 对象
+ */
+data class CollectionTableInfo(
+    val tableName: String,
+    val fkColumnName: String,
+    val member: AnalyzedClassMember,
+    val table: Table<*, *>,
+)

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Container.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Container.kt
@@ -19,8 +19,19 @@ abstract class Container<T : ColumnBuilder>(val host: Host<T>) {
     /** class → ContainerOperator 映射（用于 @LinkTable 级联保存） */
     val classOperatorMap = ConcurrentHashMap<Class<*>, ContainerOperator>()
 
+    /** class → 容器关联表信息列表 */
+    val collectionTableMap = ConcurrentHashMap<Class<*>, List<CollectionTableInfo>>()
+
     /** 创建表 */
     protected abstract fun createTableObject(type: AnalyzedClass, name: String): Table<*, *>
+
+    /** 创建容器类型子表 */
+    protected abstract fun createCollectionTableObject(
+        parentType: AnalyzedClass,
+        parentTableName: String,
+        member: AnalyzedClassMember,
+        childTableName: String
+    ): Table<*, *>
 
     /** 创建表 */
     open fun createTable(type: AnalyzedClass, name: String) {
@@ -34,7 +45,27 @@ abstract class Container<T : ColumnBuilder>(val host: Host<T>) {
             }
         }
         classTableMap[type.clazz] = name
-        val operator = ContainerOperatorImpl(createTableObject(type, name), dataSource, classTableMap = classTableMap, classOperatorMap = classOperatorMap)
+        // 创建容器类型子表
+        val collectionInfos = mutableListOf<CollectionTableInfo>()
+        if (type.hasCollectionMembers) {
+            val primaryMember = type.primaryMember ?: error(
+                "容器类型成员需要主类有 @Id 字段。Collection members require the parent class to have an @Id field."
+            )
+            for (member in type.collectionMembers) {
+                val childTableName = "${name}_${member.name}"
+                val fkColumnName = "parent_${primaryMember.name}"
+                val childTable = createCollectionTableObject(type, name, member, childTableName)
+                collectionInfos += CollectionTableInfo(childTableName, fkColumnName, member, childTable)
+            }
+        }
+        if (collectionInfos.isNotEmpty()) {
+            collectionTableMap[type.clazz] = collectionInfos
+        }
+        val operator = ContainerOperatorImpl(
+            createTableObject(type, name), dataSource,
+            classTableMap = classTableMap, classOperatorMap = classOperatorMap,
+            collectionTableInfos = collectionInfos.ifEmpty { null }
+        )
         map[name] = operator
         classOperatorMap[type.clazz] = operator
     }
@@ -42,6 +73,10 @@ abstract class Container<T : ColumnBuilder>(val host: Host<T>) {
     /** 初始化所有表 */
     open fun init() {
         map.forEach { it.value.table.createTable(dataSource) }
+        // 创建容器子表
+        collectionTableMap.values.forEach { infos ->
+            infos.forEach { it.table.createTable(dataSource) }
+        }
     }
 
     /** 获取路径 */

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
@@ -26,14 +26,15 @@ class ContainerOperatorImpl(
     override val dataSource: DataSource,
     private val sharedConnection: Connection? = null,
     private val classTableMap: Map<Class<*>, String>? = null,
-    private val classOperatorMap: Map<Class<*>, ContainerOperator>? = null
+    private val classOperatorMap: Map<Class<*>, ContainerOperator>? = null,
+    private val collectionTableInfos: List<CollectionTableInfo>? = null
 ) : ContainerOperator() {
 
     /**
      * 创建事务模式的操作器（共享 Connection）
      */
     fun withConnection(connection: Connection): ContainerOperatorImpl {
-        return ContainerOperatorImpl(table, dataSource, connection, classTableMap, classOperatorMap)
+        return ContainerOperatorImpl(table, dataSource, connection, classTableMap, classOperatorMap, collectionTableInfos)
     }
 
     /**
@@ -64,9 +65,8 @@ class ContainerOperatorImpl(
             limit(1)
             where(filter)
         }
-        return executeQuery(action) { rs ->
-            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
-        }
+        val map = executeQuery(action) { rs -> readMap(typeClass, rs) }
+        return resolveOneWithCollections(typeClass, map)
     }
 
     override fun <T> get(type: Class<T>, filter: Filter.() -> Unit): List<T> {
@@ -86,13 +86,8 @@ class ContainerOperatorImpl(
         val action = ActionSelect(table.name).apply {
             where(filter)
         }
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> findOne(type: Class<T>, id: Any, filter: Filter.() -> Unit): T? {
@@ -109,9 +104,8 @@ class ContainerOperatorImpl(
                 if (rs.next()) readJoinResult<T>(typeClass, rs) else null
             }
         }
-        return executeQuery(selectById(typeClass, id, filter) { limit(1) }) { rs ->
-            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
-        }
+        val map = executeQuery(selectById(typeClass, id, filter) { limit(1) }) { rs -> readMap(typeClass, rs) }
+        return resolveOneWithCollections(typeClass, map)
     }
 
     override fun <T> find(type: Class<T>, id: Any, filter: Filter.() -> Unit): List<T> {
@@ -131,13 +125,8 @@ class ContainerOperatorImpl(
                 }
             }
         }
-        return executeQuery(selectById(typeClass, id, filter)) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(selectById(typeClass, id, filter)) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> sort(type: Class<T>, row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
@@ -161,13 +150,8 @@ class ContainerOperatorImpl(
             limit(limit)
             orderBy(row)
         }
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> sortDescending(type: Class<T>, row: String, limit: Int, filter: Filter.() -> Unit): List<T> {
@@ -191,13 +175,8 @@ class ContainerOperatorImpl(
             limit(limit)
             orderBy(row, Order.Type.DESC)
         }
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> getPage(type: Class<T>, page: Int, size: Int, filter: Filter.() -> Unit): List<T> {
@@ -221,13 +200,8 @@ class ContainerOperatorImpl(
             limit(size)
             offset((page - 1) * size)
         }
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> sortPage(type: Class<T>, row: String, page: Int, size: Int, filter: Filter.() -> Unit): List<T> {
@@ -253,13 +227,8 @@ class ContainerOperatorImpl(
             limit(size)
             offset((page - 1) * size)
         }
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> sortDescendingPage(type: Class<T>, row: String, page: Int, size: Int, filter: Filter.() -> Unit): List<T> {
@@ -285,13 +254,8 @@ class ContainerOperatorImpl(
             limit(size)
             offset((page - 1) * size)
         }
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> selectCursor(type: Class<T>, filter: Filter.() -> Unit): Cursor<T> {
@@ -347,6 +311,7 @@ class ContainerOperatorImpl(
             }
         }
         executeUpdate(action)
+        insertCollectionData(typeClass, dataList)
     }
 
     override fun insertAndGetKeys(dataList: List<Any>): List<Long> {
@@ -369,7 +334,7 @@ class ContainerOperatorImpl(
                     buildList { while (rs.next()) add(rs.getLong(1)) }
                 }
             }
-        }
+        }.also { insertCollectionData(typeClass, dataList) }
     }
 
     override fun update(data: Any, usePrimaryKey: Boolean, filter: Filter.() -> Unit) {
@@ -392,7 +357,7 @@ class ContainerOperatorImpl(
                 val updateAction = ActionUpdate(table.name).apply {
                     if (name != null) where(name eq value?.value())
                     where(filter)
-                    typeClass.members.filter { !it.isFinal || it.isLinkTable }.forEach { member ->
+                    typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }.forEach { member ->
                         if (member.isLinkTable) {
                             val linkedObj = typeClass.getValue(data, member)
                             val fkValue = if (linkedObj != null) {
@@ -415,6 +380,7 @@ class ContainerOperatorImpl(
                 conn.executePrepared(insertAction.query, insertAction.elements, Statement.RETURN_GENERATED_KEYS) { executeUpdate() }
             }
         }
+        syncCollectionData(typeClass, data)
     }
 
     override fun updateByKey(data: Any, usePrimaryKey: Boolean) {
@@ -438,7 +404,7 @@ class ContainerOperatorImpl(
         cascadeSaveLinkedObjects(typeClass, dataList)
         val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
         val keyMembers = typeClass.members.filter { it.isKey }
-        val mutableMembers = typeClass.members.filter { !it.isFinal || it.isLinkTable }
+        val mutableMembers = typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }
         // 构建唯一标识：@Id + @Key 的值
         fun buildKey(data: Any): String {
             val id = typeClass.getPrimaryMemberValue(data)?.value().toString()
@@ -533,6 +499,7 @@ class ContainerOperatorImpl(
                 }
             }
         }
+        dataList.forEach { data -> syncCollectionData(typeClass, data) }
     }
 
     /**
@@ -553,7 +520,7 @@ class ContainerOperatorImpl(
         primaryName: String,
         keyMembers: List<AnalyzedClassMember>
     ): String {
-        val mutableMembers = typeClass.members.filter { !it.isFinal || it.isLinkTable }
+        val mutableMembers = typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }
         val setClause = mutableMembers.joinToString(", ") { member ->
             if (member.isLinkTable) "${member.linkTableColumn!!.asFormattedColumnName()} = ?" else "${member.name.asFormattedColumnName()} = ?"
         }
@@ -567,6 +534,7 @@ class ContainerOperatorImpl(
     override fun <T> delete(type: Class<T>, id: Any, filter: Filter.() -> Unit) {
         val typeClass = AnalyzedClass.of(type)
         val name = typeClass.primaryMemberName ?: error("No primary id found.")
+        deleteCollectionDataByFk(id)
         val action = ActionDelete(table.name).apply {
             where(name eq id.value())
             where(filter)
@@ -612,13 +580,8 @@ class ContainerOperatorImpl(
             }
         }
         val action = selectByKey(typeClass, data, usePrimaryKey)
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> findOneByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): T? {
@@ -641,9 +604,8 @@ class ContainerOperatorImpl(
             }
         }
         val action = selectByKey(typeClass, data, usePrimaryKey) { limit(1) }
-        return executeQuery(action) { rs ->
-            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
-        }
+        val map = executeQuery(action) { rs -> readMap(typeClass, rs) }
+        return resolveOneWithCollections(typeClass, map)
     }
 
     override fun <T> hasByKey(type: Class<T>, data: Any, usePrimaryKey: Boolean): Boolean {
@@ -683,9 +645,8 @@ class ContainerOperatorImpl(
             where("id" eq rowId)
             limit(1)
         }
-        return executeQuery(action) { rs ->
-            if (rs.next()) typeClass.createInstance<T>(typeClass.read(rs)) else null
-        }
+        val map = executeQuery(action) { rs -> readMap(typeClass, rs) }
+        return resolveOneWithCollections(typeClass, map)
     }
 
     override fun deleteByRowId(rowId: Long) {
@@ -717,19 +678,15 @@ class ContainerOperatorImpl(
         val action = ActionSelect(table.name).apply {
             where { primaryName inside ids.map { it.value() }.toTypedArray() }
         }
-        return executeQuery(action) { rs ->
-            buildList {
-                while (rs.next()) {
-                    add(typeClass.createInstance<T>(typeClass.read(rs)))
-                }
-            }
-        }
+        val maps = executeQuery(action) { rs -> readMaps(typeClass, rs) }
+        return resolveWithCollections(typeClass, maps)
     }
 
     override fun <T> deleteByIds(type: Class<T>, ids: List<Any>) {
         if (ids.isEmpty()) return
         val typeClass = AnalyzedClass.of(type)
         val name = typeClass.primaryMemberName ?: error("No primary id found.")
+        ids.forEach { deleteCollectionDataByFk(it) }
         val action = ActionDelete(table.name).apply {
             where { name inside ids.map { it.value() }.toTypedArray() }
         }
@@ -739,7 +696,7 @@ class ContainerOperatorImpl(
     override fun updateBatch(dataList: List<Any>) {
         if (dataList.isEmpty()) return
         val typeClass = AnalyzedClass.of(dataList.first().javaClass)
-        val mutableMembers = typeClass.members.filter { !it.isFinal || it.isLinkTable }
+        val mutableMembers = typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }
         if (mutableMembers.isEmpty()) error("No mutable field found.")
         cascadeSaveLinkedObjects(typeClass, dataList)
         val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
@@ -770,6 +727,7 @@ class ContainerOperatorImpl(
                 stmt.executeBatch()
             }
         }
+        dataList.forEach { data -> syncCollectionData(typeClass, data) }
     }
 
     // === 自定义 SQL ===
@@ -833,7 +791,7 @@ class ContainerOperatorImpl(
      * 获取实际列名列表（@LinkTable 用 FK 列名）
      */
     private fun getColumnNames(typeClass: AnalyzedClass): List<String> {
-        return typeClass.members.map { member ->
+        return typeClass.members.filter { !it.isCollection }.map { member ->
             if (member.isLinkTable) member.linkTableColumn!! else member.name
         }
     }
@@ -842,7 +800,7 @@ class ContainerOperatorImpl(
      * 获取实际列值列表（@LinkTable 提取 FK 值）
      */
     private fun getColumnValues(typeClass: AnalyzedClass, data: Any): List<Any?> {
-        return typeClass.members.map { member ->
+        return typeClass.members.filter { !it.isCollection }.map { member ->
             if (member.isLinkTable) {
                 val linkedObj = typeClass.getValue(data, member)
                 if (linkedObj != null) {
@@ -1107,6 +1065,344 @@ class ContainerOperatorImpl(
             is IndexedEnum -> value.index
             is Enum<*> -> value.name
             else -> value
+        }
+    }
+
+    // === 容器类型（List/Set/Map）两阶段读取辅助 ===
+
+    /**
+     * Phase 1：从 ResultSet 读取单条记录到 Map（在连接内执行）
+     */
+    private fun readMap(typeClass: AnalyzedClass, rs: ResultSet): MutableMap<String, Any?>? {
+        return if (rs.next()) typeClass.read(rs).toMutableMap() else null
+    }
+
+    /**
+     * Phase 1：从 ResultSet 读取所有记录到 Map 列表（在连接内执行）
+     */
+    private fun readMaps(typeClass: AnalyzedClass, rs: ResultSet): List<MutableMap<String, Any?>> {
+        return buildList {
+            while (rs.next()) {
+                add(typeClass.read(rs).toMutableMap())
+            }
+        }
+    }
+
+    /**
+     * Phase 2：将单个 Map 转换为实例，并加载容器数据（连接已释放）
+     */
+    private fun <T> resolveOneWithCollections(typeClass: AnalyzedClass, map: MutableMap<String, Any?>?): T? {
+        if (map == null) return null
+        if (typeClass.hasCollectionMembers && !collectionTableInfos.isNullOrEmpty()) {
+            loadCollections(typeClass, listOf(map))
+        }
+        return typeClass.createInstance(map)
+    }
+
+    /**
+     * Phase 2：将 Map 列表转换为实例列表，并批量加载容器数据（连接已释放）
+     */
+    private fun <T> resolveWithCollections(typeClass: AnalyzedClass, maps: List<MutableMap<String, Any?>>): List<T> {
+        if (maps.isNotEmpty() && typeClass.hasCollectionMembers && !collectionTableInfos.isNullOrEmpty()) {
+            loadCollections(typeClass, maps)
+        }
+        return maps.map { typeClass.createInstance(it) }
+    }
+
+    // === 容器类型（List/Set/Map）关联表操作 ===
+
+    /**
+     * 查找容器成员对应的 CollectionTableInfo
+     */
+    private fun findCollectionTableInfo(member: AnalyzedClassMember): CollectionTableInfo? {
+        return collectionTableInfos?.firstOrNull { it.member === member }
+    }
+
+    /**
+     * 插入容器数据（批量）
+     */
+    private fun insertCollectionData(typeClass: AnalyzedClass, dataList: List<Any>) {
+        if (collectionTableInfos.isNullOrEmpty() || !typeClass.hasCollectionMembers) return
+        dataList.forEach { data -> syncCollectionData(typeClass, data) }
+    }
+
+    /**
+     * 同步单条记录的容器数据（先删后插）
+     */
+    private fun syncCollectionData(typeClass: AnalyzedClass, data: Any) {
+        if (collectionTableInfos.isNullOrEmpty() || !typeClass.hasCollectionMembers) return
+        val parentId = typeClass.getPrimaryMemberValue(data)?.value() ?: return
+        typeClass.collectionMembers.forEach { member ->
+            val info = findCollectionTableInfo(member) ?: return@forEach
+            val collection = typeClass.getValue(data, member)
+            deleteCollectionByFk(info, parentId)
+            if (collection != null) {
+                insertCollectionValues(info, member, parentId, collection)
+            }
+        }
+    }
+
+    /**
+     * 删除容器子表中指定 FK 的所有数据
+     */
+    private fun deleteCollectionByFk(info: CollectionTableInfo, parentId: Any) {
+        setupQuoter()
+        val sql = "DELETE FROM ${info.tableName.asFormattedColumnName()} WHERE ${info.fkColumnName.asFormattedColumnName()} = ?"
+        withConnection { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setObject(1, convertParam(parentId))
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    /**
+     * 按 FK 值批量删除容器子表数据
+     */
+    private fun deleteCollectionDataByFk(parentId: Any) {
+        if (collectionTableInfos.isNullOrEmpty()) return
+        collectionTableInfos.forEach { info: CollectionTableInfo ->
+            deleteCollectionByFk(info, parentId.value())
+        }
+    }
+
+    /**
+     * 插入容器值到子表
+     */
+    private fun insertCollectionValues(info: CollectionTableInfo, member: AnalyzedClassMember, parentId: Any, collection: Any) {
+        setupQuoter()
+        when {
+            member.isMap -> {
+                val map = collection as? Map<*, *> ?: return
+                if (map.isEmpty()) return
+                val sql = "INSERT INTO ${info.tableName.asFormattedColumnName()} (${info.fkColumnName.asFormattedColumnName()}, ${"map_key".asFormattedColumnName()}, ${"map_value".asFormattedColumnName()}) VALUES (?, ?, ?)"
+                withConnection { conn ->
+                    conn.prepareStatement(sql).use { stmt ->
+                        map.forEach { (k, v) ->
+                            stmt.setObject(1, convertParam(parentId))
+                            stmt.setObject(2, k?.toString())
+                            stmt.setObject(3, v?.toString())
+                            stmt.addBatch()
+                        }
+                        stmt.executeBatch()
+                    }
+                }
+            }
+            member.isList -> {
+                val list = collection as? List<*> ?: return
+                if (list.isEmpty()) return
+                val sql = "INSERT INTO ${info.tableName.asFormattedColumnName()} (${info.fkColumnName.asFormattedColumnName()}, ${"value".asFormattedColumnName()}, ${"sort_order".asFormattedColumnName()}) VALUES (?, ?, ?)"
+                withConnection { conn ->
+                    conn.prepareStatement(sql).use { stmt ->
+                        list.forEachIndexed { index, v ->
+                            stmt.setObject(1, convertParam(parentId))
+                            stmt.setObject(2, v?.toString())
+                            stmt.setObject(3, index)
+                            stmt.addBatch()
+                        }
+                        stmt.executeBatch()
+                    }
+                }
+            }
+            member.isSet -> {
+                val set = collection as? Set<*> ?: return
+                if (set.isEmpty()) return
+                val sql = "INSERT INTO ${info.tableName.asFormattedColumnName()} (${info.fkColumnName.asFormattedColumnName()}, ${"value".asFormattedColumnName()}) VALUES (?, ?)"
+                withConnection { conn ->
+                    conn.prepareStatement(sql).use { stmt ->
+                        set.forEach { v ->
+                            stmt.setObject(1, convertParam(parentId))
+                            stmt.setObject(2, v?.toString())
+                            stmt.addBatch()
+                        }
+                        stmt.executeBatch()
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * 批量加载容器数据并注入到结果 map 中
+     */
+    private fun loadCollections(typeClass: AnalyzedClass, results: List<MutableMap<String, Any?>>) {
+        if (collectionTableInfos.isNullOrEmpty() || !typeClass.hasCollectionMembers) return
+        val primaryName = typeClass.primaryMemberName ?: return
+        val ids = results.mapNotNull { it[primaryName] }
+        if (ids.isEmpty()) return
+        setupQuoter()
+        typeClass.collectionMembers.forEach { member ->
+            val info = findCollectionTableInfo(member) ?: return@forEach
+            val collectionData = batchLoadCollection(info, member, ids)
+            results.forEach { map ->
+                val id = map[primaryName]
+                map[member.name] = collectionData[id?.toString()] ?: emptyCollection(member)
+            }
+        }
+    }
+
+    /**
+     * 批量查询容器子表数据
+     */
+    private fun batchLoadCollection(
+        info: CollectionTableInfo,
+        member: AnalyzedClassMember,
+        ids: List<Any>
+    ): Map<String, Any> {
+        val result = mutableMapOf<String, Any>()
+        val idArray = ids.map { convertParam(it)!! }.toTypedArray()
+        val placeholders = idArray.joinToString(", ") { "?" }
+        val orderClause = if (member.isList) " ORDER BY ${"sort_order".asFormattedColumnName()}" else ""
+        val sql = "SELECT * FROM ${info.tableName.asFormattedColumnName()} WHERE ${info.fkColumnName.asFormattedColumnName()} IN ($placeholders)$orderClause"
+        withConnection { conn ->
+            conn.prepareStatement(sql).use { stmt ->
+                idArray.forEachIndexed { i, v -> stmt.setObject(i + 1, v) }
+                stmt.executeQuery().use { rs ->
+                    when {
+                        member.isMap -> {
+                            while (rs.next()) {
+                                val fk = rs.getObject(info.fkColumnName)?.toString() ?: continue
+                                val key = rs.getString("map_key")
+                                val value = rs.getString("map_value")
+                                @Suppress("UNCHECKED_CAST")
+                                val map = result.getOrPut(fk) { mutableMapOf<String, String?>() } as MutableMap<String, String?>
+                                map[key] = value
+                            }
+                        }
+                        member.isList -> {
+                            while (rs.next()) {
+                                val fk = rs.getObject(info.fkColumnName)?.toString() ?: continue
+                                val value = rs.getString("value")
+                                @Suppress("UNCHECKED_CAST")
+                                val list = result.getOrPut(fk) { mutableListOf<String?>() } as MutableList<String?>
+                                list.add(value)
+                            }
+                        }
+                        member.isSet -> {
+                            while (rs.next()) {
+                                val fk = rs.getObject(info.fkColumnName)?.toString() ?: continue
+                                val value = rs.getString("value")
+                                @Suppress("UNCHECKED_CAST")
+                                val set = result.getOrPut(fk) { mutableSetOf<String?>() } as MutableSet<String?>
+                                set.add(value)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    /**
+     * 创建空容器
+     */
+    private fun emptyCollection(member: AnalyzedClassMember): Any {
+        return when {
+            member.isList -> emptyList<Any>()
+            member.isSet -> emptySet<Any>()
+            member.isMap -> emptyMap<Any, Any>()
+            else -> error("Not a collection type")
+        }
+    }
+
+    // === 容器类型 Accessor 工厂方法 ===
+
+    /**
+     * 通过父记录 @Id 值获取 Map 类型字段的数据库代理
+     *
+     * @param id 父记录的 @Id 值
+     * @param fieldName 容器字段名（支持属性名和列名匹配）
+     * @return [DatabaseMap] 代理对象
+     */
+    fun mapAccessor(id: Any, fieldName: String): DatabaseMap {
+        val info = resolveCollectionTableInfo(fieldName) { it.isMap }
+        return DatabaseMap(dataSource, info, id.value(), sharedConnection)
+    }
+
+    /**
+     * 通过 Filter 查找父记录，返回 Map 类型字段的数据库代理
+     */
+    fun mapAccessor(fieldName: String, filter: Filter.() -> Unit): DatabaseMap {
+        val info = resolveCollectionTableInfo(fieldName) { it.isMap }
+        val parentId = resolveParentId(filter)
+        return DatabaseMap(dataSource, info, parentId, sharedConnection)
+    }
+
+    /**
+     * 通过父记录 @Id 值获取 List 类型字段的数据库代理
+     *
+     * @param id 父记录的 @Id 值
+     * @param fieldName 容器字段名（支持属性名和列名匹配）
+     * @return [DatabaseList] 代理对象
+     */
+    fun listAccessor(id: Any, fieldName: String): DatabaseList {
+        val info = resolveCollectionTableInfo(fieldName) { it.isList }
+        return DatabaseList(dataSource, info, id.value(), sharedConnection)
+    }
+
+    /**
+     * 通过 Filter 查找父记录，返回 List 类型字段的数据库代理
+     */
+    fun listAccessor(fieldName: String, filter: Filter.() -> Unit): DatabaseList {
+        val info = resolveCollectionTableInfo(fieldName) { it.isList }
+        val parentId = resolveParentId(filter)
+        return DatabaseList(dataSource, info, parentId, sharedConnection)
+    }
+
+    /**
+     * 通过父记录 @Id 值获取 Set 类型字段的数据库代理
+     *
+     * @param id 父记录的 @Id 值
+     * @param fieldName 容器字段名（支持属性名和列名匹配）
+     * @return [DatabaseSet] 代理对象
+     */
+    fun setAccessor(id: Any, fieldName: String): DatabaseSet {
+        val info = resolveCollectionTableInfo(fieldName) { it.isSet }
+        return DatabaseSet(dataSource, info, id.value(), sharedConnection)
+    }
+
+    /**
+     * 通过 Filter 查找父记录，返回 Set 类型字段的数据库代理
+     */
+    fun setAccessor(fieldName: String, filter: Filter.() -> Unit): DatabaseSet {
+        val info = resolveCollectionTableInfo(fieldName) { it.isSet }
+        val parentId = resolveParentId(filter)
+        return DatabaseSet(dataSource, info, parentId, sharedConnection)
+    }
+
+    /**
+     * 根据字段名查找 CollectionTableInfo
+     *
+     * @param fieldName 字段名（匹配 propertyName 或 name）
+     * @param typeCheck 容器类型检查（isMap/isList/isSet）
+     */
+    private fun resolveCollectionTableInfo(fieldName: String, typeCheck: (AnalyzedClassMember) -> Boolean): CollectionTableInfo {
+        if (collectionTableInfos.isNullOrEmpty()) {
+            error("No collection table info found. Ensure the class has collection members.")
+        }
+        return collectionTableInfos.firstOrNull { info ->
+            (info.member.propertyName == fieldName || info.member.name == fieldName) && typeCheck(info.member)
+        } ?: error("Collection field '$fieldName' not found or type mismatch.")
+    }
+
+    /**
+     * 通过 Filter 查询父记录 @Id 值
+     */
+    private fun resolveParentId(filter: Filter.() -> Unit): Any {
+        val action = ActionSelect(table.name).apply {
+            limit(1)
+            where(filter)
+        }
+        return executeQuery(action) { rs ->
+            if (rs.next()) {
+                val primaryName = collectionTableInfos?.firstOrNull()?.fkColumnName
+                    ?.removePrefix("parent_")
+                    ?: error("Cannot determine primary key column.")
+                rs.getObject(primaryName) ?: error("Parent record primary key is null.")
+            } else {
+                throw NoSuchElementException("No parent record found matching the given filter.")
+            }
         }
     }
 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerPostgreSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerPostgreSQL.kt
@@ -29,6 +29,8 @@ class ContainerPostgreSQL(
                 add { id() }
             }
             type.members.forEach { member ->
+                // 跳过容器类型成员（它们存储在子表中）
+                if (member.isCollection) return@forEach
                 // @LinkTable 成员：创建外键列而非展开关联类
                 if (member.isLinkTable) {
                     val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
@@ -103,6 +105,47 @@ class ContainerPostgreSQL(
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    override fun createCollectionTableObject(
+        parentType: AnalyzedClass,
+        parentTableName: String,
+        member: AnalyzedClassMember,
+        childTableName: String
+    ): Table<*, *> {
+        val primaryMember = parentType.primaryMember!!
+        return Table(childTableName, host) {
+            add { id() }
+            // FK 列：引用主表的 @Id
+            add("parent_${primaryMember.name}") {
+                when {
+                    primaryMember.hasColumnType && primaryMember.columnTypePostgreSQL != ColumnTypePostgreSQL._DEFAULT -> {
+                        val colType = primaryMember.columnTypePostgreSQL!!
+                        if (colType.isRequired) type(colType, primaryMember.length) else type(colType)
+                    }
+                    primaryMember.hasColumnType && primaryMember.columnTypePostgreSQL == ColumnTypePostgreSQL._DEFAULT -> {
+                        val pgType = primaryMember.columnTypeSQL!!.toPostgreSQL()
+                        if (pgType.isRequired) type(pgType, primaryMember.length) else type(pgType)
+                    }
+                    primaryMember.isIndexedEnum -> type(ColumnTypePostgreSQL.BIGINT)
+                    primaryMember.isString || primaryMember.isEnum -> {
+                        if (primaryMember.length < 0) type(ColumnTypePostgreSQL.TEXT)
+                        else type(ColumnTypePostgreSQL.VARCHAR, primaryMember.length)
+                    }
+                    primaryMember.isUUID -> type(ColumnTypePostgreSQL.UUID)
+                    else -> type(primaryMember.type())
+                }
+            }
+            if (member.isMap) {
+                add("map_key") { type(ColumnTypePostgreSQL.VARCHAR, 512) }
+                add("map_value") { type(ColumnTypePostgreSQL.VARCHAR, 512) }
+            } else {
+                add("value") { type(ColumnTypePostgreSQL.VARCHAR, 512) }
+                if (member.isList) {
+                    add("sort_order") { type(ColumnTypePostgreSQL.INTEGER) }
                 }
             }
         }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
@@ -29,6 +29,8 @@ class ContainerSQL(
                 add { id() }
             }
             type.members.forEach { member ->
+                // 跳过容器类型成员（它们存储在子表中）
+                if (member.isCollection) return@forEach
                 // @LinkTable 成员：创建外键列而非展开关联类
                 if (member.isLinkTable) {
                     val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
@@ -88,6 +90,43 @@ class ContainerSQL(
                             type(customType.typeSQL, customType.length) { options(member) }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    override fun createCollectionTableObject(
+        parentType: AnalyzedClass,
+        parentTableName: String,
+        member: AnalyzedClassMember,
+        childTableName: String
+    ): Table<*, *> {
+        val primaryMember = parentType.primaryMember!!
+        return Table(childTableName, host) {
+            add { id() }
+            // FK 列：引用主表的 @Id
+            add("parent_${primaryMember.name}") {
+                when {
+                    primaryMember.hasColumnType -> {
+                        val colType = primaryMember.columnTypeSQL!!
+                        if (colType.isRequired) type(colType, primaryMember.length) else type(colType)
+                    }
+                    primaryMember.isIndexedEnum -> type(ColumnTypeSQL.BIGINT)
+                    primaryMember.isString || primaryMember.isEnum -> {
+                        if (primaryMember.length < 0) type(ColumnTypeSQL.LONGTEXT)
+                        else type(ColumnTypeSQL.VARCHAR, primaryMember.length)
+                    }
+                    primaryMember.isUUID -> type(ColumnTypeSQL.CHAR, 36)
+                    else -> type(primaryMember.type())
+                }
+            }
+            if (member.isMap) {
+                add("map_key") { type(ColumnTypeSQL.VARCHAR, 512) }
+                add("map_value") { type(ColumnTypeSQL.VARCHAR, 512) }
+            } else {
+                add("value") { type(ColumnTypeSQL.VARCHAR, 512) }
+                if (member.isList) {
+                    add("sort_order") { type(ColumnTypeSQL.INT) }
                 }
             }
         }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
@@ -20,6 +20,8 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
                 add { id() }
             }
             type.members.forEach { member ->
+                // 跳过容器类型成员（它们存储在子表中）
+                if (member.isCollection) return@forEach
                 // @LinkTable 成员：创建外键列而非展开关联类
                 if (member.isLinkTable) {
                     val linkedClass = AnalyzedClass.of(member.linkTableClass!!)
@@ -72,6 +74,40 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
                         val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType) ?: error("Unsupported type: ${member.name} (${member.returnType})")
                         add(member.name) { type(customType.typeSQLite, customType.length) { options(member) } }
                     }
+                }
+            }
+        }
+    }
+
+    override fun createCollectionTableObject(
+        parentType: AnalyzedClass,
+        parentTableName: String,
+        member: AnalyzedClassMember,
+        childTableName: String
+    ): Table<*, *> {
+        val primaryMember = parentType.primaryMember!!
+        return Table(childTableName, host) {
+            add { id() }
+            // FK 列：引用主表的 @Id
+            add("parent_${primaryMember.name}") {
+                when {
+                    primaryMember.isString || primaryMember.isEnum -> type(ColumnTypeSQLite.TEXT, primaryMember.length)
+                    primaryMember.isUUID -> type(ColumnTypeSQLite.TEXT, 36)
+                    primaryMember.canConvertedInteger() -> type(ColumnTypeSQLite.INTEGER)
+                    primaryMember.canConvertedDecimal() -> type(ColumnTypeSQLite.REAL)
+                    else -> type(ColumnTypeSQLite.TEXT)
+                }
+            }
+            if (member.isMap) {
+                // Map<K, V> → map_key, map_value
+                add("map_key") { type(ColumnTypeSQLite.TEXT, 512) }
+                add("map_value") { type(ColumnTypeSQLite.TEXT, 512) }
+            } else {
+                // List<T> / Set<T> → value
+                add("value") { type(ColumnTypeSQLite.TEXT, 512) }
+                if (member.isList) {
+                    // List 需要 sort_order 保序
+                    add("sort_order") { type(ColumnTypeSQLite.INTEGER) }
                 }
             }
         }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapper.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapper.kt
@@ -183,4 +183,54 @@ interface DataMapper<T> {
 
     // === 生命周期 ===
     fun close()
+
+    // === 容器类型 Accessor ===
+
+    /**
+     * 获取 Map 类型容器字段的数据库代理（通过 @Id 定位父记录）
+     *
+     * ```kotlin
+     * val props: MutableMap<String, String?> = mapper.mapOf("player1", "props")
+     * props["key1"] = "value1"   // → SQL INSERT/UPDATE
+     * props["key1"]              // → SQL SELECT
+     * ```
+     */
+    fun mapOf(id: Any, fieldName: String): MutableMap<String, String?>
+
+    /**
+     * 获取 Map 类型容器字段的数据库代理（通过 Filter 定位父记录）
+     */
+    fun mapOf(fieldName: String, filter: Filter.() -> Unit): MutableMap<String, String?>
+
+    /**
+     * 获取 List 类型容器字段的数据库代理（通过 @Id 定位父记录）
+     *
+     * ```kotlin
+     * val tags: MutableList<String?> = mapper.listOf("player1", "tags")
+     * tags.add("newTag")         // → SQL INSERT
+     * tags[0]                    // → SQL SELECT
+     * ```
+     */
+    fun listOf(id: Any, fieldName: String): MutableList<String?>
+
+    /**
+     * 获取 List 类型容器字段的数据库代理（通过 Filter 定位父记录）
+     */
+    fun listOf(fieldName: String, filter: Filter.() -> Unit): MutableList<String?>
+
+    /**
+     * 获取 Set 类型容器字段的数据库代理（通过 @Id 定位父记录）
+     *
+     * ```kotlin
+     * val scores: MutableSet<String?> = mapper.setOf("player1", "scores")
+     * scores.add("100")          // → SQL INSERT IF NOT EXISTS
+     * scores.contains("100")     // → SQL SELECT EXISTS
+     * ```
+     */
+    fun setOf(id: Any, fieldName: String): MutableSet<String?>
+
+    /**
+     * 获取 Set 类型容器字段的数据库代理（通过 Filter 定位父记录）
+     */
+    fun setOf(fieldName: String, filter: Filter.() -> Unit): MutableSet<String?>
 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapperImpl.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/DataMapperImpl.kt
@@ -300,6 +300,32 @@ class DataMapperImpl<T>(
 
     override fun close() = container.close()
 
+    // === 容器类型 Accessor ===
+
+    override fun mapOf(id: Any, fieldName: String): MutableMap<String, String?> {
+        return (operator as ContainerOperatorImpl).mapAccessor(id, fieldName)
+    }
+
+    override fun mapOf(fieldName: String, filter: Filter.() -> Unit): MutableMap<String, String?> {
+        return (operator as ContainerOperatorImpl).mapAccessor(fieldName, filter)
+    }
+
+    override fun listOf(id: Any, fieldName: String): MutableList<String?> {
+        return (operator as ContainerOperatorImpl).listAccessor(id, fieldName)
+    }
+
+    override fun listOf(fieldName: String, filter: Filter.() -> Unit): MutableList<String?> {
+        return (operator as ContainerOperatorImpl).listAccessor(fieldName, filter)
+    }
+
+    override fun setOf(id: Any, fieldName: String): MutableSet<String?> {
+        return (operator as ContainerOperatorImpl).setAccessor(id, fieldName)
+    }
+
+    override fun setOf(fieldName: String, filter: Filter.() -> Unit): MutableSet<String?> {
+        return (operator as ContainerOperatorImpl).setAccessor(fieldName, filter)
+    }
+
     // === 缓存辅助 ===
 
     @Suppress("UNCHECKED_CAST")

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionalDataMapper.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionalDataMapper.kt
@@ -252,6 +252,32 @@ class TransactionalDataMapper<T>(
         error("Cannot close container within a transaction")
     }
 
+    // === 容器类型 Accessor ===
+
+    override fun mapOf(id: Any, fieldName: String): MutableMap<String, String?> {
+        return (operator as ContainerOperatorImpl).mapAccessor(id, fieldName)
+    }
+
+    override fun mapOf(fieldName: String, filter: Filter.() -> Unit): MutableMap<String, String?> {
+        return (operator as ContainerOperatorImpl).mapAccessor(fieldName, filter)
+    }
+
+    override fun listOf(id: Any, fieldName: String): MutableList<String?> {
+        return (operator as ContainerOperatorImpl).listAccessor(id, fieldName)
+    }
+
+    override fun listOf(fieldName: String, filter: Filter.() -> Unit): MutableList<String?> {
+        return (operator as ContainerOperatorImpl).listAccessor(fieldName, filter)
+    }
+
+    override fun setOf(id: Any, fieldName: String): MutableSet<String?> {
+        return (operator as ContainerOperatorImpl).setAccessor(id, fieldName)
+    }
+
+    override fun setOf(fieldName: String, filter: Filter.() -> Unit): MutableSet<String?> {
+        return (operator as ContainerOperatorImpl).setAccessor(fieldName, filter)
+    }
+
     // === L2 缓存失效策略 ===
 
     private fun buildCacheKey(method: String, vararg args: Any?): String {

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/CollectionTest.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/CollectionTest.kt
@@ -1,0 +1,253 @@
+package taboolib.expansion
+
+import com.zaxxer.hikari.HikariDataSource
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CollectionTest {
+
+    private lateinit var dataSource: HikariDataSource
+    private lateinit var container: TestContainer
+
+    @BeforeEach
+    fun setup() {
+        AnalyzedClass.cached.clear()
+        dataSource = createTestDataSource()
+        container = TestContainer(dataSource)
+    }
+
+    @AfterEach
+    fun teardown() {
+        container.close()
+    }
+
+    @Test
+    fun `List - insert and query`() {
+        container.new<ListData>()
+        val op = container.get<ListData>()
+        val data = ListData("p1", "player1", listOf("tag1", "tag2", "tag3"))
+        op.insert(listOf(data))
+        val result = op.findOne(ListData::class.java, "p1")!!
+        assertEquals("p1", result.id)
+        assertEquals("player1", result.label)
+        assertEquals(listOf("tag1", "tag2", "tag3"), result.tags)
+    }
+
+    @Test
+    fun `List - preserves order`() {
+        container.new<ListData>()
+        val op = container.get<ListData>()
+        val data = ListData("p1", "test", listOf("c", "a", "b"))
+        op.insert(listOf(data))
+        val result = op.findOne(ListData::class.java, "p1")!!
+        assertEquals(listOf("c", "a", "b"), result.tags)
+    }
+
+    @Test
+    fun `Set - insert and query`() {
+        container.new<SetData>()
+        val op = container.get<SetData>()
+        val data = SetData("s1", setOf("10", "20", "30"))
+        op.insert(listOf(data))
+        val result = op.findOne(SetData::class.java, "s1")!!
+        assertEquals(setOf("10", "20", "30"), result.scores)
+    }
+
+    @Test
+    fun `Map - insert and query`() {
+        container.new<MapData>()
+        val op = container.get<MapData>()
+        val data = MapData("m1", mapOf("key1" to "val1", "key2" to "val2"))
+        op.insert(listOf(data))
+        val result = op.findOne(MapData::class.java, "m1")!!
+        assertEquals(mapOf("key1" to "val1", "key2" to "val2"), result.props)
+    }
+
+    @Test
+    fun `Mixed collections - insert and query`() {
+        container.new<MixedCollectionData>()
+        val op = container.get<MixedCollectionData>()
+        val data = MixedCollectionData(
+            "x1", "mixed",
+            listOf("a", "b"),
+            setOf("f1", "f2"),
+            mapOf("k" to "v")
+        )
+        op.insert(listOf(data))
+        val result = op.findOne(MixedCollectionData::class.java, "x1")!!
+        assertEquals("mixed", result.name)
+        assertEquals(listOf("a", "b"), result.tags)
+        assertEquals(setOf("f1", "f2"), result.uniqueFlags)
+        assertEquals(mapOf("k" to "v"), result.metadata)
+    }
+
+    @Test
+    fun `Update syncs collection data`() {
+        container.new<ListData>()
+        val op = container.get<ListData>()
+        op.insert(listOf(ListData("p1", "v1", listOf("old1", "old2"))))
+        // update with new tags
+        op.update(ListData("p1", "v2", listOf("new1", "new2", "new3")))
+        val result = op.findOne(ListData::class.java, "p1")!!
+        assertEquals("v2", result.label)
+        assertEquals(listOf("new1", "new2", "new3"), result.tags)
+    }
+
+    @Test
+    fun `Delete cascades to collection tables`() {
+        container.new<ListData>()
+        val op = container.get<ListData>()
+        op.insert(listOf(ListData("p1", "v1", listOf("t1", "t2"))))
+        op.delete(ListData::class.java, "p1")
+        val result = op.findOne(ListData::class.java, "p1")
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `Empty collection`() {
+        container.new<ListData>()
+        val op = container.get<ListData>()
+        op.insert(listOf(ListData("p1", "empty", emptyList())))
+        val result = op.findOne(ListData::class.java, "p1")!!
+        assertEquals(emptyList<String>(), result.tags)
+    }
+
+    @Test
+    fun `Multiple records with collections`() {
+        container.new<ListData>()
+        val op = container.get<ListData>()
+        op.insert(listOf(
+            ListData("p1", "first", listOf("a", "b")),
+            ListData("p2", "second", listOf("c", "d", "e"))
+        ))
+        val results = op.get(ListData::class.java) {}
+        assertEquals(2, results.size)
+        val r1 = results.first { it.id == "p1" }
+        val r2 = results.first { it.id == "p2" }
+        assertEquals(listOf("a", "b"), r1.tags)
+        assertEquals(listOf("c", "d", "e"), r2.tags)
+    }
+
+    // === Accessor 测试 ===
+
+    @Test
+    fun `MapAccessor - put, get, containsKey, remove, size, clear`() {
+        container.new<MapData>()
+        val op = container.get<MapData>()
+        op.insert(listOf(MapData("m1", mapOf("k1" to "v1"))))
+        val map = op.mapAccessor("m1", "props")
+        // get existing
+        assertEquals("v1", map["k1"])
+        assertEquals(1, map.size)
+        assertTrue(map.containsKey("k1"))
+        // put new
+        map["k2"] = "v2"
+        assertEquals("v2", map["k2"])
+        assertEquals(2, map.size)
+        // put overwrite
+        map["k1"] = "v1_new"
+        assertEquals("v1_new", map["k1"])
+        assertEquals(2, map.size)
+        // remove
+        val removed = map.remove("k1")
+        assertEquals("v1_new", removed)
+        assertEquals(1, map.size)
+        assertFalse(map.containsKey("k1"))
+        // clear
+        map.clear()
+        assertEquals(0, map.size)
+    }
+
+    @Test
+    fun `MapAccessor - entries iteration`() {
+        container.new<MapData>()
+        val op = container.get<MapData>()
+        op.insert(listOf(MapData("m1", mapOf("a" to "1", "b" to "2"))))
+        val map = op.mapAccessor("m1", "props")
+        val entries = map.entries.associate { it.key to it.value }
+        assertEquals(mapOf("a" to "1", "b" to "2"), entries)
+    }
+
+    @Test
+    fun `ListAccessor - get, add, set, removeAt, size, contains`() {
+        container.new<ListData>()
+        val op = container.get<ListData>()
+        op.insert(listOf(ListData("p1", "test", listOf("a", "b", "c"))))
+        val list = op.listAccessor("p1", "tags")
+        // get
+        assertEquals("a", list[0])
+        assertEquals("b", list[1])
+        assertEquals("c", list[2])
+        assertEquals(3, list.size)
+        // contains
+        assertTrue(list.contains("b"))
+        assertFalse(list.contains("z"))
+        // add at end
+        list.add("d")
+        assertEquals(4, list.size)
+        assertEquals("d", list[3])
+        // add at index
+        list.add(1, "x")
+        assertEquals(5, list.size)
+        assertEquals("a", list[0])
+        assertEquals("x", list[1])
+        assertEquals("b", list[2])
+        // set
+        val old = list.set(0, "A")
+        assertEquals("a", old)
+        assertEquals("A", list[0])
+        // removeAt
+        val removedVal = list.removeAt(1) // remove "x"
+        assertEquals("x", removedVal)
+        assertEquals(4, list.size)
+        assertEquals("A", list[0])
+        assertEquals("b", list[1])
+    }
+
+    @Test
+    fun `SetAccessor - add, contains, remove, size, clear, iterator`() {
+        container.new<SetData>()
+        val op = container.get<SetData>()
+        op.insert(listOf(SetData("s1", setOf("10", "20"))))
+        val set = op.setAccessor("s1", "scores")
+        // initial state
+        assertEquals(2, set.size)
+        assertTrue(set.contains("10"))
+        assertTrue(set.contains("20"))
+        assertFalse(set.contains("30"))
+        // add new
+        assertTrue(set.add("30"))
+        assertEquals(3, set.size)
+        assertTrue(set.contains("30"))
+        // add duplicate
+        assertFalse(set.add("10"))
+        assertEquals(3, set.size)
+        // remove
+        assertTrue(set.remove("20"))
+        assertEquals(2, set.size)
+        assertFalse(set.contains("20"))
+        // remove non-existent
+        assertFalse(set.remove("999"))
+        // iterator
+        val values = set.iterator().asSequence().toSet()
+        assertEquals(setOf("10", "30"), values)
+        // clear
+        set.clear()
+        assertEquals(0, set.size)
+    }
+
+    @Test
+    fun `Accessor - verify database persistence`() {
+        container.new<MapData>()
+        val op = container.get<MapData>()
+        op.insert(listOf(MapData("m1", emptyMap())))
+        // write via accessor
+        val map = op.mapAccessor("m1", "props")
+        map["persistent_key"] = "persistent_val"
+        // verify via full object read
+        val result = op.findOne(MapData::class.java, "m1")!!
+        assertEquals(mapOf("persistent_key" to "persistent_val"), result.props)
+    }
+}

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TestHelper.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TestHelper.kt
@@ -140,6 +140,34 @@ data class Level1Data(
 
 // endregion
 
+// region 容器类型测试用 data class
+
+data class ListData(
+    @Id val id: String,
+    var label: String,
+    val tags: List<String>
+)
+
+data class SetData(
+    @Id val id: String,
+    val scores: Set<String>
+)
+
+data class MapData(
+    @Id val id: String,
+    val props: Map<String, String>
+)
+
+data class MixedCollectionData(
+    @Id val id: String,
+    var name: String,
+    val tags: List<String>,
+    val uniqueFlags: Set<String>,
+    val metadata: Map<String, String>
+)
+
+// endregion
+
 // region 工具函数
 
 /**
@@ -171,9 +199,58 @@ fun createTestOperator(
     val table = buildSQLiteTable(analyzedClass, name)
     table.createTable(dataSource)
     classTableMap?.put(type, name)
-    val operator = ContainerOperatorImpl(table, dataSource, classTableMap = classTableMap, classOperatorMap = classOperatorMap)
+    // 创建容器子表
+    val collectionInfos = mutableListOf<CollectionTableInfo>()
+    if (analyzedClass.hasCollectionMembers) {
+        val primaryMember = analyzedClass.primaryMember!!
+        for (member in analyzedClass.collectionMembers) {
+            val childTableName = "${name}_${member.name}"
+            val fkColumnName = "parent_${primaryMember.name}"
+            val childTable = buildCollectionSQLiteTable(primaryMember, member, childTableName)
+            childTable.createTable(dataSource)
+            collectionInfos += CollectionTableInfo(childTableName, fkColumnName, member, childTable)
+        }
+    }
+    val operator = ContainerOperatorImpl(
+        table, dataSource,
+        classTableMap = classTableMap, classOperatorMap = classOperatorMap,
+        collectionTableInfos = collectionInfos.ifEmpty { null }
+    )
     classOperatorMap?.put(type, operator)
     return operator
+}
+
+/**
+ * 构建容器子表的 SQLite Table 对象
+ */
+private fun buildCollectionSQLiteTable(
+    primaryMember: AnalyzedClassMember,
+    member: AnalyzedClassMember,
+    childTableName: String
+): Table<HostSQLite, SQLite> {
+    val fakeHost = HostSQLite(java.io.File("test.db"))
+    return Table(childTableName, fakeHost) {
+        add { id() }
+        // FK 列
+        add("parent_${primaryMember.name}") {
+            when {
+                primaryMember.isString || primaryMember.isEnum -> type(ColumnTypeSQLite.TEXT, primaryMember.length)
+                primaryMember.isUUID -> type(ColumnTypeSQLite.TEXT, 36)
+                primaryMember.canConvertedInteger() -> type(ColumnTypeSQLite.INTEGER)
+                primaryMember.canConvertedDecimal() -> type(ColumnTypeSQLite.REAL)
+                else -> type(ColumnTypeSQLite.TEXT)
+            }
+        }
+        if (member.isMap) {
+            add("map_key") { type(ColumnTypeSQLite.TEXT, 512) }
+            add("map_value") { type(ColumnTypeSQLite.TEXT, 512) }
+        } else {
+            add("value") { type(ColumnTypeSQLite.TEXT, 512) }
+            if (member.isList) {
+                add("sort_order") { type(ColumnTypeSQLite.INTEGER) }
+            }
+        }
+    }
 }
 
 /**
@@ -186,6 +263,8 @@ private fun buildSQLiteTable(type: AnalyzedClass, name: String): Table<HostSQLit
             add { id() }
         }
         type.members.forEach { member ->
+            // 跳过容器类型成员（它们存储在子表中）
+            if (member.isCollection) return@forEach
             // @LinkTable 成员：创建外键列
             if (member.isLinkTable) {
                 val linkedClass = AnalyzedClass.of(member.linkTableClass!!)


### PR DESCRIPTION
## 概述

为 database-ptc-object 模块添加容器类型（List/Set/Map）字段的子表存储支持，以及基于代理模式的 Collection Accessor API。

## 主要改动

### 容器类型子表支持
- 数据类中的 `List<String>`、`Set<String>`、`Map<String, String>` 字段自动创建独立子表存储
- List 子表通过 `sort_order` 列保持插入顺序
- Map 子表使用 `map_key` + `map_value` 列存储键值对
- 支持 SQLite / MySQL / PostgreSQL 三种数据库
- insert/update/delete 时自动同步子表数据（级联删除）

### 连接池死锁修复
- 将读取路径拆分为两阶段：Phase 1 在连接内读 ResultSet 到 Map，Phase 2 释放连接后加载子表数据
- 解决 `maximumPoolSize=1` 场景下嵌套获取连接导致的超时死锁

### PostgreSQL 列名引用兼容
- 子表 SQL 中的硬编码反引号（`` ` ``）改为 `asFormattedColumnName()` 动态引用

### Collection Accessor API
- 新增 `DatabaseMap` / `DatabaseList` / `DatabaseSet` 代理类，实现标准 `MutableMap` / `MutableList` / `MutableSet` 接口
- DataMapper 接口新增 `mapOf()` / `listOf()` / `setOf()` 方法，支持按 @Id 或 Filter 定位父记录后直接操作子表

## 修改文件

| 模块 | 文件 | 改动 |
|------|------|------|
| database-ptc-object | `AnalyzedClass.kt` | 新增 `hasCollectionMembers` / `collectionMembers` |
| database-ptc-object | `AnalyzedClassMember.kt` | 新增 `isList` / `isSet` / `isMap` / `isCollection` |
| database-ptc-object | `Container.kt` | 容器接口支持 `collectionTableInfos` |
| database-ptc-object | `ContainerOperatorImpl.kt` | 两阶段读取 + Accessor 工厂方法 + PG 引用修复 |
| database-ptc-object | `ContainerSQL.kt` | MySQL 子表建表 |
| database-ptc-object | `ContainerSQLite.kt` | SQLite 子表建表 |
| database-ptc-object | `ContainerPostgreSQL.kt` | PostgreSQL 子表建表 |
| database-ptc-object | `CollectionTableInfo.kt` | **新建** 子表元数据 |
| database-ptc-object | `CollectionAccessor.kt` | **新建** 三个代理类 |
| database-ptc-object | `DataMapper.kt` | 接口新增 6 个方法 |
| database-ptc-object | `DataMapperImpl.kt` | 实现 Accessor 委托 |
| database-ptc-object | `TransactionalDataMapper.kt` | 实现 Accessor 委托 |
| test | `CollectionTest.kt` | **新建** 14 个容器测试用例 |

Closes TabooLib/taboolib#661