### PR TITLE
[feat] PTC Object: @Ignore 注解、集合 CustomType、事务传播

### DIFF
--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClass.kt
@@ -70,14 +70,30 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
     /** 主成员名称 */
     val primaryMemberName = primaryMember?.name
 
-    /** 实际映射到列的成员（排除 @LinkTable 成员和容器成员） */
-    val columnMembers = members.filter { !it.isLinkTable && !it.isCollection }
+    /** 实际映射到列的成员（排除 @Ignore、@LinkTable 成员和容器成员） */
+    val columnMembers = members.filter { !it.isIgnored && !it.isLinkTable && !it.isCollection }
 
     /** @LinkTable 成员列表 */
     val linkMembers = members.filter { it.isLinkTable }
 
     /** 是否存在 @LinkTable 成员 */
     val hasLinkMembers = linkMembers.isNotEmpty()
+
+    /** 是否存在 @Ignore 成员 */
+    val hasIgnoredMembers = members.any { it.isIgnored }
+
+    /**
+     * Kotlin 合成默认构造器（带 DefaultConstructorMarker 参数）。
+     * 仅在存在 @Ignore 成员时查找，用于利用 Kotlin 声明的默认值。
+     */
+    private val kotlinDefaultConstructor = if (hasIgnoredMembers && !fieldScanMode) {
+        clazz.declaredConstructors.firstOrNull { ctor ->
+            val params = ctor.parameterTypes
+            params.size >= 2
+                && params[params.size - 1].name == "kotlin.jvm.internal.DefaultConstructorMarker"
+                && params[params.size - 2] == Int::class.javaPrimitiveType
+        }?.also { it.isAccessible = true }
+    } else null
 
     /** 容器类型成员列表（List/Set/Map） */
     val collectionMembers = members.filter { it.isCollection }
@@ -163,12 +179,12 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
         return property.get(data)
     }
 
-    /** 读取数据（不含 @LinkTable 成员和容器成员） */
+    /** 读取数据（不含 @Ignore、@LinkTable 成员和容器成员） */
     fun read(result: ResultSet): Map<String, Any?> {
         val map = hashMapOf<String, Any?>()
         members.forEach { member ->
-            // 跳过 @LinkTable 成员和容器成员，它们没有对应的列
-            if (member.isLinkTable || member.isCollection) return@forEach
+            // 跳过 @Ignore、@LinkTable 成员和容器成员（扁平化集合不跳过，它们有对应的列）
+            if (member.isIgnored || member.isLinkTable || member.isCollection) return@forEach
             val obj: Any? = result.getObject(member.name)
             if (obj == null) {
                 map[member.name] = null
@@ -250,6 +266,10 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
                     """.t()
                 )
             member.isByteArray -> obj.cByteArray
+            member.isFlattenedCollection -> {
+                val ct = CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)!!
+                ct.deserialize(obj)
+            }
             else -> {
                 val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType) ?: error(
                     """
@@ -273,9 +293,10 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
                 """.t()
             )
         } else if (fieldScanMode) {
-            // 字段扫描模式：无参构造 + 反射设值
+            // 字段扫描模式：无参构造 + 反射设值（@Ignore 字段不设值，保留无参构造器的初始值）
             val instance = noArgConstructor!!.newInstance()
             members.forEach { member ->
+                if (member.isIgnored) return@forEach
                 val field = memberProperties[member.propertyName] ?: return@forEach
                 field.isAccessible = true
                 val value = map[member.name]
@@ -284,6 +305,52 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
                 }
             }
             instance
+        } else if (hasIgnoredMembers && kotlinDefaultConstructor != null) {
+            // 主构造器模式 + 存在 @Ignore 成员：使用 Kotlin 合成默认构造器
+            // 构建 defaultMask：被忽略的参数位设为 1，让 Kotlin 使用声明的默认值
+            var defaultMask = 0
+            val args = members.mapIndexed { index, member ->
+                if (member.isIgnored) {
+                    defaultMask = defaultMask or (1 shl index)
+                    // 传入占位值（Kotlin 会用默认值覆盖），对于无默认值的参数需要类型安全的零值
+                    defaultValueForType(member)
+                } else {
+                    map[member.name]
+                }
+            }
+            try {
+                kotlinDefaultConstructor.newInstance(*args.toTypedArray(), defaultMask, null)
+            } catch (ex: Throwable) {
+                // 合成构造器调用失败（可能参数无默认值），回退到手动填充默认值
+                val fallbackArgs = members.map { member ->
+                    if (member.isIgnored) defaultValueForType(member) else map[member.name]
+                }
+                try {
+                    primaryConstructor!!.newInstance(*fallbackArgs.toTypedArray())
+                } catch (ex2: Throwable) {
+                    error(
+                        """
+                        无法创建 $clazz 实例。($fallbackArgs, map=$map)
+                        Failed to create instance for $clazz. ($fallbackArgs, map=$map)
+                        """.t()
+                    )
+                }
+            }
+        } else if (hasIgnoredMembers) {
+            // 主构造器模式 + 存在 @Ignore 成员但无 Kotlin 合成构造器：手动填充默认值
+            val args = members.map { member ->
+                if (member.isIgnored) defaultValueForType(member) else map[member.name]
+            }
+            try {
+                primaryConstructor!!.newInstance(*args.toTypedArray())
+            } catch (ex: Throwable) {
+                error(
+                    """
+                    无法创建 $clazz 实例。($args, map=$map)
+                    Failed to create instance for $clazz. ($args, map=$map)
+                    """.t()
+                )
+            }
         } else {
             val args = members.map { map[it.name] }
             try {
@@ -298,6 +365,35 @@ class AnalyzedClass private constructor(val clazz: Class<*>) {
             }
         }
         return result as T
+    }
+
+    /**
+     * 为 @Ignore 字段生成类型安全的默认值。
+     * - 可空类型（非原始类型且非容器） → null
+     * - List → emptyList()
+     * - Set → emptySet()
+     * - Map → emptyMap()
+     * - 基础类型 → 零值
+     * - String → ""
+     * - 其他引用类型 → null
+     */
+    private fun defaultValueForType(member: AnalyzedClassMember): Any? {
+        val type = member.returnType
+        return when {
+            List::class.java.isAssignableFrom(type) -> emptyList<Any>()
+            Set::class.java.isAssignableFrom(type) -> emptySet<Any>()
+            Map::class.java.isAssignableFrom(type) -> emptyMap<Any, Any>()
+            type == Boolean::class.javaPrimitiveType || type == Boolean::class.java -> false
+            type == Byte::class.javaPrimitiveType || type == Byte::class.java -> 0.toByte()
+            type == Short::class.javaPrimitiveType || type == Short::class.java -> 0.toShort()
+            type == Int::class.javaPrimitiveType || type == Int::class.java -> 0
+            type == Long::class.javaPrimitiveType || type == Long::class.java -> 0L
+            type == Float::class.javaPrimitiveType || type == Float::class.java -> 0.0f
+            type == Double::class.javaPrimitiveType || type == Double::class.java -> 0.0
+            type == Char::class.javaPrimitiveType || type == Char::class.java -> '\u0000'
+            type == String::class.java -> ""
+            else -> null
+        }
     }
 
     /** 验证参数 */

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
@@ -68,17 +68,20 @@ class AnalyzedClassMember(private val root: AnnotatedElement, name: String, val 
     /** 泛型参数化类型 */
     val parameterizedType: ParameterizedType? = genericType as? ParameterizedType
 
-    /** 是否为 ID 键 */
-    val isPrimary = root.findAnnotation<Id>() != null
+    /** 是否为忽略字段（优先级最高，不参与数据库读写） */
+    val isIgnored: Boolean = root.findAnnotation<Ignore>() != null
 
-    /** 是否建立索引 */
-    val isKey = root.findAnnotation<Key>() != null
+    /** 是否为 ID 键（@Ignore 优先级最高，忽略字段不作为主键） */
+    val isPrimary = !isIgnored && root.findAnnotation<Id>() != null
 
-    /** 是否建立唯一索引 */
-    val isUniqueKey = root.findAnnotation<UniqueKey>() != null
+    /** 是否建立索引（@Ignore 优先级最高） */
+    val isKey = !isIgnored && root.findAnnotation<Key>() != null
 
-    /** 是否不为空 */
-    val isNotNull = root.findAnnotation<NotNull>() != null
+    /** 是否建立唯一索引（@Ignore 优先级最高） */
+    val isUniqueKey = !isIgnored && root.findAnnotation<UniqueKey>() != null
+
+    /** 是否不为空（@Ignore 优先级最高） */
+    val isNotNull = !isIgnored && root.findAnnotation<NotNull>() != null
 
     /** 长度 */
     val length = root.findAnnotation<Length>()?.value ?: 64
@@ -96,7 +99,7 @@ class AnalyzedClassMember(private val root: AnnotatedElement, name: String, val 
     val hasColumnType: Boolean = root.findAnnotation<ColumnType>() != null
 
     /** 是否为关联表引用 */
-    val isLinkTable: Boolean = root.findAnnotation<LinkTable>() != null
+    val isLinkTable: Boolean = !isIgnored && root.findAnnotation<LinkTable>() != null
 
     /** 关联表外键列名（下划线命名） */
     val linkTableColumn: String? = root.findAnnotation<LinkTable>()?.value?.toColumnName()
@@ -116,9 +119,15 @@ class AnalyzedClassMember(private val root: AnnotatedElement, name: String, val 
     val isMap: Boolean
         get() = Map::class.java.isAssignableFrom(returnType)
 
-    /** 是否为容器类型（List/Set/Map） */
+    /** 是否为扁平化集合（整个集合作为单列存储，由集合 CustomType 序列化） */
+    val isFlattenedCollection: Boolean
+        get() = !isIgnored && (isList || isSet || isMap)
+                && collectionElementType != null
+                && CustomTypeFactory.getCustomTypeForCollection(returnType, collectionElementType!!) != null
+
+    /** 是否为容器类型（List/Set/Map），@Ignore 字段和扁平化集合不视为容器成员 */
     val isCollection: Boolean
-        get() = isList || isSet || isMap
+        get() = !isIgnored && (isList || isSet || isMap) && !isFlattenedCollection
 
     /** 容器元素类型（List<T>/Set<T> 的 T，Map<K,V> 的 V） */
     val collectionElementType: Class<*>? = when {
@@ -192,9 +201,9 @@ class AnalyzedClassMember(private val root: AnnotatedElement, name: String, val 
     val isIndexedEnum: Boolean
         get() = isEnum && IndexedEnum::class.java.isAssignableFrom(returnType)
 
-    /** 是否为自定义对象 */
+    /** 是否为自定义对象（@Ignore 字段、扁平化集合不视为自定义对象） */
     val isCustomObject: Boolean
-        get() = !isLinkTable && !isCollection && !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID && !isByteArray
+        get() = !isIgnored && !isLinkTable && !isCollection && !isFlattenedCollection && !isBoolean && !isByte && !isShort && !isInt && !isLong && !isFloat && !isDouble && !isChar && !isString && !isEnum && !isUUID && !isByteArray
 
     /** 是否可以转换成字符串类型 */
     fun canConvertedString(): Boolean {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
@@ -229,3 +229,34 @@ annotation class LinkTable(val value: String)
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class TableName(val value: String)
+
+/**
+ * 标记字段为忽略字段，不参与数据库的读写操作。
+ *
+ * 被 @Ignore 标记的字段不会在数据库中创建列，也不会参与任何 CRUD 操作。
+ * 此注解的优先级最高，会覆盖其他所有注解（如 @Id、@Key、@LinkTable 等）。
+ *
+ * **默认值行为：**
+ * - 若字段在构造函数中且 Kotlin 声明了默认值 → 使用 Kotlin 默认值
+ * - 若字段在构造函数中但无默认值：
+ *   - 可空类型 → null
+ *   - List → emptyList()
+ *   - Set → emptySet()
+ *   - Map → emptyMap()
+ *   - 基础类型 → 类型零值（0、false、'\u0000' 等）
+ *   - String → ""
+ *   - 其他引用类型 → null
+ * - 若字段不在构造函数中（字段扫描模式） → 不设置默认值，保留无参构造器的初始值
+ *
+ * ```kotlin
+ * data class PlayerData(
+ *     @Id val uuid: String,
+ *     var level: Int,
+ *     @Ignore val cachedName: String = "unknown",  // 使用 Kotlin 默认值 "unknown"
+ *     @Ignore val tempTags: List<String> = listOf() // 使用 Kotlin 默认值 listOf()
+ * )
+ * ```
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Ignore

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerOperatorImpl.kt
@@ -339,7 +339,7 @@ class ContainerOperatorImpl(
 
     override fun update(data: Any, usePrimaryKey: Boolean, filter: Filter.() -> Unit) {
         val typeClass = AnalyzedClass.of(data::class.java)
-        if (typeClass.members.none { !it.isFinal || it.isLinkTable }) {
+        if (typeClass.members.none { !it.isIgnored && (!it.isFinal || it.isLinkTable) }) {
             error("No mutable field found.")
         }
         cascadeSaveLinkedObjects(typeClass, listOf(data))
@@ -357,7 +357,7 @@ class ContainerOperatorImpl(
                 val updateAction = ActionUpdate(table.name).apply {
                     if (name != null) where(name eq value?.value())
                     where(filter)
-                    typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }.forEach { member ->
+                    typeClass.members.filter { !it.isIgnored && (!it.isFinal || it.isLinkTable) && !it.isCollection }.forEach { member ->
                         if (member.isLinkTable) {
                             val linkedObj = typeClass.getValue(data, member)
                             val fkValue = if (linkedObj != null) {
@@ -365,6 +365,10 @@ class ContainerOperatorImpl(
                                 linkedClass.getPrimaryMemberValue(linkedObj)?.value()
                             } else null
                             set(member.linkTableColumn!!, fkValue)
+                        } else if (member.isFlattenedCollection) {
+                            val ct = CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)!!
+                            val raw = typeClass.getValue(data, member)
+                            set(member.name, if (raw != null) ct.serialize(raw) else null)
                         } else {
                             set(member.name, typeClass.getValue(data, member)?.value())
                         }
@@ -385,7 +389,7 @@ class ContainerOperatorImpl(
 
     override fun updateByKey(data: Any, usePrimaryKey: Boolean) {
         val typeClass = AnalyzedClass.of(data::class.java)
-        if (typeClass.members.none { !it.isFinal || it.isLinkTable }) {
+        if (typeClass.members.none { !it.isIgnored && (!it.isFinal || it.isLinkTable) }) {
             error("No mutable field found.")
         }
         update(data, usePrimaryKey) {
@@ -398,13 +402,13 @@ class ContainerOperatorImpl(
     override fun upsert(dataList: List<Any>) {
         if (dataList.isEmpty()) return
         val typeClass = AnalyzedClass.of(dataList.first().javaClass)
-        if (typeClass.members.none { !it.isFinal || it.isLinkTable }) {
+        if (typeClass.members.none { !it.isIgnored && (!it.isFinal || it.isLinkTable) }) {
             error("No mutable field found.")
         }
         cascadeSaveLinkedObjects(typeClass, dataList)
         val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
         val keyMembers = typeClass.members.filter { it.isKey }
-        val mutableMembers = typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }
+        val mutableMembers = typeClass.members.filter { !it.isIgnored && (!it.isFinal || it.isLinkTable) && !it.isCollection }
         // 构建唯一标识：@Id + @Key 的值
         fun buildKey(data: Any): String {
             val id = typeClass.getPrimaryMemberValue(data)?.value().toString()
@@ -484,6 +488,10 @@ class ContainerOperatorImpl(
                                     linkedClass.getPrimaryMemberValue(linkedObj)?.value()
                                 } else null
                                 stmt.setObject(idx++, fkValue)
+                            } else if (member.isFlattenedCollection) {
+                                val ct = CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)!!
+                                val raw = typeClass.getValue(data, member)
+                                stmt.setObject(idx++, if (raw != null) ct.serialize(raw) else null)
                             } else {
                                 stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
                             }
@@ -520,7 +528,7 @@ class ContainerOperatorImpl(
         primaryName: String,
         keyMembers: List<AnalyzedClassMember>
     ): String {
-        val mutableMembers = typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }
+        val mutableMembers = typeClass.members.filter { !it.isIgnored && (!it.isFinal || it.isLinkTable) && !it.isCollection }
         val setClause = mutableMembers.joinToString(", ") { member ->
             if (member.isLinkTable) "${member.linkTableColumn!!.asFormattedColumnName()} = ?" else "${member.name.asFormattedColumnName()} = ?"
         }
@@ -696,7 +704,7 @@ class ContainerOperatorImpl(
     override fun updateBatch(dataList: List<Any>) {
         if (dataList.isEmpty()) return
         val typeClass = AnalyzedClass.of(dataList.first().javaClass)
-        val mutableMembers = typeClass.members.filter { (!it.isFinal || it.isLinkTable) && !it.isCollection }
+        val mutableMembers = typeClass.members.filter { !it.isIgnored && (!it.isFinal || it.isLinkTable) && !it.isCollection }
         if (mutableMembers.isEmpty()) error("No mutable field found.")
         cascadeSaveLinkedObjects(typeClass, dataList)
         val primaryName = typeClass.primaryMemberName ?: error("No primary id found.")
@@ -714,6 +722,10 @@ class ContainerOperatorImpl(
                                 linkedClass.getPrimaryMemberValue(linkedObj)?.value()
                             } else null
                             stmt.setObject(idx++, fkValue)
+                        } else if (member.isFlattenedCollection) {
+                            val ct = CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)!!
+                            val raw = typeClass.getValue(data, member)
+                            stmt.setObject(idx++, if (raw != null) ct.serialize(raw) else null)
                         } else {
                             stmt.setObject(idx++, typeClass.getValue(data, member)?.value())
                         }
@@ -769,7 +781,7 @@ class ContainerOperatorImpl(
             // 深度优先：先保存更深层的关联对象
             cascadeSaveLinkedObjects(linkedTypeClass, linkedObjects, visited)
             // 再保存当前层
-            val hasMutableFields = linkedTypeClass.members.any { !it.isFinal }
+            val hasMutableFields = linkedTypeClass.members.any { !it.isIgnored && !it.isFinal }
             if (hasMutableFields) {
                 operator.upsert(linkedObjects)
             } else {
@@ -791,16 +803,16 @@ class ContainerOperatorImpl(
      * 获取实际列名列表（@LinkTable 用 FK 列名）
      */
     private fun getColumnNames(typeClass: AnalyzedClass): List<String> {
-        return typeClass.members.filter { !it.isCollection }.map { member ->
+        return typeClass.members.filter { !it.isIgnored && !it.isCollection }.map { member ->
             if (member.isLinkTable) member.linkTableColumn!! else member.name
         }
     }
 
     /**
-     * 获取实际列值列表（@LinkTable 提取 FK 值）
+     * 获取实际列值列表（@LinkTable 提取 FK 值，扁平化集合用集合 CustomType 序列化）
      */
     private fun getColumnValues(typeClass: AnalyzedClass, data: Any): List<Any?> {
-        return typeClass.members.filter { !it.isCollection }.map { member ->
+        return typeClass.members.filter { !it.isIgnored && !it.isCollection }.map { member ->
             if (member.isLinkTable) {
                 val linkedObj = typeClass.getValue(data, member)
                 if (linkedObj != null) {
@@ -809,6 +821,10 @@ class ContainerOperatorImpl(
                 } else {
                     null
                 }
+            } else if (member.isFlattenedCollection) {
+                val ct = CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)!!
+                val raw = typeClass.getValue(data, member)
+                if (raw != null) ct.serialize(raw) else null
             } else {
                 typeClass.getValue(data, member)?.value()
             }
@@ -963,10 +979,10 @@ class ContainerOperatorImpl(
      */
     private inline fun <T> withConnection(crossinline block: (Connection) -> T): T {
         setupQuoter()
-        return if (sharedConnection != null) {
-            block(sharedConnection)
-        } else {
-            dataSource.connection.use { block(it) }
+        return when {
+            sharedConnection != null -> block(sharedConnection)
+            TransactionContext.currentConnection.get() != null -> block(TransactionContext.currentConnection.get())
+            else -> dataSource.connection.use { block(it) }
         }
     }
 
@@ -975,21 +991,22 @@ class ContainerOperatorImpl(
      */
     private inline fun withTransaction(crossinline block: (Connection) -> Unit) {
         setupQuoter()
-        if (sharedConnection != null) {
-            // 已在事务中，直接执行
-            block(sharedConnection)
-        } else {
-            dataSource.connection.use { conn ->
-                val originalAutoCommit = conn.autoCommit
-                conn.autoCommit = false
-                try {
-                    block(conn)
-                    conn.commit()
-                } catch (e: Exception) {
-                    conn.rollback()
-                    throw e
-                } finally {
-                    conn.autoCommit = originalAutoCommit
+        when {
+            sharedConnection != null -> block(sharedConnection)
+            TransactionContext.currentConnection.get() != null -> block(TransactionContext.currentConnection.get())
+            else -> {
+                dataSource.connection.use { conn ->
+                    val originalAutoCommit = conn.autoCommit
+                    conn.autoCommit = false
+                    try {
+                        block(conn)
+                        conn.commit()
+                    } catch (e: Exception) {
+                        conn.rollback()
+                        throw e
+                    } finally {
+                        conn.autoCommit = originalAutoCommit
+                    }
                 }
             }
         }
@@ -1167,6 +1184,30 @@ class ContainerOperatorImpl(
     }
 
     /**
+     * 序列化集合元素：优先使用注册的普通 CustomType，否则 toString()
+     */
+    private fun serializeCollectionElement(value: Any?, elementType: Class<*>?): String? {
+        if (value == null) return null
+        if (elementType != null) {
+            val ct = CustomTypeFactory.getCustomTypeByClass(elementType)
+            if (ct != null) return ct.serialize(value).toString()
+        }
+        return value.toString()
+    }
+
+    /**
+     * 反序列化集合元素：优先使用注册的普通 CustomType，否则原样返回
+     */
+    private fun deserializeCollectionElement(value: Any?, elementType: Class<*>?): Any? {
+        if (value == null) return null
+        if (elementType != null) {
+            val ct = CustomTypeFactory.getCustomTypeByClass(elementType)
+            if (ct != null) return ct.deserialize(value)
+        }
+        return value
+    }
+
+    /**
      * 插入容器值到子表
      */
     private fun insertCollectionValues(info: CollectionTableInfo, member: AnalyzedClassMember, parentId: Any, collection: Any) {
@@ -1180,8 +1221,8 @@ class ContainerOperatorImpl(
                     conn.prepareStatement(sql).use { stmt ->
                         map.forEach { (k, v) ->
                             stmt.setObject(1, convertParam(parentId))
-                            stmt.setObject(2, k?.toString())
-                            stmt.setObject(3, v?.toString())
+                            stmt.setObject(2, serializeCollectionElement(k, member.mapKeyType))
+                            stmt.setObject(3, serializeCollectionElement(v, member.collectionElementType))
                             stmt.addBatch()
                         }
                         stmt.executeBatch()
@@ -1196,7 +1237,7 @@ class ContainerOperatorImpl(
                     conn.prepareStatement(sql).use { stmt ->
                         list.forEachIndexed { index, v ->
                             stmt.setObject(1, convertParam(parentId))
-                            stmt.setObject(2, v?.toString())
+                            stmt.setObject(2, serializeCollectionElement(v, member.collectionElementType))
                             stmt.setObject(3, index)
                             stmt.addBatch()
                         }
@@ -1212,7 +1253,7 @@ class ContainerOperatorImpl(
                     conn.prepareStatement(sql).use { stmt ->
                         set.forEach { v ->
                             stmt.setObject(1, convertParam(parentId))
-                            stmt.setObject(2, v?.toString())
+                            stmt.setObject(2, serializeCollectionElement(v, member.collectionElementType))
                             stmt.addBatch()
                         }
                         stmt.executeBatch()
@@ -1262,28 +1303,32 @@ class ContainerOperatorImpl(
                         member.isMap -> {
                             while (rs.next()) {
                                 val fk = rs.getObject(info.fkColumnName)?.toString() ?: continue
-                                val key = rs.getString("map_key")
-                                val value = rs.getString("map_value")
+                                val rawKey = rs.getString("map_key")
+                                val rawValue = rs.getString("map_value")
+                                val key = deserializeCollectionElement(rawKey, member.mapKeyType)
+                                val value = deserializeCollectionElement(rawValue, member.collectionElementType)
                                 @Suppress("UNCHECKED_CAST")
-                                val map = result.getOrPut(fk) { mutableMapOf<String, String?>() } as MutableMap<String, String?>
+                                val map = result.getOrPut(fk) { mutableMapOf<Any?, Any?>() } as MutableMap<Any?, Any?>
                                 map[key] = value
                             }
                         }
                         member.isList -> {
                             while (rs.next()) {
                                 val fk = rs.getObject(info.fkColumnName)?.toString() ?: continue
-                                val value = rs.getString("value")
+                                val rawValue = rs.getString("value")
+                                val value = deserializeCollectionElement(rawValue, member.collectionElementType)
                                 @Suppress("UNCHECKED_CAST")
-                                val list = result.getOrPut(fk) { mutableListOf<String?>() } as MutableList<String?>
+                                val list = result.getOrPut(fk) { mutableListOf<Any?>() } as MutableList<Any?>
                                 list.add(value)
                             }
                         }
                         member.isSet -> {
                             while (rs.next()) {
                                 val fk = rs.getObject(info.fkColumnName)?.toString() ?: continue
-                                val value = rs.getString("value")
+                                val rawValue = rs.getString("value")
+                                val value = deserializeCollectionElement(rawValue, member.collectionElementType)
                                 @Suppress("UNCHECKED_CAST")
-                                val set = result.getOrPut(fk) { mutableSetOf<String?>() } as MutableSet<String?>
+                                val set = result.getOrPut(fk) { mutableSetOf<Any?>() } as MutableSet<Any?>
                                 set.add(value)
                             }
                         }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerPostgreSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerPostgreSQL.kt
@@ -29,6 +29,8 @@ class ContainerPostgreSQL(
                 add { id() }
             }
             type.members.forEach { member ->
+                // 跳过 @Ignore 成员
+                if (member.isIgnored) return@forEach
                 // 跳过容器类型成员（它们存储在子表中）
                 if (member.isCollection) return@forEach
                 // @LinkTable 成员：创建外键列而非展开关联类
@@ -94,7 +96,11 @@ class ContainerPostgreSQL(
                     }
                     // 其他类型
                     else -> add(member.name) {
-                        val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType)
+                        val customType = if (member.isFlattenedCollection) {
+                            CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)
+                        } else {
+                            CustomTypeFactory.getCustomTypeByClass(member.returnType)
+                        }
                         if (customType == null) {
                             type(member.type()) { options(member) }
                         } else {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQL.kt
@@ -29,6 +29,8 @@ class ContainerSQL(
                 add { id() }
             }
             type.members.forEach { member ->
+                // 跳过 @Ignore 成员
+                if (member.isIgnored) return@forEach
                 // 跳过容器类型成员（它们存储在子表中）
                 if (member.isCollection) return@forEach
                 // @LinkTable 成员：创建外键列而非展开关联类
@@ -83,7 +85,11 @@ class ContainerSQL(
                     }
                     // 其他类型
                     else -> add(member.name) {
-                        val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType)
+                        val customType = if (member.isFlattenedCollection) {
+                            CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)
+                        } else {
+                            CustomTypeFactory.getCustomTypeByClass(member.returnType)
+                        }
                         if (customType == null) {
                             type(member.type()) { options(member) }
                         } else {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerSQLite.kt
@@ -20,6 +20,8 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
                 add { id() }
             }
             type.members.forEach { member ->
+                // 跳过 @Ignore 成员
+                if (member.isIgnored) return@forEach
                 // 跳过容器类型成员（它们存储在子表中）
                 if (member.isCollection) return@forEach
                 // @LinkTable 成员：创建外键列而非展开关联类
@@ -71,7 +73,11 @@ class ContainerSQLite(file: File) : Container<SQLite>(HostSQLite(file)) {
                     }
 
                     else -> {
-                        val customType = CustomTypeFactory.getCustomTypeByClass(member.returnType) ?: error("Unsupported type: ${member.name} (${member.returnType})")
+                        val customType = if (member.isFlattenedCollection) {
+                            CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)
+                        } else {
+                            CustomTypeFactory.getCustomTypeByClass(member.returnType)
+                        } ?: error("Unsupported type: ${member.name} (${member.returnType})")
                         add(member.name) { type(customType.typeSQLite, customType.length) { options(member) } }
                     }
                 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CustomType.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CustomType.kt
@@ -18,6 +18,16 @@ interface CustomType {
     /** 类型 */
     val type: Class<*>
 
+    /**
+     * 集合元素类型。
+     * 当 elementType != null 时，表示这是一个集合 CustomType，
+     * 用于将整个集合字段（List/Set/Map）作为单列存储。
+     * - type = 集合类型（如 List::class.java）
+     * - elementType = 元素类型（如 XXXData::class.java）
+     */
+    val elementType: Class<*>?
+        get() = null
+
     /** 对应 SQL 类型 */
     val typeSQL: ColumnTypeSQL
         get() = ColumnTypeSQL.TEXT

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CustomTypeFactory.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/CustomTypeFactory.kt
@@ -25,7 +25,14 @@ class CustomTypeFactory : ClassVisitor() {
     override fun visitStart(clazz: ReflexClass) {
         if (clazz.structure.interfaces.any { it.name == CustomType::class.java.name }) {
             val customType = findInstance(clazz) as? CustomType ?: error("CustomType must have an instance")
-            registeredTypes[customType.type] = customType
+            val elemType = customType.elementType
+            if (elemType != null) {
+                // 集合 CustomType：按 (集合类型, 元素类型) 注册
+                registeredCollectionTypes.getOrPut(customType.type) { ConcurrentHashMap() }[elemType] = customType
+            } else {
+                // 普通 CustomType：按类型注册
+                registeredTypes[customType.type] = customType
+            }
         }
     }
 
@@ -33,6 +40,9 @@ class CustomTypeFactory : ClassVisitor() {
 
         /** 已注册的所有自定义类型（key 为 CustomType.type） */
         val registeredTypes = ConcurrentHashMap<Class<*>, CustomType>()
+
+        /** 已注册的集合自定义类型（外层 key = 集合类型，内层 key = 元素类型） */
+        val registeredCollectionTypes = ConcurrentHashMap<Class<*>, ConcurrentHashMap<Class<*>, CustomType>>()
 
         /** 通过值获取自定义类型 */
         fun getCustomType(value: Any): CustomType? {
@@ -42,6 +52,18 @@ class CustomTypeFactory : ClassVisitor() {
         /** 通过类获取自定义类型 */
         fun getCustomTypeByClass(clazz: Class<*>): CustomType? {
             return registeredTypes[clazz] ?: registeredTypes.values.find { it.matchType(clazz) }
+        }
+
+        /**
+         * 通过集合类型和元素类型获取集合 CustomType。
+         * 先精确匹配，再兼容子类（isAssignableFrom）。
+         */
+        fun getCustomTypeForCollection(collectionClass: Class<*>, elementClass: Class<*>): CustomType? {
+            val innerMap = registeredCollectionTypes[collectionClass] ?: return null
+            // 精确匹配
+            innerMap[elementClass]?.let { return it }
+            // 兼容子类
+            return innerMap.entries.firstOrNull { it.key.isAssignableFrom(elementClass) }?.value
         }
     }
 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/PersistentContainer.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/PersistentContainer.kt
@@ -260,8 +260,25 @@ class PersistentContainer {
      * @return Result 包含返回值或异常
      */
     fun <R> transaction(block: TransactionContext.() -> R): Result<R> {
+        // 事务传递：如果当前线程已有活跃事务，复用外层连接
+        val existing = TransactionContext.currentConnection.get()
+        if (existing != null) {
+            val context = TransactionContext(container, existing)
+            return try {
+                val result = context.block()
+                if (context.shouldRollback()) {
+                    Result.failure(TransactionRollbackException("Transaction marked for rollback"))
+                } else {
+                    Result.success(result)
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+        // 新事务
         val connection = container.dataSource.connection
         connection.autoCommit = false
+        TransactionContext.currentConnection.set(connection)
         return try {
             val context = TransactionContext(container, connection)
             val result = context.block()
@@ -281,6 +298,7 @@ class PersistentContainer {
             }
             Result.failure(e)
         } finally {
+            TransactionContext.currentConnection.remove()
             try {
                 connection.autoCommit = true
             } catch (_: Exception) {

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionContext.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/TransactionContext.kt
@@ -31,6 +31,12 @@ class TransactionContext internal constructor(
     private val container: Container<*>,
     internal val connection: Connection
 ) {
+
+    companion object {
+        /** 当前线程的活跃事务连接 */
+        internal val currentConnection = ThreadLocal<Connection>()
+    }
+
     private var rollbackOnly = false
     private val operators = mutableMapOf<String, ContainerOperator>()
 

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/CollectionCustomTypeTest.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/CollectionCustomTypeTest.kt
@@ -1,0 +1,193 @@
+package taboolib.expansion
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CollectionCustomTypeTest {
+
+    private lateinit var container: TestContainer
+
+    @BeforeEach
+    fun setup() {
+        container = TestContainer(createTestDataSource())
+        // 手动注册集合 CustomType（测试环境不走 TabooLib 生命周期）
+        CustomTypeFactory.registeredCollectionTypes.clear()
+        CustomTypeFactory.registeredCollectionTypes
+            .getOrPut(List::class.java) { java.util.concurrent.ConcurrentHashMap() }[ItemData::class.java] = ItemDataListType
+        CustomTypeFactory.registeredCollectionTypes
+            .getOrPut(Set::class.java) { java.util.concurrent.ConcurrentHashMap() }[ItemData::class.java] = ItemDataSetType
+        CustomTypeFactory.registeredCollectionTypes
+            .getOrPut(Map::class.java) { java.util.concurrent.ConcurrentHashMap() }[ItemData::class.java] = ItemDataMapType
+        // 清除 AnalyzedClass 缓存，确保重新分析
+        AnalyzedClass.cached.clear()
+    }
+
+    @AfterEach
+    fun teardown() {
+        container.close()
+        CustomTypeFactory.registeredCollectionTypes.clear()
+        CustomTypeFactory.registeredTypes.remove(ItemData::class.java)
+        AnalyzedClass.cached.clear()
+    }
+
+    // === Feature 1: 扁平化集合（单列存储） ===
+
+    @Test
+    fun `flattened list - insert and read back`() {
+        val op = container.new<FlattenedListData>()
+        val items = listOf(ItemData("sword", 1), ItemData("shield", 2))
+        op.insert(listOf(FlattenedListData("p1", "player1", items)))
+
+        val result = op.findOne<FlattenedListData>(FlattenedListData::class.java, "p1")
+        assertNotNull(result)
+        assertEquals("p1", result!!.id)
+        assertEquals("player1", result.label)
+        assertEquals(items, result.items)
+    }
+
+    @Test
+    fun `flattened set - insert and read back`() {
+        val op = container.new<FlattenedSetData>()
+        val items = setOf(ItemData("potion", 5), ItemData("arrow", 64))
+        op.insert(listOf(FlattenedSetData("s1", items)))
+
+        val result = op.findOne<FlattenedSetData>(FlattenedSetData::class.java, "s1")
+        assertNotNull(result)
+        assertEquals(items, result!!.items)
+    }
+
+    @Test
+    fun `flattened map - insert and read back`() {
+        val op = container.new<FlattenedMapData>()
+        val items = mapOf("slot1" to ItemData("helmet", 1), "slot2" to ItemData("boots", 1))
+        op.insert(listOf(FlattenedMapData("m1", items)))
+
+        val result = op.findOne<FlattenedMapData>(FlattenedMapData::class.java, "m1")
+        assertNotNull(result)
+        assertEquals(items, result!!.items)
+    }
+
+    @Test
+    fun `flattened list - update preserves data`() {
+        val op = container.new<FlattenedListData>()
+        val items1 = listOf(ItemData("sword", 1))
+        op.insert(listOf(FlattenedListData("u1", "before", items1)))
+
+        val items2 = listOf(ItemData("axe", 3), ItemData("bow", 1))
+        op.update(FlattenedListData("u1", "after", items2))
+
+        val result = op.findOne<FlattenedListData>(FlattenedListData::class.java, "u1")
+        assertNotNull(result)
+        assertEquals("after", result!!.label)
+        assertEquals(items2, result.items)
+    }
+
+    @Test
+    fun `flattened collection does not create sub-table`() {
+        val analyzed = AnalyzedClass.of(FlattenedListData::class.java)
+        // items 应该是 isFlattenedCollection=true, isCollection=false
+        val itemsMember = analyzed.members.first { it.propertyName == "items" }
+        assertTrue(itemsMember.isFlattenedCollection)
+        assertFalse(itemsMember.isCollection)
+        // collectionMembers 不应包含 items
+        assertTrue(analyzed.collectionMembers.isEmpty())
+        // columnMembers 应包含 items
+        assertTrue(analyzed.columnMembers.any { it.propertyName == "items" })
+    }
+
+    @Test
+    fun `flattened list - batch upsert`() {
+        val op = container.new<FlattenedListData>()
+        val data1 = FlattenedListData("b1", "first", listOf(ItemData("a", 1)))
+        val data2 = FlattenedListData("b2", "second", listOf(ItemData("b", 2)))
+        op.insert(listOf(data1, data2))
+
+        // upsert: update b1, insert b3
+        val updated1 = FlattenedListData("b1", "updated", listOf(ItemData("c", 3)))
+        val new3 = FlattenedListData("b3", "third", listOf(ItemData("d", 4)))
+        op.upsert(listOf(updated1, new3))
+
+        val r1 = op.findOne<FlattenedListData>(FlattenedListData::class.java, "b1")
+        assertEquals("updated", r1!!.label)
+        assertEquals(listOf(ItemData("c", 3)), r1.items)
+
+        val r3 = op.findOne<FlattenedListData>(FlattenedListData::class.java, "b3")
+        assertEquals("third", r3!!.label)
+        assertEquals(listOf(ItemData("d", 4)), r3.items)
+    }
+
+    // === Feature 2: 子表元素 CustomType 序列化/反序列化 ===
+
+    @Test
+    fun `sub-table element CustomType - list insert and read back`() {
+        // 注册普通 CustomType（元素级别），移除集合 CustomType 以确保走子表
+        CustomTypeFactory.registeredCollectionTypes.clear()
+        CustomTypeFactory.registeredTypes[ItemData::class.java] = ItemDataType
+        AnalyzedClass.cached.clear()
+
+        val op = container.new<ElementCustomTypeListData>()
+        val items = listOf(ItemData("gem", 10), ItemData("ore", 32))
+        op.insert(listOf(ElementCustomTypeListData("e1", "test", items)))
+
+        val result = op.findOne<ElementCustomTypeListData>(ElementCustomTypeListData::class.java, "e1")
+        assertNotNull(result)
+        assertEquals(2, result!!.items.size)
+        assertEquals(ItemData("gem", 10), result.items[0])
+        assertEquals(ItemData("ore", 32), result.items[1])
+    }
+
+    @Test
+    fun `sub-table element CustomType - update and read back`() {
+        CustomTypeFactory.registeredCollectionTypes.clear()
+        CustomTypeFactory.registeredTypes[ItemData::class.java] = ItemDataType
+        AnalyzedClass.cached.clear()
+
+        val op = container.new<ElementCustomTypeListData>()
+        op.insert(listOf(ElementCustomTypeListData("e2", "before", listOf(ItemData("old", 1)))))
+
+        val updated = listOf(ItemData("new1", 5), ItemData("new2", 10))
+        op.update(ElementCustomTypeListData("e2", "after", updated))
+
+        val result = op.findOne<ElementCustomTypeListData>(ElementCustomTypeListData::class.java, "e2")
+        assertNotNull(result)
+        assertEquals(updated, result!!.items)
+    }
+
+    // === 混合测试 ===
+
+    @Test
+    fun `mixed flattened and sub-table collections`() {
+        val op = container.new<MixedFlatAndSubTableData>()
+        val flatItems = listOf(ItemData("flat1", 1), ItemData("flat2", 2))
+        val tags = listOf("tag1", "tag2", "tag3")
+        op.insert(listOf(MixedFlatAndSubTableData("mix1", flatItems, tags)))
+
+        val result = op.findOne<MixedFlatAndSubTableData>(MixedFlatAndSubTableData::class.java, "mix1")
+        assertNotNull(result)
+        assertEquals(flatItems, result!!.flatItems)
+        assertEquals(tags, result.tags)
+    }
+
+    @Test
+    fun `mixed - analyzed class correctly identifies members`() {
+        val analyzed = AnalyzedClass.of(MixedFlatAndSubTableData::class.java)
+        val flatMember = analyzed.members.first { it.propertyName == "flatItems" }
+        val tagsMember = analyzed.members.first { it.propertyName == "tags" }
+
+        assertTrue(flatMember.isFlattenedCollection)
+        assertFalse(flatMember.isCollection)
+
+        assertFalse(tagsMember.isFlattenedCollection)
+        assertTrue(tagsMember.isCollection)
+
+        // columnMembers 包含 flatItems 但不包含 tags
+        assertTrue(analyzed.columnMembers.any { it.propertyName == "flatItems" })
+        assertFalse(analyzed.columnMembers.any { it.propertyName == "tags" })
+
+        // collectionMembers 包含 tags 但不包含 flatItems
+        assertTrue(analyzed.collectionMembers.any { it.propertyName == "tags" })
+        assertFalse(analyzed.collectionMembers.any { it.propertyName == "flatItems" })
+    }
+}

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/IgnoreTest.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/IgnoreTest.kt
@@ -1,0 +1,94 @@
+package taboolib.expansion
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IgnoreTest {
+
+    private lateinit var container: TestContainer
+
+    @BeforeEach
+    fun setup() {
+        container = TestContainer(createTestDataSource())
+    }
+
+    @AfterEach
+    fun teardown() {
+        container.close()
+    }
+
+    @Test
+    fun `ignored field with default value - insert and read back`() {
+        val op = container.new<IgnoreWithDefaultData>()
+        val data = IgnoreWithDefaultData("p1", 100, "custom_name", 99)
+        op.insert(listOf(data))
+
+        val result = op.findOne<IgnoreWithDefaultData>(IgnoreWithDefaultData::class.java, "p1")
+        assertNotNull(result)
+        assertEquals("p1", result!!.id)
+        assertEquals(100, result.value)
+        // @Ignore 字段应使用 Kotlin 默认值，而非写入时的值
+        assertEquals("default_name", result.cachedName)
+        assertEquals(42, result.tempScore)
+    }
+
+    @Test
+    fun `ignored collection fields use Kotlin defaults`() {
+        val op = container.new<IgnoreCollectionData>()
+        val data = IgnoreCollectionData("c1", "test", listOf("x", "y"), setOf("a", "b"), mapOf("foo" to "bar"))
+        op.insert(listOf(data))
+
+        val result = op.findOne<IgnoreCollectionData>(IgnoreCollectionData::class.java, "c1")
+        assertNotNull(result)
+        assertEquals("c1", result!!.id)
+        assertEquals("test", result.label)
+        // @Ignore 容器字段应使用 Kotlin 默认值
+        assertEquals(listOf("a", "b"), result.tempTags)
+        assertEquals(setOf("x"), result.tempSet)
+        assertEquals(mapOf("k" to "v"), result.tempMap)
+    }
+
+    @Test
+    fun `ignored nullable field defaults to null`() {
+        val op = container.new<IgnoreNullableData>()
+        val data = IgnoreNullableData("n1", 50, "not_null_value")
+        op.insert(listOf(data))
+
+        val result = op.findOne<IgnoreNullableData>(IgnoreNullableData::class.java, "n1")
+        assertNotNull(result)
+        assertEquals("n1", result!!.id)
+        assertEquals(50, result.value)
+        // @Ignore 可空字段应为 null（Kotlin 默认值）
+        assertNull(result.nullable)
+    }
+
+    @Test
+    fun `update does not touch ignored fields`() {
+        val op = container.new<IgnoreWithDefaultData>()
+        op.insert(listOf(IgnoreWithDefaultData("u1", 10)))
+        // 更新 value
+        op.update(IgnoreWithDefaultData("u1", 20, "changed", 999))
+        val result = op.findOne<IgnoreWithDefaultData>(IgnoreWithDefaultData::class.java, "u1")
+        assertNotNull(result)
+        assertEquals(20, result!!.value)
+        // @Ignore 字段仍然是 Kotlin 默认值
+        assertEquals("default_name", result.cachedName)
+        assertEquals(42, result.tempScore)
+    }
+
+    @Test
+    fun `analyzed class members correctly identify ignored fields`() {
+        val analyzed = AnalyzedClass.of(IgnoreWithDefaultData::class.java)
+        // columnMembers 不应包含 @Ignore 字段
+        val columnNames = analyzed.columnMembers.map { it.propertyName }
+        assertTrue("id" in columnNames)
+        assertTrue("value" in columnNames)
+        assertFalse("cachedName" in columnNames)
+        assertFalse("tempScore" in columnNames)
+        // collectionMembers 不应包含 @Ignore 的容器字段
+        val analyzedColl = AnalyzedClass.of(IgnoreCollectionData::class.java)
+        assertTrue(analyzedColl.collectionMembers.isEmpty())
+    }
+}

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TestHelper.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TestHelper.kt
@@ -168,7 +168,144 @@ data class MixedCollectionData(
 
 // endregion
 
-// region 工具函数
+// region @Ignore 测试用 data class
+
+/** 基础 @Ignore 测试：忽略字段带 Kotlin 默认值 */
+data class IgnoreWithDefaultData(
+    @Id val id: String,
+    var value: Int,
+    @Ignore val cachedName: String = "default_name",
+    @Ignore val tempScore: Int = 42
+)
+
+/** @Ignore 容器类型测试 */
+data class IgnoreCollectionData(
+    @Id val id: String,
+    var label: String,
+    @Ignore val tempTags: List<String> = listOf("a", "b"),
+    @Ignore val tempSet: Set<String> = setOf("x"),
+    @Ignore val tempMap: Map<String, String> = mapOf("k" to "v")
+)
+
+/** @Ignore 无默认值测试（可空类型） */
+data class IgnoreNullableData(
+    @Id val id: String,
+    var value: Int,
+    @Ignore val nullable: String? = null
+)
+
+// endregion
+
+// region 集合 CustomType 测试用 data class 和 CustomType
+
+/** 测试用数据类，作为集合元素 */
+data class ItemData(val name: String, val count: Int)
+
+/** 集合 CustomType：将 List<ItemData> 作为单列存储 */
+object ItemDataListType : CustomType {
+    override val type: Class<*> = List::class.java
+    override val elementType: Class<*> = ItemData::class.java
+    override fun serialize(value: Any): Any {
+        @Suppress("UNCHECKED_CAST")
+        val list = value as List<ItemData>
+        return list.joinToString(";") { "${it.name}:${it.count}" }
+    }
+    override fun deserialize(value: Any): Any {
+        val str = value.toString()
+        if (str.isEmpty()) return emptyList<ItemData>()
+        return str.split(";").map {
+            val parts = it.split(":")
+            ItemData(parts[0], parts[1].toInt())
+        }
+    }
+}
+
+/** 集合 CustomType：将 Set<ItemData> 作为单列存储 */
+object ItemDataSetType : CustomType {
+    override val type: Class<*> = Set::class.java
+    override val elementType: Class<*> = ItemData::class.java
+    override fun serialize(value: Any): Any {
+        @Suppress("UNCHECKED_CAST")
+        val set = value as Set<ItemData>
+        return set.joinToString(";") { "${it.name}:${it.count}" }
+    }
+    override fun deserialize(value: Any): Any {
+        val str = value.toString()
+        if (str.isEmpty()) return emptySet<ItemData>()
+        return str.split(";").map {
+            val parts = it.split(":")
+            ItemData(parts[0], parts[1].toInt())
+        }.toSet()
+    }
+}
+
+/** 集合 CustomType：将 Map<String, ItemData> 作为单列存储 */
+object ItemDataMapType : CustomType {
+    override val type: Class<*> = Map::class.java
+    override val elementType: Class<*> = ItemData::class.java
+    override fun serialize(value: Any): Any {
+        @Suppress("UNCHECKED_CAST")
+        val map = value as Map<String, ItemData>
+        return map.entries.joinToString(";") { "${it.key}=${it.value.name}:${it.value.count}" }
+    }
+    override fun deserialize(value: Any): Any {
+        val str = value.toString()
+        if (str.isEmpty()) return emptyMap<String, ItemData>()
+        return str.split(";").associate {
+            val kv = it.split("=")
+            val parts = kv[1].split(":")
+            kv[0] to ItemData(parts[0], parts[1].toInt())
+        }
+    }
+}
+
+/** 普通 CustomType：用于子表元素级别的序列化/反序列化 */
+object ItemDataType : CustomType {
+    override val type: Class<*> = ItemData::class.java
+    override fun serialize(value: Any): Any {
+        val item = value as ItemData
+        return "${item.name}:${item.count}"
+    }
+    override fun deserialize(value: Any): Any {
+        val parts = value.toString().split(":")
+        return ItemData(parts[0], parts[1].toInt())
+    }
+}
+
+/** 扁平化集合测试：List<ItemData> 有匹配的集合 CustomType → 单列存储 */
+data class FlattenedListData(
+    @Id val id: String,
+    var label: String,
+    var items: List<ItemData>
+)
+
+/** 扁平化集合测试：Set<ItemData> 有匹配的集合 CustomType → 单列存储 */
+data class FlattenedSetData(
+    @Id val id: String,
+    val items: Set<ItemData>
+)
+
+/** 扁平化集合测试：Map<String, ItemData> 有匹配的集合 CustomType → 单列存储 */
+data class FlattenedMapData(
+    @Id val id: String,
+    val items: Map<String, ItemData>
+)
+
+/** 子表元素 CustomType 测试：List<ItemData> 无集合 CustomType → 走子表，元素用 ItemDataType 序列化 */
+data class ElementCustomTypeListData(
+    @Id val id: String,
+    var label: String = "",
+    val items: List<ItemData>
+)
+
+/** 混合测试：扁平化集合 + 普通子表集合 */
+data class MixedFlatAndSubTableData(
+    @Id val id: String,
+    val flatItems: List<ItemData>,  // 有集合 CustomType → 单列
+    val tags: List<String>          // 无集合 CustomType → 子表
+)
+
+// endregion
 
 /**
  * 创建 SQLite 内存 HikariDataSource
@@ -263,6 +400,8 @@ private fun buildSQLiteTable(type: AnalyzedClass, name: String): Table<HostSQLit
             add { id() }
         }
         type.members.forEach { member ->
+            // 跳过 @Ignore 成员
+            if (member.isIgnored) return@forEach
             // 跳过容器类型成员（它们存储在子表中）
             if (member.isCollection) return@forEach
             // @LinkTable 成员：创建外键列
@@ -297,7 +436,14 @@ private fun buildSQLiteTable(type: AnalyzedClass, name: String): Table<HostSQLit
                 member.isByteArray -> add(member.name) {
                     type(ColumnTypeSQLite.BLOB) { options(member) }
                 }
-                else -> error("Unsupported type: ${member.name} (${member.returnType})")
+                else -> {
+                    val customType = if (member.isFlattenedCollection) {
+                        CustomTypeFactory.getCustomTypeForCollection(member.returnType, member.collectionElementType!!)
+                    } else {
+                        CustomTypeFactory.getCustomTypeByClass(member.returnType)
+                    } ?: error("Unsupported type: ${member.name} (${member.returnType})")
+                    add(member.name) { type(customType.typeSQLite, customType.length) { options(member) } }
+                }
             }
         }
     }
@@ -348,8 +494,25 @@ class TestContainer(val dataSource: HikariDataSource) {
     }
 
     fun <R> transaction(block: TestTransactionContext.() -> R): Result<R> {
+        // 事务传递：如果当前线程已有活跃事务，复用外层连接
+        val existing = TransactionContext.currentConnection.get()
+        if (existing != null) {
+            val context = TestTransactionContext(this, existing)
+            return try {
+                val result = context.block()
+                if (context.shouldRollback()) {
+                    Result.failure(TransactionRollbackException("Transaction marked for rollback"))
+                } else {
+                    Result.success(result)
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+        // 新事务
         val connection = dataSource.connection
         connection.autoCommit = false
+        TransactionContext.currentConnection.set(connection)
         return try {
             val context = TestTransactionContext(this, connection)
             val result = context.block()
@@ -364,6 +527,7 @@ class TestContainer(val dataSource: HikariDataSource) {
             try { connection.rollback() } catch (re: Exception) { e.addSuppressed(re) }
             Result.failure(e)
         } finally {
+            TransactionContext.currentConnection.remove()
             try { connection.autoCommit = true } catch (_: Exception) {}
             try { connection.close() } catch (_: Exception) {}
         }

--- a/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TransactionPropagationTest.kt
+++ b/module/database/database-ptc-object/src/test/kotlin/taboolib/expansion/TransactionPropagationTest.kt
@@ -1,0 +1,163 @@
+package taboolib.expansion
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TransactionPropagationTest {
+
+    private lateinit var container: TestContainer
+
+    @BeforeEach
+    fun setUp() {
+        AnalyzedClass.cached.clear()
+        val ds = createTestDataSource()
+        container = TestContainer(ds)
+        container.new<SimpleData>("simple_data")
+        container.new<AllValData>("all_val_data")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        container.close()
+    }
+
+    @Test
+    fun `nested transaction reuses outer connection`() {
+        val result = container.transaction {
+            val op = operator("simple_data")
+            op.insert(listOf(SimpleData("a", 1, "alpha")))
+
+            // 嵌套事务应复用外层连接
+            val innerResult = container.transaction {
+                val innerOp = operator("simple_data")
+                innerOp.insert(listOf(SimpleData("b", 2, "beta")))
+                "inner-done"
+            }
+            assertTrue(innerResult.isSuccess)
+            assertEquals("inner-done", innerResult.getOrNull())
+            "outer-done"
+        }
+        assertTrue(result.isSuccess)
+        assertEquals("outer-done", result.getOrNull())
+        // 两条数据都应该被提交
+        val all = container.operator("simple_data").get(SimpleData::class.java)
+        assertEquals(2, all.size)
+    }
+
+    @Test
+    fun `outer rollback rolls back nested transaction data`() {
+        val result = container.transaction {
+            val op = operator("simple_data")
+            op.insert(listOf(SimpleData("a", 1, "alpha")))
+
+            container.transaction {
+                val innerOp = operator("simple_data")
+                innerOp.insert(listOf(SimpleData("b", 2, "beta")))
+            }
+
+            // 外层回滚 → 内外数据都应回滚
+            rollback()
+        }
+        assertTrue(result.isFailure)
+        val all = container.operator("simple_data").get(SimpleData::class.java)
+        assertEquals(0, all.size)
+    }
+
+    @Test
+    fun `inner exception propagates to outer and rolls back all`() {
+        val result = container.transaction {
+            val op = operator("simple_data")
+            op.insert(listOf(SimpleData("a", 1, "alpha")))
+
+            val innerResult = container.transaction {
+                val innerOp = operator("simple_data")
+                innerOp.insert(listOf(SimpleData("b", 2, "beta")))
+                error("inner-boom")
+            }
+            // 内层异常被捕获为 Result.failure，外层可以选择重新抛出
+            throw innerResult.exceptionOrNull()!!
+        }
+        assertTrue(result.isFailure)
+        assertEquals("inner-boom", result.exceptionOrNull()!!.message)
+        val all = container.operator("simple_data").get(SimpleData::class.java)
+        assertEquals(0, all.size)
+    }
+
+    @Test
+    fun `inner rollback does not commit or close outer connection`() {
+        val result = container.transaction {
+            val op = operator("simple_data")
+            op.insert(listOf(SimpleData("a", 1, "alpha")))
+
+            // 内层标记回滚，但外层不回滚
+            val innerResult = container.transaction {
+                operator("simple_data").insert(listOf(SimpleData("b", 2, "beta")))
+                rollback()
+            }
+            assertTrue(innerResult.isFailure)
+
+            // 外层继续操作，不受内层 rollback 标记影响
+            op.insert(listOf(SimpleData("c", 3, "gamma")))
+            "outer-done"
+        }
+        // 外层正常提交（内层 rollback 只影响内层 Result，不影响外层连接）
+        assertTrue(result.isSuccess)
+        val all = container.operator("simple_data").get(SimpleData::class.java)
+        // a, b, c 都在同一连接上，外层 commit 全部提交
+        assertEquals(3, all.size)
+    }
+
+    @Test
+    fun `non-transactional operator participates in active transaction`() {
+        val result = container.transaction {
+            val txOp = operator("simple_data")
+            txOp.insert(listOf(SimpleData("a", 1, "alpha")))
+
+            // 直接使用非事务操作器，应通过 ThreadLocal 参与当前事务
+            val plainOp = container.operator("all_val_data")
+            plainOp.insert(listOf(AllValData("x", "fixed")))
+
+            rollback()
+        }
+        assertTrue(result.isFailure)
+        // 两张表的数据都应被回滚
+        assertEquals(0, container.operator("simple_data").get(SimpleData::class.java).size)
+        assertEquals(0, container.operator("all_val_data").get(AllValData::class.java).size)
+    }
+
+    @Test
+    fun `nested cross-table transaction commits together`() {
+        val result = container.transaction {
+            operator("simple_data").insert(listOf(SimpleData("a", 1, "alpha")))
+
+            container.transaction {
+                operator("all_val_data").insert(listOf(AllValData("x", "fixed")))
+            }
+
+            "ok"
+        }
+        assertTrue(result.isSuccess)
+        assertEquals(1, container.operator("simple_data").get(SimpleData::class.java).size)
+        assertEquals(1, container.operator("all_val_data").get(AllValData::class.java).size)
+    }
+
+    @Test
+    fun `ThreadLocal is cleaned up after transaction`() {
+        container.transaction {
+            operator("simple_data").insert(listOf(SimpleData("a", 1, "alpha")))
+        }
+        // 事务结束后 ThreadLocal 应为 null
+        assertNull(TransactionContext.currentConnection.get())
+    }
+
+    @Test
+    fun `ThreadLocal is cleaned up after failed transaction`() {
+        container.transaction {
+            operator("simple_data").insert(listOf(SimpleData("a", 1, "alpha")))
+            error("boom")
+        }
+        assertNull(TransactionContext.currentConnection.get())
+    }
+}


### PR DESCRIPTION
## 变更内容

为 database-ptc-object 模块新增三项功能：

### 1. @Ignore 注解
- 标记字段不参与数据库建表、插入、更新和查询
- 从数据库读取时使用 Kotlin 声明的默认值
- 优先级最高，覆盖 @Id、@Key 等其他注解

### 2. 集合 CustomType（扁平化集合存储）
- CustomType 接口新增 `elementType` 属性，标识集合级别的自定义类型
- 支持将 List/Set/Map 通过自定义序列化逻辑扁平化为单列存储
- CustomTypeFactory 新增 `registeredCollectionTypes` 双层 Map 和匹配方法

### 3. 事务传播（Transaction Propagation）
- TransactionContext 新增 `ThreadLocal<Connection>` 跟踪当前线程活跃事务
- 嵌套 `transaction()` 自动复用外层事务连接，不提交/不回滚/不关闭
- ContainerOperatorImpl 的 `withConnection()`/`withTransaction()` 检查 ThreadLocal

## 修改文件

- `Annotations.kt` — 新增 @Ignore 注解
- `AnalyzedClass.kt` / `AnalyzedClassMember.kt` — 忽略字段分析和默认值填充
- `CustomType.kt` / `CustomTypeFactory.kt` — 集合 CustomType 支持
- `ContainerOperatorImpl.kt` — CRUD 过滤 @Ignore、扁平化集合序列化、ThreadLocal 连接检查
- `ContainerSQL.kt` / `ContainerPostgreSQL.kt` / `ContainerSQLite.kt` — 建表逻辑适配
- `PersistentContainer.kt` / `TransactionContext.kt` — 事务传播
- 新增 3 个单元测试文件