### PR TITLE
feat: 新增 minecraft-multiblocks 多方块结构模块

### DIFF
--- a/.claude/skills/taboolib-multiblocks/SKILL.md
+++ b/.claude/skills/taboolib-multiblocks/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: taboolib-multiblocks
+description: 在 TabooLib 中，定义和验证多方块结构（Multiblock）。 (project)
+---
+
+# TabooLib-Multiblocks 多方块结构工具
+
+## 编写规则
+
+如果要使用多方块结构功能，要遵守以下规则：
+
+1. **选择合适的结构类型**：紧凑结构用 `DenseMultiblock`（字符图案），大型稀疏结构用 `SparseMultiblock`（坐标映射）
+2. **密集型图案方向**：`pattern` 数组第一个元素 = 最顶层（最高 Y），最后一个 = 最底层；每个 `String` 数组元素是一行 Z（北→南），字符串中每个字符是 X 列（西→东）
+3. **必须设置锚点**：密集型中 `'0'` 字符**必须恰好出现一次**作为锚点；稀疏型锚点默认在 `(0,0,0)`
+4. **映射必须完整**：密集型图案中出现的所有字符（除 `'0'`、`'_'`、空格外）都必须在 `mapping` 中定义，否则会映射为空气
+5. **使用 `StringStateMatcher.parse()` 解析方块**：支持 `minecraft:stone`（材质）、`minecraft:stairs[facing=north]`（带属性）、`#minecraft:wool`（标签）三种格式
+6. **对称结构设置 `symmetrical = true`**：如果结构在水平面上关于中心轴对称，设置此标志可跳过多余旋转检测，性能提升约 4 倍
+7. **通过 `MultiblockRegistry` 注册**：使用 `命名空间:名称` 格式的 ID 进行全局注册
+
+## 类型表
+
+| 类 | 说明 |
+|---|---|
+| `DenseMultiblock` | 密集型：用字符图案 `Array<Array<String>>` 定义结构 |
+| `SparseMultiblock` | 稀疏型：用 `Map<BlockPos, IStateMatcher>` 定义结构 |
+| `StateMatcher` | 内置匹配器工厂（`ANY`/`AIR`/`fromMaterial`/`fromBlockData`/`fromPredicate`/`displayOnly`） |
+| `StringStateMatcher` | 从字符串解析匹配器（材质名/方块属性/标签） |
+| `MultiblockRegistry` | 全局注册表（`register`/`get`/`unregister`/`getAll`/`clear`） |
+| `BlockPos` | 整数坐标，支持 `+`/`-` 运算和 `rotate()` 旋转 |
+| `MultiblockRotation` | 旋转枚举（`NONE`/`CLOCKWISE_90`/`CLOCKWISE_180`/`COUNTERCLOCKWISE_90`） |
+| `IMultiblock` | 核心接口（`validate`/`simulate`/`test`/`offset`） |
+| `IStateMatcher` | 方块匹配器接口（`displayName`/`test`） |
+| `SimulateResult` | 模拟结果（`worldPosition`/`stateMatcher`/`character`） |
+
+## 特殊字符（DenseMultiblock）
+
+| 字符 | 含义 | 默认匹配器 | 可否在 mapping 中覆盖 |
+|------|------|-----------|---------------------|
+| `0` | 中心锚点（必须恰好一个） | `StateMatcher.AIR` | 可覆盖（如 `'0' to parse("minecraft:lapis_block")`） |
+| `_` | 任意方块 | `StateMatcher.ANY` | 可覆盖 |
+| ` ` (空格) | 空气 | `StateMatcher.AIR` | 可覆盖（如 `' ' to StateMatcher.ANY`） |
+
+## 字符串匹配器格式
+
+| 格式 | 示例 | 说明 |
+|------|------|------|
+| 材质名 | `minecraft:stone` | 匹配材质，忽略方块状态属性 |
+| 方块数据 | `minecraft:oak_stairs[facing=north,half=bottom]` | 精确匹配，包括指定的状态属性 |
+| 方块标签 | `#minecraft:wool` | 匹配标签中的所有方块 |
+
+## 旋转变换
+
+| 枚举值 | 角度 | `(x, y, z)` → |
+|--------|------|----------------|
+| `NONE` | 0° | `(x, y, z)` |
+| `CLOCKWISE_90` | 顺时针 90° | `(-z, y, x)` |
+| `CLOCKWISE_180` | 180° | `(-x, y, -z)` |
+| `COUNTERCLOCKWISE_90` | 逆时针 90° | `(z, y, -x)` |
+
+## 快速示例
+
+### 密集型多方块
+
+```kotlin
+val altar = DenseMultiblock(
+    pattern = arrayOf(
+        // 顶层
+        arrayOf(
+            "   ",
+            " S ",
+            "   "
+        ),
+        // 底层
+        arrayOf(
+            "SSS",
+            "S0S",
+            "SSS"
+        )
+    ),
+    mapping = mapOf(
+        'S' to StringStateMatcher.parse("minecraft:stone_bricks")
+    )
+)
+MultiblockRegistry.register("my_plugin:altar", altar)
+```
+
+### 带朝向属性和自定义锚点方块
+
+```kotlin
+val stairAltar = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            " WWW ",
+            "N   S",
+            "N 0 S",
+            "N   S",
+            " EEE "
+        )
+    ),
+    mapping = mapOf(
+        ' ' to StateMatcher.ANY,
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),
+        'N' to StringStateMatcher.parse("minecraft:oak_stairs[facing=south]"),
+        'S' to StringStateMatcher.parse("minecraft:oak_stairs[facing=north]"),
+        'W' to StringStateMatcher.parse("minecraft:oak_stairs[facing=east]"),
+        'E' to StringStateMatcher.parse("minecraft:oak_stairs[facing=west]"),
+    )
+).apply { symmetrical = true }
+```
+
+### 包含流体和含水方块
+
+```kotlin
+val fluidStructure = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            "GGGGGGG",
+            " LLLLLG",
+            "GGGGGGG",
+            " WW0WWG",
+            "GGGGGGG",
+        )
+    ),
+    mapping = mapOf(
+        ' ' to StateMatcher.ANY,
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),
+        'G' to StringStateMatcher.parse("minecraft:bricks"),
+        'W' to StringStateMatcher.parse("minecraft:water"),
+        'L' to StringStateMatcher.parse("minecraft:lava"),
+    )
+)
+```
+
+### 稀疏型多方块
+
+```kotlin
+val fourPillars = SparseMultiblock(
+    blocks = buildMap {
+        val pillar = StringStateMatcher.parse("minecraft:stone_bricks")
+        for (x in listOf(-3, 3)) {
+            for (z in listOf(-3, 3)) {
+                for (y in 0..2) {
+                    put(BlockPos(x, y, z), pillar)
+                }
+            }
+        }
+        put(BlockPos(0, 0, 0), StringStateMatcher.parse("minecraft:diamond_block"))
+    }
+)
+```
+
+### 验证结构
+
+```kotlin
+val anchor = BlockPos(block.x, block.y, block.z)
+// 自动尝试所有旋转（非对称 = 4 方向，对称 = 1 方向）
+val rotation = multiblock.validate(world, anchor)
+if (rotation != null) {
+    // 匹配成功，rotation 为匹配时的旋转方向
+}
+```
+
+### 进度检测
+
+```kotlin
+val results = multiblock.simulate(anchor, rotation)
+for (result in results) {
+    val pos = result.worldPosition
+    val block = world.getBlockAt(pos.x, pos.y, pos.z)
+    if (!result.stateMatcher.test(block)) {
+        println("缺失: $pos 需要 ${result.stateMatcher.displayName}")
+    }
+}
+```
+
+### 自定义匹配器
+
+```kotlin
+val mapping = mapOf(
+    'F' to StateMatcher.fromMaterial(Material.FURNACE),
+    'I' to StateMatcher.fromPredicate("iron_or_gold") { block ->
+        block.type == Material.IRON_BLOCK || block.type == Material.GOLD_BLOCK
+    },
+    'W' to StringStateMatcher.parse("#minecraft:planks"),
+    'T' to StringStateMatcher.parse("#minecraft:logs"),
+)
+```
+
+## 参考文档
+
+- [dense-multiblock.md](dense-multiblock.md) - 密集型多方块：图案格式、坐标系、特殊字符
+- [sparse-multiblock.md](sparse-multiblock.md) - 稀疏型多方块：坐标映射、与密集型对比
+- [state-matcher.md](state-matcher.md) - 状态匹配器：内置匹配器、字符串解析、自定义匹配器
+- [validation.md](validation.md) - 结构验证：旋转检测、对称优化、模拟、进度检测

--- a/.claude/skills/taboolib-multiblocks/dense-multiblock.md
+++ b/.claude/skills/taboolib-multiblocks/dense-multiblock.md
@@ -1,0 +1,227 @@
+# 密集型多方块 DenseMultiblock
+
+## 构造函数
+
+```kotlin
+class DenseMultiblock(
+    pattern: Array<Array<String>>,
+    mapping: Map<Char, IStateMatcher> = emptyMap()
+) : AbstractMultiblock()
+```
+
+**参数说明：**
+
+- `pattern`：结构图案，三层嵌套数组
+- `mapping`：字符到 `IStateMatcher` 的映射
+
+## 图案坐标系
+
+Pattern 是一个三维结构，索引含义如下：
+
+```
+pattern = arrayOf(           ← 外层数组：Y 层（index 0 = 最高层）
+    arrayOf(                 ←   中层数组：Z 行（index 0 = 北，从北→南）
+        "ABCDE",             ←     字符串字符：X 列（index 0 = 西，从西→东）
+        "FGHIJ",
+        "KLMNO"
+    )
+)
+```
+
+| 维度 | 索引方向 | 说明 |
+|------|---------|------|
+| **Y 层** | `pattern[0]` = 最顶层，`pattern[N]` = 最底层 | 从上到下排列 |
+| **Z 行** | `layer[0]` = Z=0（北），`layer[N]` = 最大 Z（南） | 从北到南排列 |
+| **X 列** | `row[0]` = X=0（西），`row[N]` = 最大 X（东） | 从西到东排列 |
+
+**俯视图（单层）：**
+
+```
+         X（西→东）
+         0  1  2
+Z  0  [  A  B  C  ]    ← 北
+（  1  [  D  E  F  ]
+北  2  [  G  H  I  ]    ← 南
+→
+南）
+```
+
+## 特殊字符
+
+| 字符 | 含义 | 默认匹配器 | 可覆盖 |
+|------|------|-----------|--------|
+| `0` | 中心锚点（**必须恰好一个**） | `StateMatcher.AIR` | 可在 mapping 中覆盖 |
+| `_` | 任意方块 | `StateMatcher.ANY` | 可覆盖 |
+| ` ` (空格) | 空气 | `StateMatcher.AIR` | 可覆盖 |
+
+**重要规则：**
+- 图案中**必须恰好包含一个 `0`** 字符作为锚点
+- 图案中出现的所有其他字符（除 `0`、`_`、空格外）**必须在 mapping 中定义**
+- 特殊字符可在 mapping 中覆盖默认行为
+
+## 基础示例
+
+### 单层 3x3 平台
+
+```kotlin
+val platform = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            "SSS",
+            "S0S",
+            "SSS"
+        )
+    ),
+    mapping = mapOf(
+        'S' to StringStateMatcher.parse("minecraft:stone_bricks")
+    )
+)
+```
+
+### 多层结构
+
+```kotlin
+// 3x3x3 空心立方体
+val cube = DenseMultiblock(
+    pattern = arrayOf(
+        // 顶层 (最高 Y)
+        arrayOf(
+            "BBB",
+            "BBB",
+            "BBB"
+        ),
+        // 中间层，含锚点
+        arrayOf(
+            "BBB",
+            "B0B",
+            "BBB"
+        ),
+        // 底层 (最低 Y)
+        arrayOf(
+            "BBB",
+            "BBB",
+            "BBB"
+        )
+    ),
+    mapping = mapOf(
+        'B' to StringStateMatcher.parse("minecraft:bricks")
+    )
+)
+```
+
+### 自定义锚点方块
+
+默认情况下 `'0'` 映射为空气。如果锚点位置需要特定方块，在 mapping 中覆盖：
+
+```kotlin
+val altar = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            "SSS",
+            "S0S",
+            "SSS"
+        )
+    ),
+    mapping = mapOf(
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),  // 锚点是青金石块
+        'S' to StringStateMatcher.parse("minecraft:stone_bricks")
+    )
+)
+```
+
+### 覆盖空格默认行为
+
+默认空格表示"必须为空气"。如果空格位置不需要检测，将其覆盖为 ANY：
+
+```kotlin
+val dome = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            "GGGGGGG",
+            "GGG GGG",
+            "GG   GG",
+            "G     G",
+            "GG   GG",
+            "GGG GGG",
+            "GGGGGGG"
+        ),
+        arrayOf(
+            "RRRSRRR",
+            "RRSSSRR",
+            "RSSSSSR",
+            "SSS0SSS",
+            "RSSSSSR",
+            "RRSSSRR",
+            "RRRSRRR"
+        )
+    ),
+    mapping = mapOf(
+        ' ' to StateMatcher.ANY,         // 空格 = 任意方块（不检测）
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),
+        'G' to StringStateMatcher.parse("minecraft:purple_stained_glass"),
+        'R' to StringStateMatcher.parse("minecraft:stone"),
+        'S' to StringStateMatcher.parse("minecraft:sponge"),
+    )
+).apply { symmetrical = true }
+```
+
+### 带朝向属性的方块
+
+方块的 `facing` 等状态属性在旋转时很关键：
+
+```kotlin
+val staircase = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            " WWW ",
+            "N   S",
+            "N 0 S",
+            "N   S",
+            " EEE "
+        )
+    ),
+    mapping = mapOf(
+        'N' to StringStateMatcher.parse("minecraft:oak_stairs[facing=south]"),
+        'S' to StringStateMatcher.parse("minecraft:birch_stairs[facing=north]"),
+        'W' to StringStateMatcher.parse("minecraft:brick_stairs[facing=east]"),
+        'E' to StringStateMatcher.parse("minecraft:stone_brick_stairs[facing=west]")
+    )
+)
+```
+
+### 包含流体和含水方块
+
+```kotlin
+val fluidStructure = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            "GG   GG",
+            " LLLLLG",
+            "GGGGGGG",
+            " WW0WWG",
+            "GGGGGGG",
+            " SSSSSG",
+            "GG   GG"
+        )
+    ),
+    mapping = mapOf(
+        ' ' to StateMatcher.ANY,
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),
+        'G' to StringStateMatcher.parse("minecraft:bricks"),
+        'W' to StringStateMatcher.parse("minecraft:water"),
+        'L' to StringStateMatcher.parse("minecraft:lava"),
+        'S' to StringStateMatcher.parse("minecraft:brick_slab[type=bottom,waterlogged=true]"),
+    )
+)
+```
+
+## 注意事项
+
+| 场景 | 说明 |
+|------|------|
+| 未找到 `0` | 锚点默认为 `(0, 0, 0)` 即图案最底层西北角 |
+| 多个 `0` | 使用最后一个找到的位置 |
+| 行长度不一致 | 短行末尾自动填充空格（空气） |
+| 未映射的字符 | 会映射为 `StateMatcher.AIR`（空气），应确保所有字符都有映射 |
+| `ANY` 匹配器 | 在 `simulate()` 中被跳过，不产生 `SimulateResult` |
+| 结构尺寸 | 由 `pattern` 自动推断，通过 `size` 属性获取 |

--- a/.claude/skills/taboolib-multiblocks/sparse-multiblock.md
+++ b/.claude/skills/taboolib-multiblocks/sparse-multiblock.md
@@ -1,0 +1,114 @@
+# 稀疏型多方块 SparseMultiblock
+
+## 构造函数
+
+```kotlin
+class SparseMultiblock(
+    blocks: Map<BlockPos, IStateMatcher>
+) : AbstractMultiblock()
+```
+
+**参数说明：**
+
+- `blocks`：相对位置到状态匹配器的映射，所有位置相对于锚点 `(0, 0, 0)`
+
+## 坐标说明
+
+- 所有位置**相对于锚点 `(0, 0, 0)`**
+- 锚点就是验证时传入的 `anchor` 参数位置
+- 未定义的位置**不参与验证**（等效于 `StateMatcher.ANY`）
+- 如果需要某个位置必须为空气，需显式添加 `BlockPos(...) to StateMatcher.AIR`
+
+## 基础示例
+
+### 十字形结构
+
+```kotlin
+val cross = SparseMultiblock(
+    blocks = mapOf(
+        BlockPos(0, 0, 0) to StringStateMatcher.parse("minecraft:diamond_block"),
+        BlockPos(1, 0, 0) to StringStateMatcher.parse("minecraft:iron_block"),
+        BlockPos(-1, 0, 0) to StringStateMatcher.parse("minecraft:iron_block"),
+        BlockPos(0, 0, 1) to StringStateMatcher.parse("minecraft:iron_block"),
+        BlockPos(0, 0, -1) to StringStateMatcher.parse("minecraft:iron_block"),
+    )
+)
+```
+
+### 立柱结构
+
+```kotlin
+val pillar = SparseMultiblock(
+    blocks = mapOf(
+        BlockPos(0, 0, 0) to StringStateMatcher.parse("minecraft:stone_bricks"),
+        BlockPos(0, 1, 0) to StringStateMatcher.parse("minecraft:stone_bricks"),
+        BlockPos(0, 2, 0) to StringStateMatcher.parse("minecraft:stone_bricks"),
+        BlockPos(0, 3, 0) to StringStateMatcher.parse("minecraft:chiseled_stone_bricks"),
+    )
+)
+```
+
+### 大型稀疏结构（程序生成）
+
+```kotlin
+// 四角立柱（10x4x10 的空间中只有 4 根柱子 + 中心标记）
+val fourPillars = SparseMultiblock(
+    blocks = buildMap {
+        val pillarBlock = StringStateMatcher.parse("minecraft:stone_bricks")
+        val capBlock = StringStateMatcher.parse("minecraft:chiseled_stone_bricks")
+        // 四个角的 3 格高立柱
+        for (x in listOf(-5, 5)) {
+            for (z in listOf(-5, 5)) {
+                for (y in 0..2) {
+                    put(BlockPos(x, y, z), pillarBlock)
+                }
+                put(BlockPos(x, 3, z), capBlock) // 顶部装饰
+            }
+        }
+        // 中心锚点
+        put(BlockPos(0, 0, 0), StringStateMatcher.parse("minecraft:diamond_block"))
+    }
+)
+```
+
+> 如果用 DenseMultiblock 定义同样的结构，需要填写 11x4x11 = 484 个字符，其中绝大多数是空格。稀疏型只需定义 21 个有效位置。
+
+### 需要空气检测的稀疏结构
+
+```kotlin
+// 中心必须是钻石块，周围必须是空气
+val isolated = SparseMultiblock(
+    blocks = mapOf(
+        BlockPos(0, 0, 0) to StringStateMatcher.parse("minecraft:diamond_block"),
+        // 显式要求周围为空气
+        BlockPos(1, 0, 0) to StateMatcher.AIR,
+        BlockPos(-1, 0, 0) to StateMatcher.AIR,
+        BlockPos(0, 0, 1) to StateMatcher.AIR,
+        BlockPos(0, 0, -1) to StateMatcher.AIR,
+        BlockPos(0, 1, 0) to StateMatcher.AIR,
+        BlockPos(0, -1, 0) to StateMatcher.AIR,
+    )
+)
+```
+
+## 与 DenseMultiblock 的对比
+
+| 特性 | DenseMultiblock | SparseMultiblock |
+|------|----------------|-----------------|
+| 定义方式 | 字符图案 `String[][]` | 坐标映射 `Map<BlockPos, IStateMatcher>` |
+| 锚点 | `'0'` 字符位置 | 默认 `(0,0,0)` |
+| 空气检测 | 空格字符自动检测空气 | 需显式添加 `StateMatcher.AIR` |
+| 未定义位置 | 不存在"未定义"（图案覆盖整个包围盒） | 未定义 = 不检测（ANY） |
+| 适合场景 | 紧凑、规则、方块密度高 | 大型、稀疏、不规则 |
+| 可读性 | 图案直观可视 | 坐标列表，适合程序生成 |
+| 内存效率 | 存储整个包围盒 | 只存储有效方块 |
+
+## 注意事项
+
+| 场景 | 说明 |
+|------|------|
+| 空 blocks | `size` 为 `BlockPos.ZERO`，验证始终返回成功 |
+| 不需要空气检测 | 稀疏型中未定义的位置不参与验证，等效于 ANY |
+| 需要空气检测 | 显式添加 `BlockPos(...) to StateMatcher.AIR` |
+| 对称性 | 同样支持 `symmetrical = true` 优化 |
+| 程序生成 | 配合 `buildMap { }` 使用，用循环批量添加位置 |

--- a/.claude/skills/taboolib-multiblocks/state-matcher.md
+++ b/.claude/skills/taboolib-multiblocks/state-matcher.md
@@ -1,0 +1,174 @@
+# 状态匹配器 StateMatcher
+
+状态匹配器（`IStateMatcher`）定义了"某个位置应该是什么方块"的规则。是多方块结构的核心构建块。
+
+## IStateMatcher 接口
+
+```kotlin
+interface IStateMatcher {
+    val displayName: String       // 显示名称
+    fun test(block: Block): Boolean  // 测试方块是否匹配
+}
+```
+
+## 内置常量
+
+| 常量 | 说明 | 对应 Dense 特殊字符 |
+|------|------|-------------------|
+| `StateMatcher.ANY` | 匹配任意方块（包括空气） | `_` |
+| `StateMatcher.AIR` | 仅匹配空气方块 | ` ` (空格) 和 `0` |
+
+## StateMatcher 工厂方法
+
+### fromMaterial — 匹配材质
+
+匹配指定材质，忽略方块状态属性（如 `facing`、`half` 等）：
+
+```kotlin
+StateMatcher.fromMaterial(Material.STONE)
+StateMatcher.fromMaterial(Material.FURNACE)
+StateMatcher.fromMaterial(Material.OAK_PLANKS)
+```
+
+### fromBlockData — 精确匹配方块数据
+
+包括状态属性的精确匹配：
+
+```kotlin
+val data = Bukkit.createBlockData("minecraft:oak_stairs[facing=north,half=bottom]")
+StateMatcher.fromBlockData(data)
+```
+
+### fromBlockDataLoose — 宽松匹配方块数据
+
+使用 `BlockData.matches()` 进行宽松匹配（仅检查指定的属性）：
+
+```kotlin
+StateMatcher.fromBlockDataLoose(blockData)
+```
+
+### fromPredicate — 自定义谓词
+
+完全自定义的匹配逻辑：
+
+```kotlin
+// 匹配铁块或金块
+StateMatcher.fromPredicate("iron_or_gold") { block ->
+    block.type == Material.IRON_BLOCK || block.type == Material.GOLD_BLOCK
+}
+
+// 匹配所有矿石
+StateMatcher.fromPredicate("any_ore") { block ->
+    block.type.name.endsWith("_ORE")
+}
+
+// 匹配亮度足够的方块
+StateMatcher.fromPredicate("bright") { block ->
+    block.lightLevel >= 12
+}
+```
+
+### displayOnly — 仅显示
+
+不进行实际验证（始终返回 true），仅用于 UI 显示目的：
+
+```kotlin
+StateMatcher.displayOnly("decorative")
+```
+
+## StringStateMatcher — 字符串解析
+
+`StringStateMatcher.parse()` 从字符串解析匹配器，支持三种格式：
+
+### 材质名匹配
+
+匹配指定材质，忽略方块状态属性：
+
+```kotlin
+StringStateMatcher.parse("minecraft:stone")
+StringStateMatcher.parse("minecraft:oak_planks")
+StringStateMatcher.parse("minecraft:furnace")
+StringStateMatcher.parse("stone")  // 也支持省略命名空间
+```
+
+### 方块数据匹配（带属性）
+
+方括号内指定需要匹配的状态属性：
+
+```kotlin
+StringStateMatcher.parse("minecraft:oak_stairs[facing=north]")
+StringStateMatcher.parse("minecraft:oak_stairs[facing=north,half=bottom]")
+StringStateMatcher.parse("minecraft:chest[facing=south,type=single]")
+StringStateMatcher.parse("minecraft:note_block[note=4]")
+StringStateMatcher.parse("minecraft:brick_slab[type=bottom,waterlogged=true]")
+```
+
+### 标签匹配
+
+以 `#` 开头，匹配标签中的所有方块：
+
+```kotlin
+StringStateMatcher.parse("#minecraft:planks")      // 所有木板
+StringStateMatcher.parse("#minecraft:wool")         // 所有羊毛
+StringStateMatcher.parse("#minecraft:logs")         // 所有原木
+StringStateMatcher.parse("#minecraft:buttons")      // 所有按钮
+StringStateMatcher.parse("#minecraft:stone_bricks") // 所有石砖变种
+```
+
+### 流体方块
+
+流体同样可以作为匹配条件：
+
+```kotlin
+StringStateMatcher.parse("minecraft:water")
+StringStateMatcher.parse("minecraft:lava")
+```
+
+## 自定义匹配器
+
+实现 `IStateMatcher` 接口：
+
+```kotlin
+class LightLevelMatcher(private val minLight: Int) : IStateMatcher {
+    override val displayName = "light>=$minLight"
+    override fun test(block: Block): Boolean {
+        return block.lightLevel >= minLight
+    }
+}
+
+// 使用
+val mapping = mapOf(
+    'L' to LightLevelMatcher(12)
+)
+```
+
+## 在 DenseMultiblock 中使用
+
+```kotlin
+val multiblock = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            "FIF",
+            "I0I",
+            "FIF"
+        )
+    ),
+    mapping = mapOf(
+        'F' to StateMatcher.fromMaterial(Material.FURNACE),
+        'I' to StateMatcher.fromPredicate("iron_or_gold") { block ->
+            block.type == Material.IRON_BLOCK || block.type == Material.GOLD_BLOCK
+        },
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),
+    )
+)
+```
+
+## 注意事项
+
+| 场景 | 说明 |
+|------|------|
+| 材质不存在 | `StringStateMatcher.MaterialMatcher` 返回 `false` |
+| BlockData 解析失败 | `StringStateMatcher.BlockDataMatcher` 返回 `false`（不抛异常） |
+| 标签不存在 | `StringStateMatcher.TagMatcher` 返回 `false` |
+| `ANY` 匹配器 | 在 `DenseMultiblock.simulate()` 中被跳过，不生成 `SimulateResult` |
+| mapping 优先级 | 用户定义的 mapping 会覆盖默认的特殊字符映射 |

--- a/.claude/skills/taboolib-multiblocks/validation.md
+++ b/.claude/skills/taboolib-multiblocks/validation.md
@@ -1,0 +1,186 @@
+# 结构验证与旋转检测
+
+## 验证方法
+
+### 自动旋转验证
+
+`validate(world, anchor)` 自动尝试所有旋转方向，返回第一个匹配的旋转：
+
+- 非对称结构：按 `NONE` → `CLOCKWISE_90` → `CLOCKWISE_180` → `COUNTERCLOCKWISE_90` 顺序尝试
+- 对称结构（`symmetrical = true`）：仅尝试 `NONE`
+
+```kotlin
+val anchor = BlockPos(block.x, block.y, block.z)
+
+val rotation = multiblock.validate(world, anchor)
+if (rotation != null) {
+    // 匹配成功，rotation 为匹配时的旋转方向
+    println("结构匹配，旋转: $rotation")
+} else {
+    // 未匹配任何旋转方向
+}
+```
+
+### 指定旋转验证
+
+`validate(world, anchor, rotation)` 只检查指定旋转方向：
+
+```kotlin
+val matched = multiblock.validate(world, anchor, MultiblockRotation.NONE)
+if (matched) {
+    // 在 NONE 旋转下匹配成功
+}
+```
+
+### 单方块测试
+
+`test(world, anchor, x, y, z, rotation)` 测试结构中单个位置是否匹配：
+
+```kotlin
+val blockOk = multiblock.test(world, anchor, 1, 0, 0, MultiblockRotation.NONE)
+```
+
+如果坐标不在结构范围内，返回 `true`。
+
+## 旋转方向
+
+`MultiblockRotation` 定义了 4 种绕 Y 轴的旋转：
+
+| 枚举值 | 角度 | 坐标变换 `(x, y, z)` → | 方向变化 |
+|--------|------|------------------------|---------|
+| `NONE` | 0° | `(x, y, z)` | 原始方向 |
+| `CLOCKWISE_90` | 顺时针 90° | `(-z, y, x)` | 北→东→南→西 |
+| `CLOCKWISE_180` | 180° | `(-x, y, -z)` | 北↔南, 东↔西 |
+| `COUNTERCLOCKWISE_90` | 逆时针 90° | `(z, y, -x)` | 北→西→南→东 |
+
+**旋转验证示例：**
+
+```
+假设东侧有一个楼梯 facing=west（朝西面放置）
+NONE 旋转下它在 anchor 东侧
+CLOCKWISE_90 后它应该在 anchor 南侧
+```
+
+所有旋转围绕 Y 轴进行（水平旋转），Y 坐标不变。
+
+## 对称优化
+
+如果结构在水平面上关于中心轴对称（如正方形平台），设置对称标志可跳过多余旋转：
+
+```kotlin
+// 标记为对称结构
+multiblock.symmetrical = true
+
+// 验证时只检查 NONE 旋转，性能提升约 4 倍
+val rotation = multiblock.validate(world, anchor)
+```
+
+**什么时候设置对称：**
+- 正方形平台 — 对称
+- 圆形结构 — 对称
+- 十字形（四臂相同）— 对称
+- L 形结构 — 不对称
+- 带朝向的结构 — 通常不对称
+
+## 模拟
+
+`simulate(anchor, rotation)` 返回结构中所有方块的世界坐标，**不访问世界**——纯坐标计算。
+
+```kotlin
+val results = multiblock.simulate(anchor, MultiblockRotation.NONE)
+for (result in results) {
+    println("位置: ${result.worldPosition}")
+    println("匹配器: ${result.stateMatcher.displayName}")
+    println("字符: ${result.character}")  // 仅 DenseMultiblock 有值
+}
+```
+
+**注意：** `StateMatcher.ANY` 匹配器在 simulate 中会被跳过，不产生 `SimulateResult`（因为"任意方块"不需要检测）。
+
+### 用途
+
+| 用途 | 说明 |
+|------|------|
+| **预览高亮** | 在世界中高亮显示结构方块位置 |
+| **进度检测** | 逐个检查哪些方块已放置、哪些缺失 |
+| **放置引导** | 提示玩家每个位置需要什么方块 |
+| **结构分析** | 统计结构使用了多少种不同方块 |
+
+## 完整示例
+
+### 检测玩家右键的方块
+
+```kotlin
+@SubscribeEvent
+fun onInteract(e: PlayerInteractEvent) {
+    if (e.action != Action.RIGHT_CLICK_BLOCK) return
+    val block = e.clickedBlock ?: return
+    val anchor = BlockPos(block.x, block.y, block.z)
+
+    for ((id, multiblock) in MultiblockRegistry.getAll()) {
+        val rotation = multiblock.validate(block.world, anchor)
+        if (rotation != null) {
+            e.player.sendMessage("检测到结构: $id (旋转: $rotation)")
+            return
+        }
+    }
+}
+```
+
+### 进度检测
+
+```kotlin
+fun checkProgress(
+    world: World,
+    multiblock: IMultiblock,
+    anchor: BlockPos,
+    rotation: MultiblockRotation
+): Pair<Int, List<SimulateResult>> {
+    val results = multiblock.simulate(anchor, rotation)
+    var completed = 0
+    val missing = mutableListOf<SimulateResult>()
+
+    for (result in results) {
+        val pos = result.worldPosition
+        val block = world.getBlockAt(pos.x, pos.y, pos.z)
+        if (result.stateMatcher.test(block)) {
+            completed++
+        } else {
+            missing.add(result)
+        }
+    }
+
+    return completed to missing
+}
+
+// 使用
+val (done, missing) = checkProgress(world, multiblock, anchor, rotation)
+player.sendMessage("进度: $done/${done + missing.size}")
+for (m in missing) {
+    player.sendMessage("  缺失: ${m.worldPosition} 需要 ${m.stateMatcher.displayName}")
+}
+```
+
+### 遍历所有注册的多方块
+
+```kotlin
+fun findMultiblockAt(world: World, anchor: BlockPos): Pair<String, MultiblockRotation>? {
+    for ((id, multiblock) in MultiblockRegistry.getAll()) {
+        val rotation = multiblock.validate(world, anchor)
+        if (rotation != null) {
+            return id to rotation
+        }
+    }
+    return null
+}
+```
+
+## 注意事项
+
+| 场景 | 说明 |
+|------|------|
+| 大型结构 | 验证遍历所有方块，结构越大开销越高，建议限制检测频率 |
+| `test()` 坐标越界 | 如果坐标不在结构范围内，返回 `true`（不检测） |
+| 锚点选择 | 应与结构定义的 `'0'` 位置对应，通常是玩家交互的方块 |
+| 旋转与方块属性 | 当前版本不自动旋转方块的 `facing` 等属性，需在匹配器中自行处理 |
+| 并发安全 | `MultiblockRegistry` 内部使用 `ConcurrentHashMap`，线程安全 |

--- a/module/minecraft/minecraft-multiblocks/README.md
+++ b/module/minecraft/minecraft-multiblocks/README.md
@@ -1,0 +1,574 @@
+# minecraft-multiblocks
+
+多方块结构模块，提供在 Minecraft 世界中定义、验证和匹配多方块结构的能力。参考 [Patchouli](https://vazkiimods.github.io/Patchouli/docs/patchouli-basics/multiblocks/) 的 Multiblock 设计，适配 TabooLib/Bukkit 生态。
+
+## 依赖
+
+```kotlin
+compileOnly(project(":module:minecraft:minecraft-multiblocks"))
+```
+
+## 核心概念
+
+### 什么是多方块结构
+
+多方块结构（Multiblock）是由多个方块按照特定排列组成的结构。模块提供：
+
+- **结构定义** — 用图案或坐标描述结构由哪些方块组成
+- **结构验证** — 检测世界中某个位置是否存在该结构（支持自动旋转检测）
+- **结构模拟** — 计算结构中每个方块的世界坐标（用于预览、进度提示等）
+
+### 两种定义方式
+
+| 类型 | 适用场景 | 定义方式 |
+|------|---------|---------|
+| `DenseMultiblock` | 紧凑结构、方块密度高 | 字符图案（`String[][]`），类似合成配方 |
+| `SparseMultiblock` | 大型稀疏结构、不规则形状 | 坐标映射（`Map<BlockPos, IStateMatcher>`） |
+
+两种方式在功能上完全等价——都支持验证、模拟和旋转检测。选择哪种取决于结构的形状特征。
+
+---
+
+## 密集型（DenseMultiblock）
+
+密集型使用二维字符串数组定义结构，类似 Minecraft 合成配方的格式。每个字符代表一个方块，通过 `mapping` 映射到具体的方块匹配器。
+
+### 基础用法
+
+```kotlin
+// 定义一个 3x2x3 的石砖祭坛
+val altar = DenseMultiblock(
+    pattern = arrayOf(
+        // 第一个数组 = 最顶层（最高 Y）
+        arrayOf(
+            "   ",
+            " S ",
+            "   "
+        ),
+        // 最后一个数组 = 最底层（最低 Y）
+        arrayOf(
+            "SSS",
+            "S0S",    // '0' = 中心锚点
+            "SSS"
+        )
+    ),
+    mapping = mapOf(
+        'S' to StringStateMatcher.parse("minecraft:stone_bricks")
+    )
+)
+```
+
+### 图案坐标系
+
+图案是一个三维结构，索引含义如下：
+
+```
+pattern = arrayOf(           ← 外层数组：Y 层
+    arrayOf(                 ←   中层数组：Z 行（北→南）
+        "ABCDE",             ←     字符串字符：X 列（西→东）
+        "FGHIJ",
+        "KLMNO"
+    ),
+    ...
+)
+```
+
+| 维度 | 索引方向 | 说明 |
+|------|---------|------|
+| **Y 层** | `pattern[0]` = 最顶层，`pattern[N]` = 最底层 | 从上到下排列 |
+| **Z 行** | `layer[0]` = Z=0（北），`layer[N]` = 最大 Z（南） | 从北到南排列 |
+| **X 列** | `row[0]` = X=0（西），`row[N]` = 最大 X（东） | 从西到东排列 |
+
+**俯视图（单层）：**
+
+```
+         X（西→东）
+         0  1  2
+Z  0  [  A  B  C  ]    ← 北
+（  1  [  D  E  F  ]
+北  2  [  G  H  I  ]    ← 南
+→
+南）
+```
+
+### 特殊字符
+
+| 字符 | 含义 | 默认匹配器 | 可否覆盖 |
+|------|------|-----------|---------|
+| `0` | **中心锚点**（必须恰好出现一次） | `StateMatcher.AIR` | 可在 mapping 中覆盖 |
+| `_` | 任意方块（不参与验证） | `StateMatcher.ANY` | 可覆盖 |
+| ` ` (空格) | 空气 | `StateMatcher.AIR` | 可覆盖 |
+
+**重要规则：**
+- 图案中 **必须恰好包含一个 `0` 字符** 作为锚点
+- 图案中出现的所有其他字符（除 `0`、`_`、空格外）**必须在 mapping 中定义**
+- 特殊字符的默认行为可以在 mapping 中覆盖，例如 `'0' to StringStateMatcher.parse("minecraft:lapis_block")` 可使锚点位置要求为青金石块
+
+### 大型多方块示例
+
+```kotlin
+// 一个 7x5x7 的穹顶结构（参考 Patchouli 测试用例）
+val dome = DenseMultiblock(
+    pattern = arrayOf(
+        // 第 1 层（最顶层）
+        arrayOf(
+            "GGGGGGG",
+            "GGG GGG",
+            "GG   GG",
+            "G     G",
+            "GG   GG",
+            "GGG GGG",
+            "GGGGGGG"
+        ),
+        // 第 2 层
+        arrayOf(
+            "GGG GGG",
+            "GG   GG",
+            "G     G",
+            "       ",
+            "G     G",
+            "GG   GG",
+            "GGG GGG"
+        ),
+        // 第 3 层
+        arrayOf(
+            "GG   GG",
+            "G     G",
+            "       ",
+            "       ",
+            "       ",
+            "G     G",
+            "GG   GG"
+        ),
+        // 第 4 层（中间有箱子）
+        arrayOf(
+            "GGG GGG",
+            "GG   GG",
+            "G     G",
+            "   C   ",
+            "G     G",
+            "GG   GG",
+            "GGG GGG"
+        ),
+        // 第 5 层（底层，包含锚点）
+        arrayOf(
+            "RRRSRRR",
+            "RRSSSRR",
+            "RSSSSSR",
+            "SSS0SSS",
+            "RSSSSSR",
+            "RRSSSRR",
+            "RRRSRRR"
+        )
+    ),
+    mapping = mapOf(
+        ' ' to StateMatcher.ANY,                                          // 覆盖空格为"任意方块"
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),         // 自定义锚点方块
+        'G' to StringStateMatcher.parse("minecraft:purple_stained_glass"),
+        'R' to StringStateMatcher.parse("minecraft:stone"),
+        'S' to StringStateMatcher.parse("minecraft:sponge"),
+        'C' to StringStateMatcher.parse("minecraft:chest"),
+    )
+).apply { symmetrical = true }
+```
+
+### 带方块属性的朝向结构
+
+方块属性（如楼梯的 `facing`）在旋转检测中非常重要：
+
+```kotlin
+// 四方向楼梯平台
+val stairPlatform = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            " WWW ",
+            "N   S",
+            "N 0 S",
+            "N   S",
+            " EEE "
+        )
+    ),
+    mapping = mapOf(
+        'N' to StringStateMatcher.parse("minecraft:oak_stairs[facing=south]"),
+        'S' to StringStateMatcher.parse("minecraft:oak_stairs[facing=north]"),
+        'W' to StringStateMatcher.parse("minecraft:oak_stairs[facing=east]"),
+        'E' to StringStateMatcher.parse("minecraft:oak_stairs[facing=west]"),
+    )
+)
+```
+
+### 包含流体的结构
+
+流体方块和含水方块同样可以作为匹配条件：
+
+```kotlin
+val fluidStructure = DenseMultiblock(
+    pattern = arrayOf(
+        arrayOf(
+            "GG   GG",
+            " LLLLLG",
+            "GGGGGGG",
+            " WW0WWG",
+            "GGGGGGG",
+            " SSSSSG",
+            "GG   GG"
+        )
+    ),
+    mapping = mapOf(
+        ' ' to StateMatcher.ANY,
+        '0' to StringStateMatcher.parse("minecraft:lapis_block"),
+        'G' to StringStateMatcher.parse("minecraft:bricks"),
+        'W' to StringStateMatcher.parse("minecraft:water"),
+        'L' to StringStateMatcher.parse("minecraft:lava"),
+        'S' to StringStateMatcher.parse("minecraft:brick_slab[type=bottom,waterlogged=true]"),
+    )
+)
+```
+
+---
+
+## 稀疏型（SparseMultiblock）
+
+稀疏型使用坐标到匹配器的映射定义结构，只需列出有方块的位置。适合大型但方块稀疏的结构（如四角立柱、大型框架等）——不需要定义大量的空气/任意方块。
+
+### 基础用法
+
+```kotlin
+// 十字形结构
+val cross = SparseMultiblock(
+    blocks = mapOf(
+        BlockPos(0, 0, 0) to StringStateMatcher.parse("minecraft:diamond_block"),
+        BlockPos(1, 0, 0) to StringStateMatcher.parse("minecraft:iron_block"),
+        BlockPos(-1, 0, 0) to StringStateMatcher.parse("minecraft:iron_block"),
+        BlockPos(0, 0, 1) to StringStateMatcher.parse("minecraft:iron_block"),
+        BlockPos(0, 0, -1) to StringStateMatcher.parse("minecraft:iron_block"),
+    )
+)
+```
+
+### 坐标说明
+
+- 所有位置**相对于锚点 `(0, 0, 0)`**
+- 锚点就是验证时传入的 `anchor` 位置
+- 未定义的位置**不参与验证**（等效于 `ANY`）
+- 如果需要某个位置必须为空气，显式添加 `BlockPos(...) to StateMatcher.AIR`
+
+### 大型稀疏结构示例
+
+```kotlin
+// 四角立柱（10x4x10 的空间中只有 4 根柱子 + 中心标记）
+val fourPillars = SparseMultiblock(
+    blocks = buildMap {
+        val pillarBlock = StringStateMatcher.parse("minecraft:stone_bricks")
+        // 四个角的 3 格高立柱
+        for (x in listOf(-5, 5)) {
+            for (z in listOf(-5, 5)) {
+                for (y in 0..2) {
+                    put(BlockPos(x, y, z), pillarBlock)
+                }
+            }
+        }
+        // 立柱顶部的雕花石砖
+        val capBlock = StringStateMatcher.parse("minecraft:chiseled_stone_bricks")
+        for (x in listOf(-5, 5)) {
+            for (z in listOf(-5, 5)) {
+                put(BlockPos(x, 3, z), capBlock)
+            }
+        }
+        // 中心锚点
+        put(BlockPos(0, 0, 0), StringStateMatcher.parse("minecraft:diamond_block"))
+    }
+)
+```
+
+> 如果用 DenseMultiblock 定义同样的结构，需要填写 11x4x11 = 484 个字符，其中绝大多数是空格。稀疏型只需定义 21 个有效位置。
+
+### 密集型 vs 稀疏型对比
+
+| 特性 | DenseMultiblock | SparseMultiblock |
+|------|----------------|-----------------|
+| 定义方式 | 字符图案 `String[][]` | 坐标映射 `Map<BlockPos, IStateMatcher>` |
+| 锚点 | `'0'` 字符位置 | 默认 `(0,0,0)` |
+| 空气检测 | 空格字符自动检测空气 | 需显式指定 `StateMatcher.AIR` |
+| 未定义位置 | 不存在"未定义"（图案覆盖整个包围盒） | 未定义 = 不检测（ANY） |
+| 适合场景 | 紧凑、规则、方块密度高 | 大型、稀疏、不规则 |
+| 可读性 | 图案直观可视 | 坐标列表，适合程序生成 |
+
+---
+
+## 状态匹配器
+
+状态匹配器（`IStateMatcher`）定义了"某个位置应该是什么方块"的规则。
+
+### 内置匹配器
+
+| 匹配器 | 说明 |
+|--------|------|
+| `StateMatcher.ANY` | 匹配任意方块（包括空气），等效于不检测 |
+| `StateMatcher.AIR` | 仅匹配空气方块 |
+
+### 工厂方法
+
+```kotlin
+// 匹配指定材质（忽略方块状态属性）
+StateMatcher.fromMaterial(Material.STONE)
+
+// 精确匹配方块数据（包括状态属性）
+val data = Bukkit.createBlockData("minecraft:oak_stairs[facing=north,half=bottom]")
+StateMatcher.fromBlockData(data)
+
+// 自定义谓词
+StateMatcher.fromPredicate("iron_or_gold") { block ->
+    block.type == Material.IRON_BLOCK || block.type == Material.GOLD_BLOCK
+}
+
+// 仅用于显示（始终返回 true）
+StateMatcher.displayOnly("decorative")
+```
+
+### 字符串解析匹配器
+
+`StringStateMatcher.parse()` 支持三种格式：
+
+| 格式 | 示例 | 说明 |
+|------|------|------|
+| 材质名 | `minecraft:stone` | 匹配材质，忽略状态属性 |
+| 方块数据 | `minecraft:oak_stairs[facing=north,half=bottom]` | 精确匹配，包含状态属性 |
+| 方块标签 | `#minecraft:wool` | 匹配标签中的所有方块（如所有颜色的羊毛） |
+
+```kotlin
+StringStateMatcher.parse("minecraft:stone")
+StringStateMatcher.parse("minecraft:oak_stairs[facing=north]")
+StringStateMatcher.parse("#minecraft:planks")   // 所有木板
+StringStateMatcher.parse("#minecraft:logs")     // 所有原木
+```
+
+### 自定义匹配器
+
+实现 `IStateMatcher` 接口：
+
+```kotlin
+class LightLevelMatcher(private val minLight: Int) : IStateMatcher {
+    override val displayName = "light>=$minLight"
+    override fun test(block: Block): Boolean {
+        return block.lightLevel >= minLight
+    }
+}
+```
+
+---
+
+## 验证结构
+
+### 自动旋转验证
+
+`validate(world, anchor)` 对非对称结构自动尝试 4 个旋转方向，返回第一个匹配的旋转：
+
+```kotlin
+val anchor = BlockPos(block.x, block.y, block.z)
+
+val rotation = multiblock.validate(world, anchor)
+if (rotation != null) {
+    // 结构匹配！rotation 为匹配时的旋转方向
+}
+```
+
+### 指定旋转验证
+
+```kotlin
+val matched = multiblock.validate(world, anchor, MultiblockRotation.NONE)
+```
+
+### 单方块测试
+
+```kotlin
+val blockOk = multiblock.test(world, anchor, 1, 0, 0, MultiblockRotation.NONE)
+```
+
+### 旋转方向
+
+| 枚举值 | 角度 | 坐标变换 `(x, y, z)` → |
+|--------|------|------------------------|
+| `NONE` | 0° | `(x, y, z)` |
+| `CLOCKWISE_90` | 顺时针 90° | `(-z, y, x)` |
+| `CLOCKWISE_180` | 180° | `(-x, y, -z)` |
+| `COUNTERCLOCKWISE_90` | 逆时针 90° | `(z, y, -x)` |
+
+旋转围绕 Y 轴进行（水平旋转），Y 坐标不变。
+
+### 对称优化
+
+如果结构在水平面上关于中心轴对称（如正方形平台），设置 `symmetrical = true` 可跳过多余的旋转检查：
+
+```kotlin
+multiblock.symmetrical = true
+// 验证时只检查 1 个旋转，性能提升约 4 倍
+```
+
+---
+
+## 模拟
+
+`simulate()` 返回结构中所有方块的世界坐标和匹配器，**不访问世界**——纯坐标计算。
+
+```kotlin
+val results = multiblock.simulate(anchor, MultiblockRotation.NONE)
+for (result in results) {
+    val pos = result.worldPosition       // 世界坐标
+    val matcher = result.stateMatcher    // 匹配器
+    val char = result.character          // 图案字符（仅 Dense 有值）
+}
+```
+
+**用途：**
+- **预览高亮** — 在世界中高亮显示结构方块位置
+- **进度检测** — 逐个检查哪些方块已放置、哪些缺失
+- **放置引导** — 提示玩家每个位置需要什么方块
+
+> 注意：`StateMatcher.ANY` 匹配器在 simulate 中会被跳过（不产生 SimulateResult），因为"任意方块"不需要检测。
+
+---
+
+## 注册与管理
+
+使用 `MultiblockRegistry` 进行全局注册，建议使用 `命名空间:名称` 格式的 ID：
+
+```kotlin
+// 注册
+MultiblockRegistry.register("my_plugin:altar", altar)
+
+// 获取
+val mb = MultiblockRegistry.get("my_plugin:altar")
+
+// 移除
+MultiblockRegistry.unregister("my_plugin:altar")
+
+// 获取所有
+val all = MultiblockRegistry.getAll()
+
+// 清空
+MultiblockRegistry.clear()
+```
+
+---
+
+## 完整示例
+
+### 示例 1：多方块熔炉
+
+```kotlin
+import taboolib.module.multiblocks.*
+
+// 定义 3x3x3 多方块熔炉（中心镂空，底部实心）
+val blastFurnace = DenseMultiblock(
+    pattern = arrayOf(
+        // 顶层
+        arrayOf(
+            "BBB",
+            "B B",
+            "BBB"
+        ),
+        // 中间层（包含锚点）
+        arrayOf(
+            "BBB",
+            "B0B",
+            "BBB"
+        ),
+        // 底层
+        arrayOf(
+            "BBB",
+            "BBB",
+            "BBB"
+        )
+    ),
+    mapping = mapOf(
+        'B' to StringStateMatcher.parse("minecraft:bricks")
+    )
+)
+
+MultiblockRegistry.register("my_plugin:blast_furnace", blastFurnace)
+```
+
+### 示例 2：监听玩家交互检测结构
+
+```kotlin
+@SubscribeEvent
+fun onInteract(e: PlayerInteractEvent) {
+    if (e.action != Action.RIGHT_CLICK_BLOCK) return
+    val block = e.clickedBlock ?: return
+    val anchor = BlockPos(block.x, block.y, block.z)
+
+    for ((id, multiblock) in MultiblockRegistry.getAll()) {
+        val rotation = multiblock.validate(block.world, anchor)
+        if (rotation != null) {
+            e.player.sendMessage("检测到结构: $id (旋转: $rotation)")
+            // 获取所有方块位置
+            val results = multiblock.simulate(anchor, rotation)
+            // ... 进一步处理
+            return
+        }
+    }
+}
+```
+
+### 示例 3：进度检测（显示缺失方块）
+
+```kotlin
+fun checkProgress(world: World, multiblock: IMultiblock, anchor: BlockPos, rotation: MultiblockRotation) {
+    val results = multiblock.simulate(anchor, rotation)
+    var completed = 0
+    val missing = mutableListOf<SimulateResult>()
+
+    for (result in results) {
+        val pos = result.worldPosition
+        val block = world.getBlockAt(pos.x, pos.y, pos.z)
+        if (result.stateMatcher.test(block)) {
+            completed++
+        } else {
+            missing.add(result)
+        }
+    }
+
+    println("进度: $completed/${results.size}")
+    for (m in missing) {
+        println("  缺失: ${m.worldPosition} 需要 ${m.stateMatcher.displayName}")
+    }
+}
+```
+
+---
+
+## API 参考
+
+### 核心类一览
+
+| 类 | 说明 |
+|---|---|
+| `IMultiblock` | 多方块结构核心接口 |
+| `IStateMatcher` | 方块状态匹配器接口 |
+| `AbstractMultiblock` | 抽象基类，实现旋转验证逻辑 |
+| `DenseMultiblock` | 密集型实现（字符图案） |
+| `SparseMultiblock` | 稀疏型实现（坐标映射） |
+| `StateMatcher` | 内置匹配器工厂（ANY / AIR / fromMaterial / fromBlockData / fromPredicate） |
+| `StringStateMatcher` | 字符串解析匹配器（材质名 / 方块属性 / 标签） |
+| `MultiblockRegistry` | 全局注册表 |
+| `BlockPos` | 整数坐标，支持旋转和加减运算 |
+| `MultiblockRotation` | 旋转方向枚举（4 方向） |
+
+### IMultiblock 接口方法
+
+| 方法 | 返回值 | 说明 |
+|------|--------|------|
+| `validate(world, anchor)` | `MultiblockRotation?` | 自动旋转验证，返回匹配的旋转方向或 `null` |
+| `validate(world, anchor, rotation)` | `Boolean` | 指定旋转方向验证 |
+| `simulate(anchor, rotation)` | `List<SimulateResult>` | 模拟结构，返回所有方块位置和匹配器 |
+| `test(world, anchor, x, y, z, rotation)` | `Boolean` | 测试单个方块是否匹配 |
+| `offset(x, y, z)` | `IMultiblock` | 设置锚点偏移（链式调用） |
+
+### SimulateResult 字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `worldPosition` | `BlockPos` | 方块在世界中的实际坐标 |
+| `stateMatcher` | `IStateMatcher` | 该位置的匹配规则 |
+| `character` | `Char?` | 图案中对应的字符（仅 DenseMultiblock 有值） |

--- a/module/minecraft/minecraft-multiblocks/build.gradle.kts
+++ b/module/minecraft/minecraft-multiblocks/build.gradle.kts
@@ -1,0 +1,8 @@
+dependencies {
+    compileOnly(project(":common"))
+    compileOnly(project(":common-util"))
+    compileOnly(project(":common-platform-api"))
+    compileOnly(project(":platform:platform-bukkit"))
+    // Bukkit API
+    compileOnly("ink.ptms.core:v12101:12101-minimize:universal")
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/AbstractMultiblock.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/AbstractMultiblock.kt
@@ -1,0 +1,62 @@
+package taboolib.module.multiblocks
+
+import org.bukkit.World
+
+/**
+ * 多方块结构的抽象基类
+ *
+ * 实现通用的验证逻辑和旋转检测。
+ * 子类只需实现 [simulate] 和 [size] 即可。
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+abstract class AbstractMultiblock : IMultiblock {
+
+    override var id: String = ""
+    override var symmetrical: Boolean = false
+
+    /** '0' 锚点在图案中的坐标 */
+    protected var offX: Int = 0
+    protected var offY: Int = 0
+    protected var offZ: Int = 0
+
+    override fun offset(x: Int, y: Int, z: Int): IMultiblock {
+        offX = x
+        offY = y
+        offZ = z
+        return this
+    }
+
+    override fun validate(world: World, anchor: BlockPos): MultiblockRotation? {
+        val rotations = if (symmetrical) listOf(MultiblockRotation.NONE) else MultiblockRotation.ALL
+        for (rotation in rotations) {
+            if (validate(world, anchor, rotation)) {
+                return rotation
+            }
+        }
+        return null
+    }
+
+    override fun validate(world: World, anchor: BlockPos, rotation: MultiblockRotation): Boolean {
+        val results = simulate(anchor, rotation)
+        for (result in results) {
+            val pos = result.worldPosition
+            val block = world.getBlockAt(pos.x, pos.y, pos.z)
+            if (!result.stateMatcher.test(block)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    override fun test(world: World, anchor: BlockPos, x: Int, y: Int, z: Int, rotation: MultiblockRotation): Boolean {
+        val relativePos = BlockPos(x - offX, y - offY, z - offZ)
+        val rotatedPos = relativePos.rotate(rotation)
+        val worldPos = anchor + rotatedPos
+        val results = simulate(anchor, rotation)
+        val result = results.find { it.worldPosition == worldPos } ?: return true
+        val block = world.getBlockAt(worldPos.x, worldPos.y, worldPos.z)
+        return result.stateMatcher.test(block)
+    }
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/BlockPos.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/BlockPos.kt
@@ -1,0 +1,31 @@
+package taboolib.module.multiblocks
+
+/**
+ * 简单的整数坐标，用于表示多方块结构中的相对位置
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+data class BlockPos(val x: Int, val y: Int, val z: Int) {
+
+    operator fun plus(other: BlockPos) = BlockPos(x + other.x, y + other.y, z + other.z)
+
+    operator fun minus(other: BlockPos) = BlockPos(x - other.x, y - other.y, z - other.z)
+
+    /**
+     * 绕 Y 轴旋转该坐标
+     */
+    fun rotate(rotation: MultiblockRotation): BlockPos {
+        return when (rotation) {
+            MultiblockRotation.NONE -> this
+            MultiblockRotation.CLOCKWISE_90 -> BlockPos(-z, y, x)
+            MultiblockRotation.CLOCKWISE_180 -> BlockPos(-x, y, -z)
+            MultiblockRotation.COUNTERCLOCKWISE_90 -> BlockPos(z, y, -x)
+        }
+    }
+
+    companion object {
+
+        val ZERO = BlockPos(0, 0, 0)
+    }
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/DenseMultiblock.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/DenseMultiblock.kt
@@ -1,0 +1,134 @@
+package taboolib.module.multiblocks
+
+/**
+ * 密集型多方块结构
+ *
+ * 使用二维字符串数组定义结构图案，每个字符映射到一个 [IStateMatcher]。
+ * 适用于紧凑的、方块密度较高的结构。
+ *
+ * ## 图案格式
+ *
+ * ```kotlin
+ * val multiblock = DenseMultiblock(
+ *     pattern = arrayOf(
+ *         // 第一个数组 = 最顶层（最高 Y）
+ *         arrayOf(
+ *             "   ",
+ *             " S ",
+ *             "   "
+ *         ),
+ *         // 最后一个数组 = 最底层（最低 Y）
+ *         arrayOf(
+ *             "SSS",
+ *             "S0S",
+ *             "SSS"
+ *         )
+ *     ),
+ *     mapping = mapOf(
+ *         'S' to StringStateMatcher.parse("minecraft:stone")
+ *     )
+ * )
+ * ```
+ *
+ * ## 特殊字符
+ * - `0` — 中心锚点（默认映射为空气，可在 mapping 中覆盖）
+ * - `_` — 匹配任意方块
+ * - ` ` (空格) — 空气
+ *
+ * @param pattern 结构图案，外层数组为 Y 层（从上到下），内层数组为 Z 行，字符串中的字符为 X 列
+ * @param mapping 字符到状态匹配器的映射
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+class DenseMultiblock(
+    pattern: Array<Array<String>>,
+    mapping: Map<Char, IStateMatcher> = emptyMap()
+) : AbstractMultiblock() {
+
+    private val stateTargets: Array<Array<Array<IStateMatcher>>>
+    private val charMap: Array<Array<CharArray>>
+    override val size: BlockPos
+
+    init {
+        // 合并默认映射
+        val fullMapping = HashMap<Char, IStateMatcher>().apply {
+            put('_', StateMatcher.ANY)
+            put(' ', StateMatcher.AIR)
+            put('0', StateMatcher.AIR)
+            putAll(mapping)
+        }
+
+        // 解析图案尺寸
+        val sizeY = pattern.size
+        val sizeZ = if (pattern.isNotEmpty()) pattern[0].size else 0
+        val sizeX = if (sizeZ > 0) pattern[0][0].length else 0
+        size = BlockPos(sizeX, sizeY, sizeZ)
+
+        // 构建状态匹配器和字符的三维数组
+        // pattern[0] = 最顶层, pattern[last] = 最底层
+        // 实际 Y 坐标: actualY = sizeY - 1 - patternIndex
+        stateTargets = Array(sizeY) { actualY ->
+            val patternIndex = sizeY - 1 - actualY
+            val layer = pattern.getOrNull(patternIndex) ?: emptyArray()
+            Array(sizeZ) { z ->
+                val row = layer.getOrNull(z) ?: ""
+                Array(sizeX) { x ->
+                    val ch = row.getOrNull(x) ?: ' '
+                    fullMapping[ch] ?: StateMatcher.AIR
+                }
+            }
+        }
+        charMap = Array(sizeY) { actualY ->
+            val patternIndex = sizeY - 1 - actualY
+            val layer = pattern.getOrNull(patternIndex) ?: emptyArray()
+            Array(sizeZ) { z ->
+                val row = layer.getOrNull(z) ?: ""
+                CharArray(sizeX) { x -> row.getOrNull(x) ?: ' ' }
+            }
+        }
+
+        // 查找中心锚点 '0' 并设置偏移
+        var found = false
+        for (patternIndex in pattern.indices) {
+            val actualY = sizeY - 1 - patternIndex
+            val layer = pattern[patternIndex]
+            for (z in layer.indices) {
+                val row = layer[z]
+                for (x in row.indices) {
+                    if (row[x] == '0') {
+                        offX = x
+                        offY = actualY
+                        offZ = z
+                        found = true
+                    }
+                }
+            }
+        }
+        if (!found) {
+            offX = 0
+            offY = 0
+            offZ = 0
+        }
+    }
+
+    override fun simulate(anchor: BlockPos, rotation: MultiblockRotation): List<SimulateResult> {
+        val results = mutableListOf<SimulateResult>()
+        for (y in 0 until size.y) {
+            for (z in 0 until size.z) {
+                for (x in 0 until size.x) {
+                    val matcher = stateTargets[y][z][x]
+                    // 跳过 ANY 匹配器（任意方块都满足，无需检测）
+                    if (matcher === StateMatcher.ANY) continue
+                    val ch = charMap[y][z][x]
+                    // 计算相对于锚点的位置
+                    val relativePos = BlockPos(x - offX, y - offY, z - offZ)
+                    val rotatedPos = relativePos.rotate(rotation)
+                    val worldPos = anchor + rotatedPos
+                    results.add(SimulateResult(worldPos, matcher, ch))
+                }
+            }
+        }
+        return results
+    }
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/IMultiblock.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/IMultiblock.kt
@@ -1,0 +1,82 @@
+package taboolib.module.multiblocks
+
+import org.bukkit.World
+
+/**
+ * 多方块结构接口
+ *
+ * 定义了多方块的核心行为：验证、模拟、放置等。
+ * 参考 Patchouli 的 IMultiblock 设计，适配 TabooLib/Bukkit 生态。
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+interface IMultiblock {
+
+    /** 结构标识符 */
+    var id: String
+
+    /** 是否对称（对称结构只检查一个旋转方向，提升性能） */
+    var symmetrical: Boolean
+
+    /** 结构的尺寸 */
+    val size: BlockPos
+
+    /**
+     * 设置结构相对于锚点的偏移
+     */
+    fun offset(x: Int, y: Int, z: Int): IMultiblock
+
+    /**
+     * 模拟结构，返回所有组成方块的世界坐标和匹配器
+     *
+     * @param anchor 锚点（'0' 标记位置）在世界中的坐标
+     * @param rotation 旋转方向
+     * @return 结构中每个方块的模拟结果
+     */
+    fun simulate(anchor: BlockPos, rotation: MultiblockRotation): List<SimulateResult>
+
+    /**
+     * 验证世界中指定位置是否存在该结构（自动尝试所有旋转方向）
+     *
+     * @param world 世界
+     * @param anchor 锚点坐标
+     * @return 匹配的旋转方向，若不匹配返回 null
+     */
+    fun validate(world: World, anchor: BlockPos): MultiblockRotation?
+
+    /**
+     * 验证世界中指定位置、指定旋转方向是否存在该结构
+     *
+     * @param world 世界
+     * @param anchor 锚点坐标
+     * @param rotation 旋转方向
+     * @return 是否匹配
+     */
+    fun validate(world: World, anchor: BlockPos, rotation: MultiblockRotation): Boolean
+
+    /**
+     * 测试结构中某个相对位置的方块是否匹配
+     *
+     * @param world 世界
+     * @param anchor 锚点坐标
+     * @param x 结构内 X 坐标
+     * @param y 结构内 Y 坐标
+     * @param z 结构内 Z 坐标
+     * @param rotation 旋转方向
+     * @return 是否匹配
+     */
+    fun test(world: World, anchor: BlockPos, x: Int, y: Int, z: Int, rotation: MultiblockRotation): Boolean
+}
+
+/**
+ * 模拟结果，表示多方块中的一个组成方块
+ */
+data class SimulateResult(
+    /** 世界中的实际位置 */
+    val worldPosition: BlockPos,
+    /** 状态匹配器 */
+    val stateMatcher: IStateMatcher,
+    /** 在图案中对应的字符（仅 DenseMultiblock 有值） */
+    val character: Char? = null
+)

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/IStateMatcher.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/IStateMatcher.kt
@@ -1,0 +1,27 @@
+package taboolib.module.multiblocks
+
+import org.bukkit.block.Block
+
+/**
+ * 方块状态匹配器，用于判断世界中某个位置的方块是否符合预期
+ *
+ * 参考 Patchouli 的 IStateMatcher 设计，适配 Bukkit 平台。
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+interface IStateMatcher {
+
+    /**
+     * 用于显示的方块名称
+     */
+    val displayName: String
+
+    /**
+     * 测试给定的方块是否匹配
+     *
+     * @param block 世界中的方块
+     * @return 是否匹配
+     */
+    fun test(block: Block): Boolean
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/MultiblockRegistry.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/MultiblockRegistry.kt
@@ -1,0 +1,61 @@
+package taboolib.module.multiblocks
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * 多方块结构全局注册表
+ *
+ * 管理所有已注册的多方块结构定义。
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+object MultiblockRegistry {
+
+    private val multiblocks = ConcurrentHashMap<String, IMultiblock>()
+
+    /**
+     * 注册一个多方块结构
+     *
+     * @param id 结构唯一标识符
+     * @param multiblock 多方块结构实例
+     */
+    fun register(id: String, multiblock: IMultiblock) {
+        multiblock.id = id
+        multiblocks[id] = multiblock
+    }
+
+    /**
+     * 获取已注册的多方块结构
+     *
+     * @param id 结构标识符
+     * @return 多方块结构实例，未注册时返回 null
+     */
+    fun get(id: String): IMultiblock? {
+        return multiblocks[id]
+    }
+
+    /**
+     * 移除已注册的多方块结构
+     *
+     * @param id 结构标识符
+     * @return 被移除的多方块结构实例，未注册时返回 null
+     */
+    fun unregister(id: String): IMultiblock? {
+        return multiblocks.remove(id)
+    }
+
+    /**
+     * 获取所有已注册的多方块结构
+     */
+    fun getAll(): Map<String, IMultiblock> {
+        return multiblocks.toMap()
+    }
+
+    /**
+     * 清空注册表
+     */
+    fun clear() {
+        multiblocks.clear()
+    }
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/MultiblockRotation.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/MultiblockRotation.kt
@@ -1,0 +1,28 @@
+package taboolib.module.multiblocks
+
+/**
+ * 多方块结构的旋转方向（绕 Y 轴）
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+enum class MultiblockRotation {
+
+    /** 不旋转 */
+    NONE,
+
+    /** 顺时针 90°（俯视） */
+    CLOCKWISE_90,
+
+    /** 旋转 180° */
+    CLOCKWISE_180,
+
+    /** 逆时针 90°（俯视） */
+    COUNTERCLOCKWISE_90;
+
+    companion object {
+
+        /** 所有旋转方向 */
+        val ALL = values().toList()
+    }
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/SparseMultiblock.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/SparseMultiblock.kt
@@ -1,0 +1,68 @@
+package taboolib.module.multiblocks
+
+/**
+ * 稀疏型多方块结构
+ *
+ * 使用位置到匹配器的映射定义结构，适用于方块分布稀疏的大型结构。
+ * 所有位置均相对于锚点（0, 0, 0）。
+ *
+ * ## 示例
+ *
+ * ```kotlin
+ * val multiblock = SparseMultiblock(
+ *     blocks = mapOf(
+ *         BlockPos(1, 0, 0) to StringStateMatcher.parse("minecraft:stone"),
+ *         BlockPos(-1, 0, 0) to StringStateMatcher.parse("minecraft:stone"),
+ *         BlockPos(0, 0, 1) to StringStateMatcher.parse("minecraft:stone"),
+ *         BlockPos(0, 0, -1) to StringStateMatcher.parse("minecraft:stone"),
+ *         BlockPos(0, 1, 0) to StringStateMatcher.parse("minecraft:stone"),
+ *     )
+ * )
+ * ```
+ *
+ * @param blocks 相对位置到状态匹配器的映射，位置相对于锚点
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+class SparseMultiblock(
+    private val blocks: Map<BlockPos, IStateMatcher>
+) : AbstractMultiblock() {
+
+    override val size: BlockPos
+
+    init {
+        // 计算包围盒
+        if (blocks.isEmpty()) {
+            size = BlockPos.ZERO
+        } else {
+            var minX = Int.MAX_VALUE
+            var minY = Int.MAX_VALUE
+            var minZ = Int.MAX_VALUE
+            var maxX = Int.MIN_VALUE
+            var maxY = Int.MIN_VALUE
+            var maxZ = Int.MIN_VALUE
+            for (pos in blocks.keys) {
+                if (pos.x < minX) minX = pos.x
+                if (pos.y < minY) minY = pos.y
+                if (pos.z < minZ) minZ = pos.z
+                if (pos.x > maxX) maxX = pos.x
+                if (pos.y > maxY) maxY = pos.y
+                if (pos.z > maxZ) maxZ = pos.z
+            }
+            size = BlockPos(maxX - minX + 1, maxY - minY + 1, maxZ - minZ + 1)
+        }
+        // 稀疏型结构默认锚点在原点
+        offX = 0
+        offY = 0
+        offZ = 0
+    }
+
+    override fun simulate(anchor: BlockPos, rotation: MultiblockRotation): List<SimulateResult> {
+        return blocks.map { (relativePos, matcher) ->
+            val rotatedPos = relativePos.rotate(rotation)
+            val worldPos = anchor + rotatedPos
+            SimulateResult(worldPos, matcher)
+        }
+    }
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/StateMatcher.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/StateMatcher.kt
@@ -1,0 +1,89 @@
+package taboolib.module.multiblocks
+
+import org.bukkit.Material
+import org.bukkit.block.Block
+import org.bukkit.block.data.BlockData
+
+/**
+ * 内置的方块状态匹配器实现
+ *
+ * 提供常用的匹配器工厂方法和内置常量。
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+object StateMatcher {
+
+    /** 匹配任意方块（包括空气） */
+    val ANY: IStateMatcher = object : IStateMatcher {
+        override val displayName = "any"
+        override fun test(block: Block) = true
+    }
+
+    /** 仅匹配空气方块 */
+    val AIR: IStateMatcher = object : IStateMatcher {
+        override val displayName = "air"
+        override fun test(block: Block) = block.type.isAir
+    }
+
+    /**
+     * 匹配指定材质（忽略方块状态属性）
+     *
+     * @param material 目标材质
+     */
+    fun fromMaterial(material: Material): IStateMatcher {
+        return object : IStateMatcher {
+            override val displayName = material.key.toString()
+            override fun test(block: Block) = block.type == material
+        }
+    }
+
+    /**
+     * 精确匹配方块数据（包括状态属性）
+     *
+     * @param blockData 目标方块数据
+     */
+    fun fromBlockData(blockData: BlockData): IStateMatcher {
+        return object : IStateMatcher {
+            override val displayName = blockData.asString
+            override fun test(block: Block) = block.blockData.matches(blockData)
+        }
+    }
+
+    /**
+     * 宽松匹配方块数据（仅检查指定的状态属性，忽略未指定的属性）
+     *
+     * @param blockData 目标方块数据
+     */
+    fun fromBlockDataLoose(blockData: BlockData): IStateMatcher {
+        return object : IStateMatcher {
+            override val displayName = blockData.asString
+            override fun test(block: Block) = block.blockData.matches(blockData)
+        }
+    }
+
+    /**
+     * 自定义谓词匹配
+     *
+     * @param name 显示名称
+     * @param predicate 匹配谓词
+     */
+    fun fromPredicate(name: String, predicate: (Block) -> Boolean): IStateMatcher {
+        return object : IStateMatcher {
+            override val displayName = name
+            override fun test(block: Block) = predicate(block)
+        }
+    }
+
+    /**
+     * 仅用于显示，不进行实际验证（始终返回 true）
+     *
+     * @param name 显示名称
+     */
+    fun displayOnly(name: String): IStateMatcher {
+        return object : IStateMatcher {
+            override val displayName = name
+            override fun test(block: Block) = true
+        }
+    }
+}

--- a/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/StringStateMatcher.kt
+++ b/module/minecraft/minecraft-multiblocks/src/main/kotlin/taboolib/module/multiblocks/StringStateMatcher.kt
@@ -1,0 +1,88 @@
+package taboolib.module.multiblocks
+
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.Tag
+import org.bukkit.block.Block
+
+/**
+ * 字符串解析的状态匹配器
+ *
+ * 支持以下格式：
+ * - `minecraft:stone` — 匹配指定材质（忽略状态属性）
+ * - `minecraft:oak_stairs[facing=north,half=bottom]` — 精确匹配方块数据
+ * - `#minecraft:wool` — 标签匹配（以 # 开头，匹配标签中的所有方块）
+ *
+ * @author FxRayHughes
+ * @since 2026/3/30
+ */
+object StringStateMatcher {
+
+    /**
+     * 从字符串解析状态匹配器
+     *
+     * @param input 匹配器字符串
+     * @return 解析后的状态匹配器
+     * @throws IllegalArgumentException 无法解析时
+     */
+    fun parse(input: String): IStateMatcher {
+        val str = input.trim()
+        // 标签匹配
+        if (str.startsWith("#")) {
+            return TagMatcher(str.substring(1))
+        }
+        // 包含方块属性的精确匹配
+        if (str.contains("[")) {
+            return BlockDataMatcher(str)
+        }
+        // 简单材质匹配
+        return MaterialMatcher(str)
+    }
+
+    /**
+     * 材质匹配器
+     */
+    private class MaterialMatcher(val materialName: String) : IStateMatcher {
+
+        private val material: Material? by lazy {
+            Material.matchMaterial(materialName)
+        }
+
+        override val displayName: String get() = materialName
+
+        override fun test(block: Block): Boolean {
+            return material != null && block.type == material
+        }
+    }
+
+    /**
+     * 精确方块数据匹配器
+     */
+    private class BlockDataMatcher(val blockDataString: String) : IStateMatcher {
+
+        override val displayName: String get() = blockDataString
+
+        override fun test(block: Block): Boolean {
+            return try {
+                val expected = Bukkit.createBlockData(blockDataString)
+                block.blockData.matches(expected)
+            } catch (_: Exception) {
+                false
+            }
+        }
+    }
+
+    /**
+     * 标签匹配器（匹配方块标签中的所有方块）
+     */
+    private class TagMatcher(val tagName: String) : IStateMatcher {
+
+        override val displayName: String get() = "#$tagName"
+
+        override fun test(block: Block): Boolean {
+            return Bukkit.getTags(Tag.REGISTRY_BLOCKS, Material::class.java).any { tag ->
+                tag.key.toString() == tagName && tag.isTagged(block.type)
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,7 @@ include(
     "module:minecraft:minecraft-i18n",
     "module:minecraft:minecraft-kether",
     "module:minecraft:minecraft-metrics",
+    "module:minecraft:minecraft-multiblocks",
     "module:minecraft:minecraft-porticus",
 
     // 数据库工具


### PR DESCRIPTION
## Summary
- 新增 `minecraft-multiblocks` 模块，提供多方块结构定义与验证能力
- 参考 Patchouli 的 multiblock 设计，适配 TabooLib/Bukkit 生态
- 支持密集型（DenseMultiblock）和稀疏型（SparseMultiblock）两种结构定义方式

## 模块结构
| 类 | 说明 |
|---|---|
| `IMultiblock` | 多方块核心接口 |
| `IStateMatcher` | 方块状态匹配器接口 |
| `AbstractMultiblock` | 抽象基类（旋转验证逻辑） |
| `DenseMultiblock` | 密集型：字符图案定义结构 |
| `SparseMultiblock` | 稀疏型：坐标映射定义结构 |
| `StateMatcher` | 内置匹配器（ANY/AIR/材质/BlockData/谓词） |
| `StringStateMatcher` | 字符串解析匹配器（材质名/方块属性/标签） |
| `MultiblockRegistry` | 全局注册表 |
| `BlockPos` | 整数坐标（支持旋转） |
| `MultiblockRotation` | 旋转枚举（4方向） |

## 核心特性
- **两种定义方式**：密集型适用紧凑结构，稀疏型适用大型不规则结构
- **旋转检测**：非对称结构自动尝试 4 个旋转方向，对称结构优化为 1 个
- **灵活匹配**：支持材质匹配、精确 BlockData 匹配、方块标签匹配、自定义谓词
- **字符串解析**：支持 `minecraft:stone`、`minecraft:stairs[facing=north]`、`#minecraft:wool` 格式

## Test plan
- [x] `./gradlew :module:minecraft:minecraft-multiblocks:build` 构建通过