### PR TITLE
修复 AetherResolver 依赖防重逻辑

### DIFF
--- a/common-env/src/main/java/taboolib/common/env/RuntimeEnvDependency.java
+++ b/common-env/src/main/java/taboolib/common/env/RuntimeEnvDependency.java
@@ -48,7 +48,7 @@ public class RuntimeEnvDependency {
         try {
             Class.forName("com.mohistmc.MohistMC");
             isAetherFound = false;
-        }catch (ClassNotFoundException ignored){
+        } catch (ClassNotFoundException ignored) {
         }
     }
 
@@ -226,46 +226,54 @@ public class RuntimeEnvDependency {
     /**
      * 从本地文件中加载依赖
      */
-    @SuppressWarnings("deprecation")
     public void loadFromLocalFile(URL url) throws Throwable {
         if (url == null) {
             return;
         }
         try (InputStream inputStream = url.openStream()) {
-            JsonElement parsed = new JsonParser().parse(PrimitiveIO.readFully(inputStream, StandardCharsets.UTF_8));
-            if (!parsed.isJsonArray()) return;
-            JsonArray array = parsed.getAsJsonArray();
-            for (JsonElement element : array) {
-                JsonObject object = element.getAsJsonObject();
-                // 获取检查条件
-                List<String> test = new ArrayList<>();
-                for (JsonElement testElement : array(object, "test")) {
-                    test.add(testElement.getAsString());
-                }
-                if (!test.isEmpty() && test.stream().allMatch(this::test)) {
-                    continue;
-                }
-                // 获取依赖信息
-                String value = object.get("value").getAsString();
-                String repository = find(object, "repository", defaultRepositoryCentral);
-                boolean transitive = find(object, "transitive");
-                boolean ignoreOptional = find(object, "ignoreOptional");
-                boolean ignoreException = find(object, "ignoreException");
-                boolean external = find(object, "external");
-                // 读取依赖范围
-                List<DependencyScope> scopes = new ArrayList<>();
-                for (JsonElement scope : array(object, "scopes")) {
-                    scopes.add(DependencyScope.valueOf(scope.getAsString().toUpperCase()));
-                }
-                // 读取重定向规则
-                List<JarRelocation> relocation = new ArrayList<>();
-                JsonArray relocate = array(object, "relocate");
-                for (int i = 0; i + 1 < relocate.size(); i += 2) {
-                    relocation.add(new JarRelocation(relocate.get(i).getAsString(), relocate.get(i + 1).getAsString()));
-                }
-                // 加载依赖
-                loadDependency(value, new File(defaultLibrary), relocation, repository, ignoreOptional, ignoreException, transitive, scopes, external);
+            String json = PrimitiveIO.readFully(inputStream, StandardCharsets.UTF_8);
+            loadFromJson(json);
+        }
+    }
+
+    /**
+     * 读取 JSON 字符串并根据格式加载依赖
+     */
+    public void loadFromJson(String json) throws Throwable {
+        //noinspection deprecation
+        JsonElement parsed = new JsonParser().parse(json);
+        if (!parsed.isJsonArray()) return;
+        JsonArray array = parsed.getAsJsonArray();
+        for (JsonElement element : array) {
+            JsonObject object = element.getAsJsonObject();
+            // 获取检查条件
+            List<String> test = new ArrayList<>();
+            for (JsonElement testElement : array(object, "test")) {
+                test.add(testElement.getAsString());
             }
+            if (!test.isEmpty() && test.stream().allMatch(this::test)) {
+                continue;
+            }
+            // 获取依赖信息
+            String value = object.get("value").getAsString();
+            String repository = find(object, "repository", defaultRepositoryCentral);
+            boolean transitive = find(object, "transitive");
+            boolean ignoreOptional = find(object, "ignoreOptional");
+            boolean ignoreException = find(object, "ignoreException");
+            boolean external = find(object, "external");
+            // 读取依赖范围
+            List<DependencyScope> scopes = new ArrayList<>();
+            for (JsonElement scope : array(object, "scopes")) {
+                scopes.add(DependencyScope.valueOf(scope.getAsString().toUpperCase()));
+            }
+            // 读取重定向规则
+            List<JarRelocation> relocation = new ArrayList<>();
+            JsonArray relocate = array(object, "relocate");
+            for (int i = 0; i + 1 < relocate.size(); i += 2) {
+                relocation.add(new JarRelocation(relocate.get(i).getAsString(), relocate.get(i + 1).getAsString()));
+            }
+            // 加载依赖
+            loadDependency(value, new File(defaultLibrary), relocation, repository, ignoreOptional, ignoreException, transitive, scopes, external);
         }
     }
 

--- a/common-env/src/main/java/taboolib/common/env/aether/AetherResolver.java
+++ b/common-env/src/main/java/taboolib/common/env/aether/AetherResolver.java
@@ -119,9 +119,10 @@ public class AetherResolver {
     public static @Nullable ClassLoader inject(@NotNull File file, @Nullable List<JarRelocation> relocation, boolean isExternal) throws Throwable {
         // 文件路径: group/name/version/file
         // 两次获取父文件跳到 name 层, 避免重复加载同一个依赖 (的不同版本)
-        String path = file.getParentFile().getParentFile().getPath();
-        if (injectedDependencies.contains(path)) return null;
-        else injectedDependencies.add(path);
+        String id = file.getParentFile().getParentFile().getPath()
+                + ":" + PrimitiveSettings.IS_ISOLATED_MODE; // 区分类加载器 (隔离类加载器或插件类加载器)
+        if (injectedDependencies.contains(id)) return null;
+        else injectedDependencies.add(id);
         // 如果没有重定向规则，直接注入
         if (relocation == null || relocation.isEmpty()) {
             return ClassAppender.addPath(file.toPath(), PrimitiveSettings.IS_ISOLATED_MODE, isExternal);

--- a/module/script/script-javascript/src/main/kotlin/taboolib/common5/NashornCompiler.kt
+++ b/module/script/script-javascript/src/main/kotlin/taboolib/common5/NashornCompiler.kt
@@ -3,26 +3,6 @@
     RuntimeDependency(
         "!org.openjdk.nashorn:nashorn-core:15.4",
         test = "!jdk.nashorn.api.scripting.NashornScriptEngineFactory"
-    ),
-    RuntimeDependency(
-        "!org.ow2.asm:asm:9.7.1",
-        test = "!jdk.nashorn.api.scripting.NashornScriptEngineFactory"
-    ),
-    RuntimeDependency(
-        "!org.ow2.asm:asm-commons:9.7.1",
-        test = "!jdk.nashorn.api.scripting.NashornScriptEngineFactory"
-    ),
-    RuntimeDependency(
-        "!org.ow2.asm:asm-tree:9.7.1",
-        test = "!jdk.nashorn.api.scripting.NashornScriptEngineFactory"
-    ),
-    RuntimeDependency(
-        "!org.ow2.asm:asm-util:9.7.1",
-        test = "!jdk.nashorn.api.scripting.NashornScriptEngineFactory"
-    ),
-    RuntimeDependency(
-        "!org.ow2.asm:asm-analysis:9.7.1",
-        test = "!jdk.nashorn.api.scripting.NashornScriptEngineFactory"
     )
 )
 


### PR DESCRIPTION
解释详见 [#636](https://github.com/TabooLib/taboolib/issues/636#issuecomment-3941324315)，原因是 AetherResolver依赖防重 未判定不同的类加载器。

修后 #646 不再需要，故回退

此外将Json处理部分从loadFromLocalFile单独抽离了出来，以应对动态版本的依赖加载。

fixes #636
