### PR TITLE
fix: PlayerFakeOp 兼容 Java 16+ 和 Paper 1.21.8+

### DIFF
--- a/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMS.kt
+++ b/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMS.kt
@@ -17,17 +17,30 @@ abstract class PlayerFakeOpNMS {
 
     /**
      * 获取 [player] 的 PlayerFakeOp 代理对象
-     * 
+     *
      * 此代理对象使得 isOp() hasPermission(String) hasPermission(Permission) 三个方法均返回 true
-     * 
+     *
      * @param player 原 CraftPlayer 对象
      * @return [player] 的 PlayerFakeOp 代理对象
      */
     abstract fun playerFakeOp(player: Player): Player
-    
+
+    /**
+     * 以 OP 权限执行指令
+     *
+     * 通过 NMS 创建带 OP 权限等级的 CommandSourceStack 直接在 Brigadier 层派发命令，
+     * 不修改玩家真实 OP 状态，兼容 Paper 1.21.8+ 的 Brigadier 命令系统。
+     * 1.12 及以下自动回退到 Bukkit.dispatchCommand(fakeOp(), cmd)。
+     *
+     * @param player 执行指令的玩家
+     * @param command 指令内容（不含前缀 /）
+     * @return 是否执行成功
+     */
+    abstract fun dispatchCommandAsOp(player: Player, command: String): Boolean
+
     companion object {
 
-        val INSTANCE by unsafeLazy { 
+        val INSTANCE by unsafeLazy {
             nmsProxy<PlayerFakeOpNMS>()
         }
     }

--- a/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMSImpl.kt
+++ b/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMSImpl.kt
@@ -14,11 +14,14 @@ import net.bytebuddy.matcher.ElementMatchers
 import net.minecraft.server.level.EntityPlayer
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer
+import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.permissions.Permission
 import taboolib.common.util.unsafeLazy
 import taboolib.module.nms.nmsClass
 import java.lang.reflect.Constructor
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 
 class PlayerFakeOpNMSImpl : PlayerFakeOpNMS() {
 
@@ -27,6 +30,121 @@ class PlayerFakeOpNMSImpl : PlayerFakeOpNMS() {
     override fun playerFakeOp(player: Player): Player {
         return playerFakeOpUtil.createProxy(player as CraftPlayer)
     }
+
+    override fun dispatchCommandAsOp(player: Player, command: String): Boolean {
+        val craftPlayer = player as CraftPlayer
+        // 尝试 NMS 派发（1.13+ Brigadier 环境）
+        val h = getOrCreateDispatchHelper(craftPlayer)
+        if (h != null) {
+            val entityPlayer = craftPlayer.handle
+            val fakeOpPlayer = playerFakeOpUtil.createProxy(craftPlayer)
+            // CommandSourceStack + ALL_PERMISSIONS（NMS 层权限）
+            val css = h.createCommandSourceStack.invoke(entityPlayer)
+            val opCss = h.withPermission.invoke(css, h.permissionArg)
+            // 替换 CommandSource，使 getBukkitSender() 返回 FakeOp 代理（Bukkit 层权限）
+            val proxySource = Proxy.newProxyInstance(h.commandSourceClass.classLoader, arrayOf(h.commandSourceClass)) { _, method, args ->
+                if (method.name == "getBukkitSender") fakeOpPlayer else method.invoke(entityPlayer, *(args ?: emptyArray()))
+            }
+            val finalCss = h.withSource.invoke(opCss, proxySource)
+            // NMS 同步派发
+            val commands = h.getCommands.invoke(h.getServer.invoke(craftPlayer.server))
+            h.dispatchCommand.invoke(commands, finalCss, command)
+            return true
+        }
+        // 回退：无 Brigadier 的旧版本（1.12 及以下），直接用 FakeOp 代理派发
+        return Bukkit.dispatchCommand(playerFakeOpUtil.createProxy(craftPlayer), command)
+    }
+
+    private fun getOrCreateDispatchHelper(craftPlayer: CraftPlayer): DispatchHelper? {
+        val cached = dispatchHelper
+        if (cached === UNAVAILABLE) return null
+        if (cached is DispatchHelper) return cached
+        return try {
+            DispatchHelper.create(craftPlayer.handle, craftPlayer.server as CraftServer).also { dispatchHelper = it }
+        } catch (e: Throwable) {
+            e.printStackTrace()
+            dispatchHelper = UNAVAILABLE
+            null
+        }
+    }
+
+    companion object {
+        private object UNINITIALIZED
+        private object UNAVAILABLE
+
+        @Volatile
+        private var dispatchHelper: Any? = UNINITIALIZED
+    }
+
+    /**
+     * 缓存 NMS 命令派发所需的反射引用。
+     * 方法名优先 + 签名回退，兼容 Spigot 1.13+ / Paper 1.20.6+ / Paper 1.21.8+。
+     */
+    class DispatchHelper(
+        val createCommandSourceStack: Method,
+        val withPermission: Method,
+        val permissionArg: Any,
+        val withSource: Method,
+        val commandSourceClass: Class<*>,
+        val getServer: Method,
+        val getCommands: Method,
+        val dispatchCommand: Method,
+    ) {
+        companion object {
+
+            fun create(entityPlayer: Any, craftServer: CraftServer): DispatchHelper {
+                val epClass = entityPlayer.javaClass
+                val createCSS = find(epClass, "createCommandSourceStack") { it.parameterCount == 0 && !it.returnType.isPrimitive }
+                val cssClass = createCSS.returnType
+
+                // withPermission：int（1.13~1.21.7）或 PermissionSet（1.21.8+）
+                val withPermInt = cssClass.methods.firstOrNull { m ->
+                    m.name == "withPermission" && m.parameterCount == 1 && m.parameterTypes[0] == Integer.TYPE && m.returnType == cssClass
+                }
+                val withPerm: Method
+                val permArg: Any
+                if (withPermInt != null) {
+                    withPerm = withPermInt
+                    permArg = 4
+                } else {
+                    withPerm = cssClass.methods.first { m ->
+                        m.name == "withPermission" && m.parameterCount == 1 && m.returnType == cssClass
+                    }
+                    permArg = withPerm.parameterTypes[0].getField("ALL_PERMISSIONS").get(null)!!
+                }
+
+                // withSource(CommandSource)
+                val withSource = find(cssClass, "withSource") { it.parameterCount == 1 && it.returnType == cssClass && it.parameterTypes[0].isInterface }
+
+                // CraftServer.getServer() → MinecraftServer
+                val getServer = craftServer.javaClass.getMethod("getServer")
+                val mcServer = getServer.invoke(craftServer)!!
+
+                // getCommands()
+                val getCommands = find(mcServer.javaClass, "getCommands", "vanillaCommandDispatcher") { it.parameterCount == 0 && !it.returnType.isPrimitive }
+
+                // performPrefixedCommand / performCommand
+                val dispatch = find(getCommands.returnType, "performPrefixedCommand", "performCommand") {
+                    it.parameterCount == 2 && it.parameterTypes[0] == cssClass && it.parameterTypes[1] == String::class.java
+                }
+
+                return DispatchHelper(createCSS, withPerm, permArg, withSource, withSource.parameterTypes[0], getServer, getCommands, dispatch)
+            }
+
+            /** 按名称优先查找，回退到签名匹配 */
+            private fun find(clazz: Class<*>, vararg names: String, predicate: (Method) -> Boolean): Method {
+                for (name in names) {
+                    clazz.methods.firstOrNull { it.name == name && predicate(it) }?.let { return it }
+                }
+                return clazz.methods.firstOrNull(predicate)
+                    ?: error("Cannot find method [${names.joinToString()}] in ${clazz.name}")
+            }
+        }
+    }
+
+    // ============================================================
+    // FakeOp CraftPlayer 代理（ByteBuddy 生成）
+    // ============================================================
 
     class PlayerFakeOpUtil {
 
@@ -69,8 +187,8 @@ class PlayerFakeOpNMSImpl : PlayerFakeOpNMS() {
                 .method(ElementMatchers.named("isOp"))
                 .intercept(FixedValue.value(true))
                 .make()
-            // Load the new class by injecting it into the given ClassLoader by reflective access
-            playerFakeOpClass = dynamicType.load(javaClass.classLoader, ClassLoadingStrategy.Default.INJECTION).loaded
+            // CHILD_FIRST: avoid Java 16+ module restrictions (INJECTION) and AsmClassLoader interference (WRAPPER)
+            playerFakeOpClass = dynamicType.load(javaClass.classLoader, ClassLoadingStrategy.Default.CHILD_FIRST).loaded
             playerFakeOpConstructor = playerFakeOpClass.getConstructor(CraftServer::class.java, entityPlayerClass, CraftPlayer::class.java)
         }
 

--- a/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpUtils.kt
+++ b/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpUtils.kt
@@ -1,13 +1,12 @@
 package taboolib.expansion
 
-import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 
 /**
  * 获取 [this] 的 PlayerFakeOp 代理对象
- * 
+ *
  * 此代理对象使得 isOp() hasPermission(String) hasPermission(Permission) 三个方法均返回 true
- * 
+ *
  * @receiver 原 CraftPlayer 对象
  * @return [this] 的 PlayerFakeOp 代理对象
  */
@@ -16,8 +15,12 @@ fun Player.fakeOp(): Player {
 }
 
 /**
- * 以OP的权限执行指令 (仅针对非原版指令)
+ * 以 OP 权限执行指令
+ *
+ * 通过 NMS 直接在 Brigadier 层同步派发命令，不修改玩家真实 OP 状态：
+ * - NMS 层：CommandSourceStack 使用 ALL_PERMISSIONS（处理原版命令权限检查）
+ * - Bukkit 层：替换 CommandSource 使 getBukkitSender() 返回 FakeOp 代理（处理插件命令权限检查）
  */
 fun Player.dispatchCommandAsOp(command: String): Boolean {
-    return Bukkit.dispatchCommand(fakeOp(), command)
+    return PlayerFakeOpNMS.INSTANCE.dispatchCommandAsOp(this, command)
 }


### PR DESCRIPTION
- ByteBuddy 类加载策略从 INJECTION 改为 CHILD_FIRST，解决：
  1. Java 16+ 模块系统阻止反射注入
  2. WRAPPER 策略下 AsmClassLoader parent-first 委派干扰

- dispatchCommandAsOp 新增 NMS CommandSourceStack 派发路径（1.13+）：
  - withPermission(ALL_PERMISSIONS) 处理原版命令权限
  - withSource(proxy) 替换 CommandSource，使 getBukkitSender() 返回 FakeOp 代理处理插件命令权限
  - NMS 同步执行，绕过 Paper 1.21.8+ 命令队列化问题
  - 不修改玩家真实 OP 状态

- 1.12 及以下自动回退到旧方案 Bukkit.dispatchCommand(fakeOp(), cmd)