### PR TITLE
支持 SNAPSHOT 依赖下载和命令组件描述

### DIFF
--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponent.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponent.kt
@@ -17,7 +17,7 @@ fun CommandComponent.int(
     permission: String = "",
     dynamic: CommandComponentDynamic.() -> Unit = {}
 ): CommandComponentDynamic {
-    return dynamic(comment, optional, permission, dynamic).also {
+    return dynamic(comment = comment, optional = optional, permission = permission, dynamic = dynamic).also {
         CommandSuggestProviderLoader.getProvider().provideIntSuggest(it, comment, suggest)
     }
 }
@@ -34,7 +34,7 @@ fun CommandComponent.decimal(
     permission: String = "",
     dynamic: CommandComponentDynamic.() -> Unit = {}
 ): CommandComponentDynamic {
-    return dynamic(comment, optional, permission, dynamic).also {
+    return dynamic(comment = comment, optional = optional, permission = permission, dynamic = dynamic).also {
         CommandSuggestProviderLoader.getProvider().provideDecimalSuggest(it, comment, suggest)
     }
 }
@@ -48,7 +48,7 @@ fun CommandComponent.bool(
     permission: String = "",
     dynamic: CommandComponentDynamic.() -> Unit = {}
 ): CommandComponentDynamic {
-    return dynamic(comment, optional, permission, dynamic).also {
+    return dynamic(comment = comment, optional = optional, permission = permission, dynamic = dynamic).also {
         CommandSuggestProviderLoader.getProvider().provideBoolSuggest(it, comment)
     }
 }
@@ -67,7 +67,7 @@ fun CommandComponent.enum(
     permission: String = "",
     dynamic: CommandComponentDynamic.() -> Unit = {}
 ): CommandComponentDynamic {
-    return dynamic(comment, optional, permission, dynamic).also {
+    return dynamic(comment = comment, optional = optional, permission = permission, dynamic = dynamic).also {
         CommandSuggestProviderLoader.getProvider().provideEnumSuggest(it, enums, comment, suggest)
     }
 }
@@ -84,7 +84,7 @@ fun CommandComponent.player(
     permission: String = "",
     dynamic: CommandComponentDynamic.() -> Unit = {}
 ): CommandComponentDynamic {
-    return dynamic(comment, optional, permission, dynamic).also {
+    return dynamic(comment = comment, optional = optional, permission = permission, dynamic = dynamic).also {
         CommandSuggestProviderLoader.getProvider().providePlayerSuggest(it, comment, suggest)
     }
 }

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponentLocation.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/ExtraComponentLocation.kt
@@ -16,7 +16,7 @@ fun CommandComponent.world(
     permission: String = "",
     dynamic: CommandComponentDynamic.() -> Unit = {}
 ): CommandComponentDynamic {
-    return dynamic(comment, optional, permission, dynamic).suggestWorlds(suggest)
+    return dynamic(comment = comment, optional = optional, permission = permission, dynamic = dynamic).suggestWorlds(suggest)
 }
 
 /**

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/SimpleCommand.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/SimpleCommand.kt
@@ -31,6 +31,7 @@ annotation class CommandBody(
     val permission: String = "",
     val permissionDefault: PermissionDefault = PermissionDefault.OP,
     val hidden: Boolean = false,
+    val description: String = "",
 )
 
 fun mainCommand(func: CommandBase.() -> Unit): SimpleCommandMain {
@@ -55,6 +56,7 @@ class SimpleCommandBody(val func: CommandComponent.() -> Unit = {}) {
     var permission = ""
     var permissionDefault: PermissionDefault = PermissionDefault.OP
     var hidden = false
+    var description = ""
     val children = ArrayList<SimpleCommandBody>()
 
     override fun toString(): String {
@@ -87,6 +89,7 @@ class SimpleCommandRegister : ClassVisitor(0) {
                         permission = annotation.property("permission", "")
                         permissionDefault = annotation.enum("permissionDefault", PermissionDefault.OP)
                         hidden = annotation.property("hidden", false)
+                        description = annotation.property("description", "")
                     }
                 }
 
@@ -98,6 +101,7 @@ class SimpleCommandRegister : ClassVisitor(0) {
                         permission = annotation.property("permission", "")
                         permissionDefault = annotation.enum("permissionDefault", PermissionDefault.OP)
                         hidden = annotation.property("hidden", false)
+                        description = annotation.property("description", "")
                         // 向下搜索字段
                         ReflexClass.of(field.fieldType).structure.fields.forEach {
                             children += loadBody(it, owner) ?: return@forEach
@@ -135,7 +139,7 @@ class SimpleCommandRegister : ClassVisitor(0) {
                 main[clazz.name]?.func?.invoke(this)
                 body[clazz.name]?.forEach { body ->
                     fun register(body: SimpleCommandBody, component: CommandComponent) {
-                        component.literal(body.name, *body.aliases, optional = body.optional, permission = body.permission, hidden = body.hidden) {
+                        component.literal(body.name, *body.aliases, optional = body.optional, permission = body.permission, hidden = body.hidden, description = body.description) {
                             if (body.children.isEmpty()) {
                                 body.func(this)
                             } else {

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandComponent.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandComponent.kt
@@ -21,9 +21,10 @@ abstract class CommandComponent(val index: Int, var optional: Boolean, val permi
         optional: Boolean = false,
         permission: String = "",
         hidden: Boolean = false,
+        description: String = "",
         literal: CommandComponentLiteral.() -> Unit = {}
     ): CommandComponentLiteral {
-        val component = CommandComponentLiteral(arrayOf(*aliases), hidden, index + 1, optional, permission).also(literal).also { it.parent = this }
+        val component = CommandComponentLiteral(arrayOf(*aliases), hidden, description, index + 1, optional, permission).also(literal).also { it.parent = this }
         // 如果当前节点已存在命令执行器
         // 则自动视为可选节点
         if (commandExecutor != null) {
@@ -40,9 +41,10 @@ abstract class CommandComponent(val index: Int, var optional: Boolean, val permi
         comment: String = "...",
         optional: Boolean = false,
         permission: String = "",
+        description: String = "",
         dynamic: CommandComponentDynamic.() -> Unit = {}
     ): CommandComponentDynamic {
-        val component = CommandComponentDynamic(comment, index + 1, optional, permission).also(dynamic).also { it.parent = this }
+        val component = CommandComponentDynamic(comment, description, index + 1, optional, permission).also(dynamic).also { it.parent = this }
         // 如果当前节点已存在命令执行器
         // 则自动视为可选节点
         if (commandExecutor != null) {

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandComponentDynamic.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandComponentDynamic.kt
@@ -2,7 +2,7 @@ package taboolib.common.platform.command.component
 
 import taboolib.common.platform.command.CommandContext
 
-class CommandComponentDynamic(val comment: String, index: Int, optional: Boolean, permission: String) : CommandComponent(index, optional, permission) {
+class CommandComponentDynamic(val comment: String, val description: String = "", index: Int, optional: Boolean, permission: String) : CommandComponent(index, optional, permission) {
 
     internal var commandRestrict: CommandRestrict<*>? = null
     internal var commandSuggestion: CommandSuggestion<*>? = null

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandComponentLiteral.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandComponentLiteral.kt
@@ -3,6 +3,7 @@ package taboolib.common.platform.command.component
 class CommandComponentLiteral(
     val aliases: Array<String>,
     val hidden: Boolean,
+    val description: String = "",
     index: Int,
     optional: Boolean,
     permission: String

--- a/common/src/main/java/taboolib/common/PrimitiveLoader.java
+++ b/common/src/main/java/taboolib/common/PrimitiveLoader.java
@@ -118,8 +118,14 @@ public class PrimitiveLoader {
     static boolean load(String repo, String group, String name, String version, boolean isIsolated, boolean isExternal, List<String[]> relocate) {
         if (name.isEmpty()) return false;
         boolean downloaded = false;
-        File envFile = new File(getLibraryFile(), String.format("%s/%s/%s/%s-%s.jar", group.replace(".", "/"), name, version, name, version));
-        File shaFile = new File(getLibraryFile(), String.format("%s/%s/%s/%s-%s.jar.sha1", group.replace(".", "/"), name, version, name, version));
+        // SNAPSHOT 版本需要先查询 maven-metadata.xml 获取实际带时间戳的文件名
+        String resolvedFileName = version.endsWith("-SNAPSHOT")
+                ? resolveSnapshotFileName(repo, group, name, version)
+                : null;
+        // 本地保存文件名：SNAPSHOT 使用带时间戳的文件名，否则使用标准格式
+        String localFileName = resolvedFileName != null ? resolvedFileName : String.format("%s-%s.jar", name, version);
+        File envFile = new File(getLibraryFile(), String.format("%s/%s/%s/%s", group.replace(".", "/"), name, version, localFileName));
+        File shaFile = new File(getLibraryFile(), String.format("%s/%s/%s/%s.sha1", group.replace(".", "/"), name, version, localFileName));
         // 检查文件有效性
         if (!PrimitiveIO.validation(envFile, shaFile) || (IS_FORCE_DOWNLOAD_IN_DEV_MODE && IS_DEV_MODE && group.equals(TABOOLIB_GROUP))) {
             try {
@@ -128,11 +134,28 @@ public class PrimitiveLoader {
                         name,
                         version
                 );
-                // 获取地址
-                String url = String.format("%s/%s/%s/%s/%s-%s.jar", repo, group.replace(".", "/"), name, version, name, version);
-                // 下载资源
+                // 获取远程下载地址
+                String url;
+                if (resolvedFileName != null) {
+                    url = String.format("%s/%s/%s/%s/%s", repo, group.replace(".", "/"), name, version, resolvedFileName);
+                } else {
+                    url = String.format("%s/%s/%s/%s/%s-%s.jar", repo, group.replace(".", "/"), name, version, name, version);
+                }
+                // 下载 jar
                 PrimitiveIO.downloadFile(new URL(url), envFile);
-                PrimitiveIO.downloadFile(new URL(url + ".sha1"), shaFile);
+                // 尝试下载 sha1 文件；本地 file:// 仓库可能没有 sha1，则用 jar 自行生成
+                try {
+                    PrimitiveIO.downloadFile(new URL(url + ".sha1"), shaFile);
+                } catch (IOException ignored) {
+                    if (IS_DEV_MODE) {
+                        PrimitiveIO.debug("无法下载 {0}-{1}.jar.sha1，将用 jar 自行生成。", name, version);
+                        if (envFile.exists()) {
+                            generateSha1File(envFile, shaFile);
+                        }
+                    } else {
+                        throw new IOException("无法下载 " + url + ".sha1");
+                    }
+                }
                 downloaded = true;
             } catch (IOException e) {
                 e.printStackTrace();
@@ -270,6 +293,51 @@ public class PrimitiveLoader {
             file.mkdirs();
         }
         return file;
+    }
+
+    /**
+     * 解析 SNAPSHOT 版本的实际文件名
+     * 从快照仓库的 maven-metadata.xml 中获取带时间戳的实际文件名
+     * 例如：common-env-6.2.4-20240301.123456-1.jar
+     * 若解析失败则返回 null，回退到标准文件名格式
+     */
+    static String resolveSnapshotFileName(String repo, String group, String name, String version) {
+        try {
+            String metadataUrl = String.format("%s/%s/%s/%s/maven-metadata.xml",
+                    repo, group.replace(".", "/"), name, version);
+            java.io.InputStream ins = new URL(metadataUrl).openStream();
+            javax.xml.parsers.DocumentBuilderFactory factory = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+            javax.xml.parsers.DocumentBuilder builder = factory.newDocumentBuilder();
+            org.w3c.dom.Document doc = builder.parse(ins);
+            org.w3c.dom.NodeList timestampNodes = doc.getElementsByTagName("timestamp");
+            org.w3c.dom.NodeList buildNumberNodes = doc.getElementsByTagName("buildNumber");
+            if (timestampNodes.getLength() > 0 && buildNumberNodes.getLength() > 0) {
+                String timestamp = timestampNodes.item(0).getTextContent();
+                String buildNumber = buildNumberNodes.item(0).getTextContent();
+                // 将版本中的 -SNAPSHOT 替换为 -时间戳-构建号
+                String baseVersion = version.substring(0, version.length() - "-SNAPSHOT".length());
+                return String.format("%s-%s-%s-%s.jar", name, baseVersion, timestamp, buildNumber);
+            }
+        } catch (Throwable ignored) {
+            PrimitiveIO.debug("无法解析快照版本的实际文件名，回退到标准格式：{0}", name + "-" + version + ".jar");
+        }
+        return null;
+    }
+
+    /**
+     * 根据 jar 文件内容计算 sha1 并写入 sha1 文件
+     * 用于本地 file:// 仓库不提供 sha1 文件的场景
+     */
+    static void generateSha1File(File jarFile, File shaFile) {
+        try {
+            String hash = PrimitiveIO.getHash(jarFile);
+            shaFile.getParentFile().mkdirs();
+            try (java.io.FileOutputStream fos = new java.io.FileOutputStream(shaFile)) {
+                fos.write(hash.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            PrimitiveIO.debug("无法生成 {0}，将用 jar 自行生成。", shaFile.getName());
+        }
     }
 
     static int deepHashCode(List<String[]> array) {

--- a/module/minecraft/minecraft-command-helper/build.gradle.kts
+++ b/module/minecraft/minecraft-command-helper/build.gradle.kts
@@ -4,4 +4,7 @@ dependencies {
     compileOnly(project(":common-platform-api"))
     compileOnly(project(":module:minecraft:minecraft-chat"))
     compileOnly(project(":module:minecraft:minecraft-i18n"))
+    testImplementation(project(":common"))
+    testImplementation(project(":common-util"))
+    testImplementation(project(":common-platform-api"))
 }

--- a/module/minecraft/minecraft-command-helper/src/main/kotlin/taboolib/expansion/CommandHelper.kt
+++ b/module/minecraft/minecraft-command-helper/src/main/kotlin/taboolib/expansion/CommandHelper.kt
@@ -23,10 +23,6 @@ fun CommandComponent.createHelper(checkPermissions: Boolean = true) {
             return filterChildren.filter { it !is CommandComponentLiteral || !it.hidden }
         }
 
-        fun space(space: Int): String {
-            return (1..space).joinToString("") { " " }
-        }
-
         fun print(compound: CommandComponent, index: Int, size: Int, offset: Int = 8, level: Int = 0, end: Boolean = false, optional: Boolean = false) {
             var option = optional
             var comment = 0
@@ -37,11 +33,11 @@ fun CommandComponent.createHelper(checkPermissions: Boolean = true) {
                     } else {
                         newline = true
                         builder.appendLine()
-                        builder.append(space(offset))
+                        builder.append(CommandHelper.space(offset))
                         if (level > 1) {
                             builder.append(if (end) " " else "§7│")
                         }
-                        builder.append(space(level))
+                        builder.append(CommandHelper.space(level))
                         if (index + 1 < size) {
                             builder.append("§7├── ")
                         } else {
@@ -52,6 +48,7 @@ fun CommandComponent.createHelper(checkPermissions: Boolean = true) {
                     option = false
                     comment = compound.aliases[0].length
                 }
+
                 is CommandComponentDynamic -> {
                     val value = if (compound.comment.startsWith("@")) {
                         sender.asLangText(compound.comment.substring(1))
@@ -91,4 +88,209 @@ fun CommandComponent.createHelper(checkPermissions: Boolean = true) {
             sender.sendMessage(it)
         }
     }
+}
+
+
+/**
+ * 创建命令描述帮助
+ */
+fun CommandComponent.createDescriptionHelper(checkPermissions: Boolean = true) {
+    execute<ProxyCommandSender> { sender, context, _ ->
+        val command = context.command
+        val rootChildren = context.commandCompound.children
+            .filter { !checkPermissions || sender.hasPermission(it.permission) }
+            .filter { it !is CommandComponentLiteral || !it.hidden }
+        val text =
+            CommandHelper.buildDescriptionHelperText(command.name, rootChildren) { key -> sender.asLangText(key) }
+        text.lines().forEach { sender.sendMessage(it) }
+    }
+}
+
+object CommandHelper {
+    fun space(n: Int) = (1..n).joinToString("") { " " }
+
+    /**
+     * 构建命令帮助文本（纯字符串，不依赖平台 sender）
+     *
+     * @param commandName 命令名称
+     * @param rootChildren 根节点的子节点列表（已过滤权限和隐藏）
+     * @param langResolver 将 @key 风格的注释解析为实际文本，默认原样返回
+     */
+    fun buildHelperText(
+        commandName: String,
+        rootChildren: List<CommandComponent>,
+        langResolver: (String) -> String = { it }
+    ): String {
+        val builder = StringBuilder("§cUsage: /$commandName")
+        var newline = false
+
+        fun print(
+            compound: CommandComponent,
+            index: Int,
+            size: Int,
+            offset: Int = 8,
+            level: Int = 0,
+            end: Boolean = false,
+            optional: Boolean = false
+        ) {
+            var option = optional
+            var comment = 0
+            when (compound) {
+                is CommandComponentLiteral -> {
+                    if (size == 1) {
+                        builder.append(" ").append("§c${compound.aliases[0]}")
+                    } else {
+                        newline = true
+                        builder.appendLine()
+                        builder.append(space(offset))
+                        if (level > 1) {
+                            builder.append(if (end) " " else "§7│")
+                        }
+                        builder.append(space(level))
+                        if (index + 1 < size) {
+                            builder.append("§7├── ")
+                        } else {
+                            builder.append("§7└── ")
+                        }
+                        builder.append("§c${compound.aliases[0]}")
+                    }
+                    option = false
+                    comment = compound.aliases[0].length
+                }
+
+                is CommandComponentDynamic -> {
+                    val value = if (compound.comment.startsWith("@")) {
+                        langResolver(compound.comment.substring(1))
+                    } else {
+                        compound.comment
+                    }
+                    comment = if (compound.optional || option) {
+                        option = true
+                        builder.append(" ").append("§8[<$value>]")
+                        compound.comment.length + 4
+                    } else {
+                        builder.append(" ").append("§7<$value>")
+                        compound.comment.length + 2
+                    }
+                }
+            }
+            if (level > 0) comment += 1
+            val children = compound.children.filter { it !is CommandComponentLiteral || !it.hidden }
+            children.forEachIndexed { i, child ->
+                if (newline) {
+                    print(child, i, children.size, offset, level + comment, end, option)
+                } else {
+                    val length = if (offset == 8) commandName.length + 1 else comment + 1
+                    print(child, i, children.size, offset + length, level, end, option)
+                }
+            }
+        }
+
+        val size = rootChildren.size
+        rootChildren.forEachIndexed { index, child ->
+            print(child, index, size, end = index + 1 == size)
+        }
+        return builder.toString()
+    }
+
+
+    /**
+     * 构建带描述的命令帮助文本（纯字符串，不依赖平台 sender）
+     *
+     * @param commandName 命令名称
+     * @param rootChildren 根节点的子节点列表（已过滤权限和隐藏）
+     * @param langResolver 将 @key 风格的注释/描述解析为实际文本，默认原样返回
+     */
+    fun buildDescriptionHelperText(
+        commandName: String,
+        rootChildren: List<CommandComponent>,
+        langResolver: (String) -> String = { it }
+    ): String {
+        val builder = StringBuilder("§cUsage: /$commandName")
+        var newline = false
+
+        fun space(n: Int) = (1..n).joinToString("") { " " }
+
+        fun resolveDesc(desc: String): String =
+            if (desc.startsWith("@")) langResolver(desc.substring(1)) else desc
+
+        fun print(
+            compound: CommandComponent,
+            index: Int,
+            size: Int,
+            offset: Int = 8,
+            level: Int = 0,
+            end: Boolean = false,
+            optional: Boolean = false,
+            parentDescription: String = ""
+        ) {
+            var option = optional
+            var comment = 0
+            var currentDescription = parentDescription
+            when (compound) {
+                is CommandComponentLiteral -> {
+                    if (size == 1) {
+                        builder.append(" ").append("§c${compound.aliases[0]}")
+                        currentDescription = compound.description
+                    } else {
+                        newline = true
+                        builder.appendLine()
+                        builder.append(space(offset))
+                        if (level > 1) {
+                            builder.append(if (end) " " else "§7│")
+                        }
+                        builder.append(space(level))
+                        if (index + 1 < size) {
+                            builder.append("§7├── ")
+                        } else {
+                            builder.append("§7└── ")
+                        }
+                        builder.append("§c${compound.aliases[0]}")
+                        currentDescription = compound.description
+                    }
+                    option = false
+                    comment = compound.aliases[0].length
+                }
+
+                is CommandComponentDynamic -> {
+                    val value = if (compound.comment.startsWith("@")) {
+                        langResolver(compound.comment.substring(1))
+                    } else {
+                        compound.comment
+                    }
+                    comment = if (compound.optional || option) {
+                        option = true
+                        builder.append(" ").append("§8[<$value>]")
+                        compound.comment.length + 4
+                    } else {
+                        builder.append(" ").append("§7<$value>")
+                        compound.comment.length + 2
+                    }
+                    if (compound.description.isNotEmpty()) {
+                        currentDescription = compound.description
+                    }
+                }
+            }
+            if (level > 0) comment += 1
+            val children = compound.children.filter { it !is CommandComponentLiteral || !it.hidden }
+            if (children.isEmpty() && currentDescription.isNotEmpty()) {
+                builder.append(" §7- §c${resolveDesc(currentDescription)}")
+            }
+            children.forEachIndexed { i, child ->
+                if (newline) {
+                    print(child, i, children.size, offset, level + comment, end, option, currentDescription)
+                } else {
+                    val length = if (offset == 8) commandName.length + 1 else comment + 1
+                    print(child, i, children.size, offset + length, level, end, option, currentDescription)
+                }
+            }
+        }
+
+        val size = rootChildren.size
+        rootChildren.forEachIndexed { index, child ->
+            print(child, index, size, end = index + 1 == size)
+        }
+        return builder.toString()
+    }
+
 }

--- a/module/minecraft/minecraft-command-helper/src/test/kotlin/taboolib/expansion/CommandHelperTest.kt
+++ b/module/minecraft/minecraft-command-helper/src/test/kotlin/taboolib/expansion/CommandHelperTest.kt
@@ -1,0 +1,296 @@
+package taboolib.expansion
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import taboolib.common.platform.command.component.CommandComponentDynamic
+import taboolib.common.platform.command.component.CommandComponentLiteral
+
+/**
+ * CommandHelper 输出格式单元测试
+ *
+ * 测试 CommandHelper.buildHelperText / buildDescriptionHelperText 的字符串输出格式，
+ * 不依赖 Minecraft 平台，直接构造 CommandComponent 树进行验证。
+ */
+class CommandHelperTest {
+
+    // ===== 工具方法 =====
+
+    private fun literal(
+        vararg aliases: String,
+        hidden: Boolean = false,
+        description: String = "",
+        index: Int = 0
+    ): CommandComponentLiteral {
+        return CommandComponentLiteral(arrayOf(*aliases), hidden, description, index, false, "")
+    }
+
+    private fun dynamic(
+        comment: String,
+        optional: Boolean = false,
+        description: String = "",
+        index: Int = 0
+    ): CommandComponentDynamic {
+        return CommandComponentDynamic(comment, description, index, optional, "")
+    }
+
+    // ===== CommandHelper.buildHelperText 测试 =====
+
+    @Test
+    fun singleLiteralChildInlined() {
+        // 单个 literal 子节点时应内联在同一行显示，格式：/test add
+        val add = literal("add", index = 0)
+        val result = CommandHelper.buildHelperText("test", listOf(add))
+        assertEquals("§cUsage: /test §cadd", result)
+    }
+
+    @Test
+    fun multipleLiteralChildrenFormatAsTree() {
+        // 多个 literal 子节点时应展开为树形，格式：
+        //   §cUsage: /test
+        //           §7├── §cadd
+        //           §7└── §cremove
+        val add = literal("add", index = 0)
+        val remove = literal("remove", index = 0)
+        val result = CommandHelper.buildHelperText("test", listOf(add, remove))
+        val lines = result.lines()
+        assertEquals("§cUsage: /test", lines[0])
+        assertEquals("        §7├── §cadd", lines[1])
+        assertEquals("        §7└── §cremove", lines[2])
+    }
+
+    @Test
+    fun singleDynamicChildShowsRequiredParam() {
+        // 单个必填 dynamic 节点应内联显示尖括号格式：/test <player>
+        val player = dynamic("player", index = 0)
+        val result = CommandHelper.buildHelperText("test", listOf(player))
+        assertEquals("§cUsage: /test §7<player>", result)
+    }
+
+    @Test
+    fun optionalDynamicChildShowsBracketParam() {
+        // optional dynamic 节点应显示方括号格式：/test [<player>]
+        val player = dynamic("player", optional = true, index = 0)
+        val result = CommandHelper.buildHelperText("test", listOf(player))
+        assertEquals("§cUsage: /test §8[<player>]", result)
+    }
+
+    @Test
+    fun literalFollowedByDynamicChild() {
+        // literal 后跟 dynamic 子节点时应内联拼接：/test add <player>
+        val add = literal("add", index = 0)
+        val player = dynamic("player", index = 1)
+        add.children.add(player)
+        player.parent = add
+        val result = CommandHelper.buildHelperText("test", listOf(add))
+        assertEquals("§cUsage: /test §cadd §7<player>", result)
+    }
+
+    @Test
+    fun multipleLiteralsEachWithDynamicChild() {
+        // 多个 literal 各自带 dynamic 子节点时，每行应包含各自的参数
+        // 预期格式：
+        //   §cUsage: /test
+        //           §7├── §cadd §7<player>
+        //           §7└── §cremove §7<player>
+        val add = literal("add", index = 0)
+        val addPlayer = dynamic("player", index = 1)
+        add.children.add(addPlayer)
+        addPlayer.parent = add
+
+        val remove = literal("remove", index = 0)
+        val removePlayer = dynamic("player", index = 1)
+        remove.children.add(removePlayer)
+        removePlayer.parent = remove
+
+        val result = CommandHelper.buildHelperText("test", listOf(add, remove))
+        val lines = result.lines()
+        assertEquals("§cUsage: /test", lines[0])
+        assert(lines[1].contains("§7├── ") && lines[1].contains("§cadd") && lines[1].contains("§7<player>")) {
+            "第二行应包含 ├── add <player>，实际：${lines[1]}"
+        }
+        assert(lines[2].contains("§7└── ") && lines[2].contains("§cremove") && lines[2].contains("§7<player>")) {
+            "第三行应包含 └── remove <player>，实际：${lines[2]}"
+        }
+    }
+
+    @Test
+    fun hiddenLiteralChildIsFiltered() {
+        // hidden=true 的 literal 子节点不应出现在输出中，visible 节点应正常显示
+        val visible = literal("visible", index = 0)
+        val hidden = literal("hidden", hidden = true, index = 0)
+        // 将 hidden 挂为 parent 的子节点来触发内部过滤逻辑
+        val parent = literal("parent", index = 0)
+        parent.children.add(visible)
+        parent.children.add(hidden)
+        visible.parent = parent
+        hidden.parent = parent
+        val result = CommandHelper.buildHelperText("test", listOf(parent))
+        assert(!result.contains("§chidden")) { "hidden 节点不应出现在输出中，实际：$result" }
+        assert(result.contains("§cvisible")) { "visible 节点应出现在输出中，实际：$result" }
+    }
+
+    @Test
+    fun dynamicCommentWithAtPrefixIsResolvedByLangResolver() {
+        // dynamic comment 以 @ 开头时，应通过 langResolver 将 key 转换为实际文本
+        val node = dynamic("@my.key", index = 0)
+        val result = CommandHelper.buildHelperText("test", listOf(node)) { key -> "已解析:$key" }
+        assertEquals("§cUsage: /test §7<已解析:my.key>", result)
+    }
+
+    @Test
+    fun treeIndentationIsAlways8Spaces() {
+        // 树形模式下每个分支行前固定缩进 8 个空格，与命令名长度无关
+        val a = literal("a", index = 0)
+        val b = literal("b", index = 0)
+        val result = CommandHelper.buildHelperText("longcmd", listOf(a, b))
+        val lines = result.lines()
+        assert(lines[1].startsWith("        §7├── ")) { "期望 8 空格缩进，实际：'${lines[1]}'" }
+        assert(lines[2].startsWith("        §7└── ")) { "期望 8 空格缩进，实际：'${lines[2]}'" }
+    }
+
+    @Test
+    fun lastLiteralUsesCornerBranchSymbol() {
+        // 非末尾节点使用 ├──，末尾节点使用 └──
+        val a = literal("a", index = 0)
+        val b = literal("b", index = 0)
+        val c = literal("c", index = 0)
+        val result = CommandHelper.buildHelperText("test", listOf(a, b, c))
+        val lines = result.lines()
+        assert(lines[1].contains("§7├── §ca")) { "a 应使用 ├──，实际：${lines[1]}" }
+        assert(lines[2].contains("§7├── §cb")) { "b 应使用 ├──，实际：${lines[2]}" }
+        assert(lines[3].contains("§7└── §cc")) { "c 应使用 └──，实际：${lines[3]}" }
+    }
+
+    // ===== buildDescriptionHelperText 测试 =====
+
+    @Test
+    fun leafLiteralWithDescriptionAppendsDescAtEnd() {
+        // leaf literal 节点有描述时，应在行尾追加 " §7- §c描述" 格式
+        val add = literal("add", description = "添加玩家", index = 0)
+        val result = CommandHelper.buildDescriptionHelperText("test", listOf(add))
+        assert(result.contains("§7- §c添加玩家")) { "应包含描述，实际：$result" }
+    }
+
+    @Test
+    fun literalDescriptionPropagatesDownToDynamicLeaf() {
+        // literal 节点的描述应向下传递给无描述的 dynamic leaf 子节点
+        // 预期：/test add <player> §7- §c添加对象
+        val add = literal("add", description = "添加对象", index = 0)
+        val player = dynamic("player", index = 1)
+        add.children.add(player)
+        player.parent = add
+        val result = CommandHelper.buildDescriptionHelperText("test", listOf(add))
+        assert(result.contains("§7- §c添加对象")) { "literal 描述应传递到叶子节点，实际：$result" }
+    }
+
+    @Test
+    fun leafDynamicWithDescriptionAppendsDescAtEnd() {
+        // leaf dynamic 节点有描述时，应在行尾追加描述
+        val player = dynamic("player", description = "目标玩家", index = 0)
+        val result = CommandHelper.buildDescriptionHelperText("test", listOf(player))
+        assert(result.contains("§7- §c目标玩家")) { "应包含 dynamic 描述，实际：$result" }
+    }
+
+    @Test
+    fun multipleLeavesEachShowOwnDescription() {
+        // 多个 leaf literal 各自有描述时，每个节点末尾应显示各自的描述
+        val add = literal("add", description = "添加", index = 0)
+        val remove = literal("remove", description = "删除", index = 0)
+        val result = CommandHelper.buildDescriptionHelperText("test", listOf(add, remove))
+        assert(result.contains("§7- §c添加")) { "add 描述应存在，实际：$result" }
+        assert(result.contains("§7- §c删除")) { "remove 描述应存在，实际：$result" }
+    }
+
+    @Test
+    fun descriptionWithAtPrefixIsResolvedByLangResolver() {
+        // 描述字段以 @ 开头时，应通过 langResolver 解析为实际文本
+        val add = literal("add", description = "@cmd.add.desc", index = 0)
+        val result = CommandHelper.buildDescriptionHelperText("test", listOf(add)) { key -> "描述:$key" }
+        assert(result.contains("§7- §c描述:cmd.add.desc")) { "描述应被解析，实际：$result" }
+    }
+
+    @Test
+    fun leafWithNoDescriptionDoesNotAppendSeparator() {
+        // 无描述的 leaf 节点不应追加 "§7- §c" 分隔符
+        val add = literal("add", index = 0)
+        val result = CommandHelper.buildDescriptionHelperText("test", listOf(add))
+        assert(!result.contains("§7- §c")) { "无描述时不应追加分隔符，实际：$result" }
+    }
+
+    @Test
+    fun dynamicCommentWithAtPrefixResolvedInDescriptionHelper() {
+        // buildDescriptionHelperText 中 dynamic comment 的 @ 前缀同样通过 langResolver 解析
+        val node = dynamic("@target", index = 0)
+        val result = CommandHelper.buildDescriptionHelperText("test", listOf(node)) { key -> "目标:$key" }
+        assertEquals("§cUsage: /test §7<目标:target>", result)
+    }
+
+    @Test
+    fun complexCommandTreeFormatsCorrectly() {
+        // 复杂命令树：模拟一个带多层子命令的插件管理命令
+        // 预期结构：
+        //   /plugin
+        //           §7├── §creload
+        //           §7├── §cenable §7<name>
+        //           §7├── §cdisable §7<name>
+        //           §7└── §cinfo §7<name> §8[<page>]
+        val reload = literal("reload", description = "重载插件配置", index = 0)
+
+        val enable = literal("enable", description = "启用插件", index = 0)
+        val enableName = dynamic("name", index = 1)
+        enable.children.add(enableName)
+        enableName.parent = enable
+
+        val disable = literal("disable", description = "禁用插件", index = 0)
+        val disableName = dynamic("name", index = 1)
+        disable.children.add(disableName)
+        disableName.parent = disable
+
+        val info = literal("info", description = "查看插件信息", index = 0)
+        val infoName = dynamic("name", index = 1)
+        val infoPage = dynamic("page", optional = true, index = 2)
+        info.children.add(infoName)
+        infoName.parent = info
+        infoName.children.add(infoPage)
+        infoPage.parent = infoName
+
+        val rootChildren = listOf(reload, enable, disable, info)
+        val result = CommandHelper.buildDescriptionHelperText("plugin", rootChildren)
+        val lines = result.lines()
+
+        // 第一行：命令头
+        assertEquals("§cUsage: /plugin", lines[0])
+
+        // reload 行：leaf literal，末尾追加描述
+        assert(lines[1].contains("§7├── ") && lines[1].contains("§creload") && lines[1].contains("§7- §c重载插件配置")) {
+            "reload 行格式不符，实际：${lines[1]}"
+        }
+
+        // enable 行：literal + dynamic <name>，末尾追加描述
+        assert(
+            lines[2].contains("§7├── ") && lines[2].contains("§cenable") && lines[2].contains("§7<name>") && lines[2].contains(
+                "§7- §c启用插件"
+            )
+        ) {
+            "enable 行格式不符，实际：${lines[2]}"
+        }
+
+        // disable 行：literal + dynamic <name>，末尾追加描述
+        assert(
+            lines[3].contains("§7├── ") && lines[3].contains("§cdisable") && lines[3].contains("§7<name>") && lines[3].contains(
+                "§7- §c禁用插件"
+            )
+        ) {
+            "disable 行格式不符，实际：${lines[3]}"
+        }
+
+        // info 行：literal + dynamic <name> + optional [<page>]，末尾追加描述
+        assert(
+            lines[4].contains("§7└── ") && lines[4].contains("§cinfo") && lines[4].contains("§7<name>") && lines[4].contains(
+                "§8[<page>]"
+            ) && lines[4].contains("§7- §c查看插件信息")
+        ) {
+            "info 行格式不符，实际：${lines[4]}"
+        }
+    }
+}


### PR DESCRIPTION
# 更新内容说明

## 1. 依赖管理优化

- **支持 SNAPSHOT 版本依赖下载**：解决了从仓库拉取快照版依赖时可能出现的问题
- **修复本地发布不生成 .sha1 文件的问题**：完善了本地仓库依赖的校验机制，避免因此导致的依赖下载失败

## 2. 命令系统增强

- **为命令添加描述字段**
- **新增描述命令扩展方法**：在 `CommandHelper` 工具中添加了 `createDescriptionHelper` 方法，用于便捷地创建带描述的命令