### PR TITLE
feat(database): PTC Object 手动建表、版本迁移、PostgreSQL Schema 支持

### DIFF
--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/AnalyzedClassMember.kt
@@ -236,9 +236,12 @@ class AnalyzedClassMember(private val root: AnnotatedElement, name: String, val 
             return toCharArray().joinToString("") { if (it.isUpperCase()) "_${it.lowercase()}" else it.toString() }.trimStart('_')
         }
 
-        /** 解析数据类的表名：优先使用 @TableName 注解值，否则将类名转为下划线命名 */
+        /** 解析数据类的表名：优先使用 @TableName 注解值，否则将类名转为下划线命名；支持 schema 前缀 */
         fun Class<*>.resolveTableName(): String {
-            return getAnnotation(TableName::class.java)?.value ?: simpleName.toColumnName()
+            val annotation = getAnnotation(TableName::class.java)
+            val name = annotation?.value ?: simpleName.toColumnName()
+            val schema = annotation?.schema ?: ""
+            return if (schema.isNotEmpty()) "$schema.$name" else name
         }
 
         /** 获取注解 */

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Annotations.kt
@@ -224,11 +224,23 @@ annotation class LinkTable(val value: String)
  * )
  * ```
  *
+ * 支持 PostgreSQL Schema：
+ * ```kotlin
+ * @TableName("player_home", schema = "game")
+ * data class PlayerHome(
+ *     @Id val username: String,
+ *     var world: String,
+ * )
+ * // 建表时自动创建 Schema：CREATE SCHEMA IF NOT EXISTS "game"
+ * // 表名解析为：game.player_home
+ * ```
+ *
  * @param value 自定义表名
+ * @param schema PostgreSQL Schema 名称（为空时不使用 Schema 前缀）
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class TableName(val value: String)
+annotation class TableName(val value: String, val schema: String = "")
 
 /**
  * 标记字段为忽略字段，不参与数据库的读写操作。

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Container.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/Container.kt
@@ -22,6 +22,12 @@ abstract class Container<T : ColumnBuilder>(val host: Host<T>) {
     /** class → 容器关联表信息列表 */
     val collectionTableMap = ConcurrentHashMap<Class<*>, List<CollectionTableInfo>>()
 
+    /** 手动建表 SQL（非 null 时跳过自动建表） */
+    internal var manualTableStatements: List<String>? = null
+
+    /** 版本迁移配置 */
+    internal var migrationInstance: MigrationConfig? = null
+
     /** 创建表 */
     protected abstract fun createTableObject(type: AnalyzedClass, name: String): Table<*, *>
 
@@ -72,10 +78,76 @@ abstract class Container<T : ColumnBuilder>(val host: Host<T>) {
 
     /** 初始化所有表 */
     open fun init() {
-        map.forEach { it.value.table.createTable(dataSource) }
-        // 创建容器子表
-        collectionTableMap.values.forEach { infos ->
-            infos.forEach { it.table.createTable(dataSource) }
+        if (manualTableStatements != null) {
+            // 手动建表：执行用户提供的 SQL
+            dataSource.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    manualTableStatements!!.forEach { stmt.executeUpdate(it) }
+                }
+            }
+        } else {
+            // 自动建表
+            map.forEach { it.value.table.createTable(dataSource) }
+            // 创建容器子表
+            collectionTableMap.values.forEach { infos ->
+                infos.forEach { it.table.createTable(dataSource) }
+            }
+        }
+        // 版本迁移
+        migrationInstance?.let { runMigrations(it) }
+    }
+
+    /** 执行版本迁移 */
+    private fun runMigrations(config: MigrationConfig) {
+        if (config.versions.isEmpty()) return
+        dataSource.connection.use { conn ->
+            // 创建 meta 表
+            conn.createStatement().use { stmt ->
+                stmt.executeUpdate(
+                    "CREATE TABLE IF NOT EXISTS _ptc_meta (" +
+                    "table_name VARCHAR(255) NOT NULL PRIMARY KEY, " +
+                    "version INT NOT NULL DEFAULT 0)"
+                )
+            }
+            // 对每个注册的表执行迁移
+            for (tableName in map.keys) {
+                // 查询当前版本
+                val currentVersion = conn.prepareStatement(
+                    "SELECT version FROM _ptc_meta WHERE table_name = ?"
+                ).use { ps ->
+                    ps.setString(1, tableName)
+                    ps.executeQuery().use { rs ->
+                        if (rs.next()) rs.getInt("version") else 0
+                    }
+                }
+                // 执行待迁移版本
+                val pending = config.versions.filter { it.key > currentVersion }
+                if (pending.isEmpty()) continue
+                pending.forEach { (_, sqls) ->
+                    conn.createStatement().use { stmt ->
+                        sqls.forEach { stmt.executeUpdate(it) }
+                    }
+                }
+                // 更新版本号
+                val maxVersion = pending.keys.max()
+                if (currentVersion == 0) {
+                    conn.prepareStatement(
+                        "INSERT INTO _ptc_meta (table_name, version) VALUES (?, ?)"
+                    ).use { ps ->
+                        ps.setString(1, tableName)
+                        ps.setInt(2, maxVersion)
+                        ps.executeUpdate()
+                    }
+                } else {
+                    conn.prepareStatement(
+                        "UPDATE _ptc_meta SET version = ? WHERE table_name = ?"
+                    ).use { ps ->
+                        ps.setInt(1, maxVersion)
+                        ps.setString(2, tableName)
+                        ps.executeUpdate()
+                    }
+                }
+            }
         }
     }
 

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerPostgreSQL.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/ContainerPostgreSQL.kt
@@ -158,14 +158,37 @@ class ContainerPostgreSQL(
     }
 
     override fun init() {
+        // 收集需要创建的 schema
+        val schemas = mutableSetOf<String>()
+        map.keys.forEach { tableName ->
+            val dotIndex = tableName.indexOf('.')
+            if (dotIndex > 0) {
+                schemas.add(tableName.substring(0, dotIndex))
+            }
+        }
+        // 创建不存在的 schema
+        if (schemas.isNotEmpty()) {
+            dataSource.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    schemas.forEach { schema ->
+                        stmt.executeUpdate("CREATE SCHEMA IF NOT EXISTS \"$schema\"")
+                    }
+                }
+            }
+        }
+        // 调用父类 init（建表 + 迁移）
         super.init()
         // 为 @Key 字段创建 PostgreSQL 索引
         if (keyColumns.isNotEmpty()) {
             dataSource.connection.use { conn ->
                 conn.createStatement().use { stmt ->
                     keyColumns.forEach { (tableName, columns) ->
+                        // 索引名中的点号替换为下划线，避免被当作 schema 限定符
+                        val safeIndexName = tableName.replace('.', '_')
+                        // 表名含 schema 时需要分别引用："schema"."table"
+                        val quotedTableName = tableName.split('.').joinToString(".") { "\"$it\"" }
                         columns.forEach { col ->
-                            stmt.executeUpdate("CREATE INDEX IF NOT EXISTS \"idx_${tableName}_${col}\" ON \"$tableName\" (\"$col\")")
+                            stmt.executeUpdate("CREATE INDEX IF NOT EXISTS \"idx_${safeIndexName}_${col}\" ON $quotedTableName (\"$col\")")
                         }
                     }
                 }

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MapperDelegate.kt
@@ -8,6 +8,47 @@ import kotlin.reflect.KProperty
  */
 class MapperConfig<T> {
     internal var cacheInstance: L2Cache? = null
+    internal var manualTableSQL: List<String>? = null
+    internal var migrationInstance: MigrationConfig? = null
+
+    /**
+     * 手动建表：跳过自动建表，执行用户提供的 SQL
+     *
+     * ```kotlin
+     * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+     *     manualTable(
+     *         """CREATE TABLE IF NOT EXISTS player_home (
+     *             username VARCHAR(64) PRIMARY KEY,
+     *             world VARCHAR(64)
+     *         )"""
+     *     )
+     * }
+     * ```
+     */
+    fun manualTable(vararg sql: String) {
+        manualTableSQL = sql.toList()
+    }
+
+    /**
+     * 版本迁移：通过 meta 表跟踪版本号，按版本执行迁移 SQL
+     *
+     * ```kotlin
+     * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+     *     migration {
+     *         version(1,
+     *             "ALTER TABLE player_home ADD COLUMN x DOUBLE DEFAULT 0",
+     *             "ALTER TABLE player_home ADD COLUMN y DOUBLE DEFAULT 0"
+     *         )
+     *         version(2,
+     *             "ALTER TABLE player_home ADD COLUMN z DOUBLE DEFAULT 0"
+     *         )
+     *     }
+     * }
+     * ```
+     */
+    fun migration(block: MigrationConfig.() -> Unit) {
+        migrationInstance = MigrationConfig().apply(block)
+    }
 
     /**
      * 使用内置 L2 双层缓存
@@ -116,6 +157,8 @@ class MapperDelegate<T>(
     private fun createMapper(): DataMapper<T> {
         val mapperConfig = MapperConfig<T>().apply(config)
         val container = persistentContainer(source, flags, clearFlags, ssl) {
+            container.manualTableStatements = mapperConfig.manualTableSQL
+            container.migrationInstance = mapperConfig.migrationInstance
             new(type)
         }
         return DataMapperImpl(type, container, mapperConfig.cacheInstance)

--- a/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MigrationConfig.kt
+++ b/module/database/database-ptc-object/src/main/kotlin/taboolib/expansion/MigrationConfig.kt
@@ -1,0 +1,35 @@
+package taboolib.expansion
+
+/**
+ * 版本迁移配置
+ *
+ * 通过 [MapperConfig.migration] 配置迁移 SQL，框架会自动跟踪版本号并按序执行。
+ *
+ * ```kotlin
+ * val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
+ *     migration {
+ *         version(1,
+ *             "ALTER TABLE player_home ADD COLUMN x DOUBLE DEFAULT 0",
+ *             "ALTER TABLE player_home ADD COLUMN y DOUBLE DEFAULT 0"
+ *         )
+ *         version(2,
+ *             "ALTER TABLE player_home ADD COLUMN z DOUBLE DEFAULT 0"
+ *         )
+ *     }
+ * }
+ * ```
+ */
+class MigrationConfig {
+
+    internal val versions = sortedMapOf<Int, List<String>>()
+
+    /**
+     * 注册一个版本的迁移 SQL
+     *
+     * @param version 版本号（必须大于 0，按升序执行）
+     * @param sql 该版本需要执行的 SQL 语句
+     */
+    fun version(version: Int, vararg sql: String) {
+        versions[version] = sql.toList()
+    }
+}

--- a/module/database/src/main/kotlin/taboolib/module/database/ExecutableSource.kt
+++ b/module/database/src/main/kotlin/taboolib/module/database/ExecutableSource.kt
@@ -43,12 +43,12 @@ open class ExecutableSource(val table: Table<*, *>, var dataSource: DataSource, 
         if (table.host is HostPostgreSQL) {
             table.columns.filterIsInstance<ColumnPostgreSQL>().forEach { col ->
                 if (col.options.contains(ColumnOptionPostgreSQL.KEY)) {
-                    val indexName = "idx_${table.name}_${col.name}"
+                    val indexName = "idx_${table.name.replace('.', '_')}_${col.name}"
                     val sql = "CREATE INDEX IF NOT EXISTS ${indexName.asFormattedColumnName()} ON ${table.name.asFormattedColumnName()} (${col.name.asFormattedColumnName()})"
                     executeUpdate(sql)
                 }
                 if (col.options.contains(ColumnOptionPostgreSQL.UNIQUE)) {
-                    val indexName = "uk_${table.name}_${col.name}"
+                    val indexName = "uk_${table.name.replace('.', '_')}_${col.name}"
                     val sql = "CREATE UNIQUE INDEX IF NOT EXISTS ${indexName.asFormattedColumnName()} ON ${table.name.asFormattedColumnName()} (${col.name.asFormattedColumnName()})"
                     executeUpdate(sql)
                 }


### PR DESCRIPTION
## 改动概述

在已有的 `@Ignore` 注解基础上，继续增强 PTC Object ORM 模块，新增三项功能：

### 1. 手动建表 (`manualTable`)
跳过框架自动建表，执行用户提供的 SQL 语句创建表结构。

```kotlin
val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
    manualTable(
        """CREATE TABLE IF NOT EXISTS player_home (
            username VARCHAR(64) PRIMARY KEY,
            world VARCHAR(64)
        )"""
    )
}
```

### 2. 版本迁移 (`migration`)
通过 `_ptc_meta` 表跟踪版本号，按版本执行迁移 SQL。

```kotlin
val homeTable by mapper<PlayerHome>(dbFile("data.db")) {
    migration {
        version(1,
            "ALTER TABLE player_home ADD COLUMN x DOUBLE DEFAULT 0",
            "ALTER TABLE player_home ADD COLUMN y DOUBLE DEFAULT 0"
        )
        version(2,
            "ALTER TABLE player_home ADD COLUMN z DOUBLE DEFAULT 0"
        )
    }
}
```

### 3. PostgreSQL Schema 支持
`@TableName` 新增 `schema` 参数，建表前自动 `CREATE SCHEMA IF NOT EXISTS`。

```kotlin
@TableName("player_home", schema = "game")
data class PlayerHome(
    @Id val username: String,
    var world: String,
)
```

## 修改文件

- `Annotations.kt` — `@TableName` 新增 `schema` 参数
- `AnalyzedClassMember.kt` — `resolveTableName()` 支持 schema 前缀
- `MapperDelegate.kt` — `MapperConfig` 新增 `manualTable()` / `migration()`
- `MigrationConfig.kt` — 新建迁移配置类
- `Container.kt` — `init()` 支持手动建表和版本迁移
- `ContainerPostgreSQL.kt` — 建表前自动创建 Schema
- `ExecutableSource.kt` — 修复 PostgreSQL 索引名含 schema 点号的语法错误