### PR TITLE
fix(FileWatcher): gracefully handle inotify instance exhaustion

### DIFF
--- a/common-legacy-api/src/main/java/taboolib/common5/FileWatcher.java
+++ b/common-legacy-api/src/main/java/taboolib/common5/FileWatcher.java
@@ -2,6 +2,7 @@ package taboolib.common5;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import taboolib.common.LifeCycle;
+import taboolib.common.PrimitiveIO;
 import taboolib.common.TabooLib;
 import taboolib.common.platform.Ghost;
 
@@ -50,8 +51,18 @@ public class FileWatcher {
     private final WatchService watchService;
 
     public FileWatcher(int interval) {
+        WatchService ws;
         try {
-            this.watchService = FileSystems.getDefault().newWatchService();
+            ws = FileSystems.getDefault().newWatchService();
+        } catch (IOException e) {
+            PrimitiveIO.warning(PrimitiveIO.t(
+                "FileWatcher 初始化失败，文件自动重载功能不可用: " + e.getMessage(),
+                "FileWatcher failed to initialize, auto-reload is unavailable: " + e.getMessage()
+            ));
+            ws = null;
+        }
+        this.watchService = ws;
+        if (this.watchService != null) {
             this.executorService.scheduleAtFixedRate(() -> {
                 WatchKey key;
                 while ((key = watchService.poll()) != null) {
@@ -76,8 +87,6 @@ public class FileWatcher {
             }, 1000, interval, TimeUnit.MILLISECONDS);
             // 注册关闭回调
             TabooLib.registerLifeCycleTask(LifeCycle.DISABLE, 0, this::release);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 
@@ -99,6 +108,9 @@ public class FileWatcher {
      * @param runImmediately 是否在添加监听器时立即执行一次
      */
     public void addSimpleListener(File file, Consumer<File> runnable, boolean runImmediately) {
+        if (watchService == null) {
+            return;
+        }
         if (runImmediately) {
             runnable.accept(file);
         }


### PR DESCRIPTION
## Problem

On Linux, when the OS inotify instance limit is reached (`fs.inotify.max_user_instances`), `FileWatcher` constructor throws a `RuntimeException`, causing `ExceptionInInitializerError` during `<clinit>`. Since JVM permanently marks the class as failed after a `<clinit>` error, `FileWatcher.INSTANCE` becomes inaccessible for the entire ClassLoader lifetime.

This causes `ConfigLoader` to crash mid-visit before writing to `files[name]`, so all subsequent `@ConfigNode` fields report `"xxx.yml not defined"` — affecting every plugin with `autoReload = true` loaded after the limit is hit.

## Fix

- Catch `IOException` in `FileWatcher(int)` constructor; set `watchService = null` and emit a `PrimitiveIO.warning` instead of throwing
- Skip scheduler registration and `DISABLE` lifecycle callback when `watchService` is null
- `addSimpleListener` returns early (no-op) when `watchService` is null
- `INSTANCE` is always a valid object (degraded mode), so callers are unaffected