### PR TITLE
fix(incision): suppress non-error logs outside debug mode

### DIFF
--- a/module/incision/src/main/kotlin/taboolib/module/incision/diagnostic/Forensics.kt
+++ b/module/incision/src/main/kotlin/taboolib/module/incision/diagnostic/Forensics.kt
@@ -1,31 +1,32 @@
 package taboolib.module.incision.diagnostic
 
+import taboolib.common.PrimitiveSettings
+import taboolib.common.platform.function.warning
+
 /**
  * 结构化诊断日志器。
  *
  * 所有 incision 内部日志都走该入口，固定字段格式便于 grep:
  * `[Incision][<Phase>] id=... target=... resolver=... result=... took=...ms`
  *
- * 当前为最小实现 — 直接 println；后续接入 TabooLib `info/warning/severe`。
+ * 非错误输出仅在 TabooLib debug 模式下可见。
  */
 object Forensics {
 
-    /** 是否开启调试输出 — 通过 JVM 参数 -Dtaboolib.incision.debug=true 或环境变量 INCISION_DEBUG=1 启用 */
-    val DEBUG: Boolean by lazy {
-        System.getProperty("taboolib.incision.debug")?.equals("true", true) == true
-                || System.getenv("INCISION_DEBUG") == "1"
-    }
+    /** 是否开启调试输出 — 跟随 TabooLib 的 PrimitiveSettings debug 开关。 */
+    val DEBUG: Boolean
+        get() = PrimitiveSettings.IS_DEBUG_MODE
 
     fun info(message: String) {
-        println("[Incision] $message")
+        if (DEBUG) taboolib.common.platform.function.info("[Incision] $message")
     }
 
     fun debug(message: String) {
-        if (DEBUG) println("[Incision][DEBUG] $message")
+        if (DEBUG) taboolib.common.platform.function.debug("[Incision][DEBUG] $message")
     }
 
     fun warn(message: String) {
-        println("[Incision][WARN] $message")
+        if (DEBUG) warning("[Incision][WARN] $message")
     }
 
     fun error(message: String, cause: Throwable? = null) {


### PR DESCRIPTION
## Summary
- gate incision diagnostic info and warn output behind the TabooLib debug flag
- make Forensics.DEBUG follow PrimitiveSettings.IS_DEBUG_MODE
- keep rror and trauma reporting visible so only actual errors print in non-debug mode

## Verification
- ./gradlew.bat :module:incision:compileKotlin