### PR TITLE
fix(common-env): 修复多插件不同协程版本导致 NoClassDefFoundError

### DIFF
--- a/common-env/src/main/java/taboolib/common/env/aether/AetherResolver.java
+++ b/common-env/src/main/java/taboolib/common/env/aether/AetherResolver.java
@@ -119,8 +119,11 @@ public class AetherResolver {
     public static @Nullable ClassLoader inject(@NotNull File file, @Nullable List<JarRelocation> relocation, boolean isExternal) throws Throwable {
         // 文件路径: group/name/version/file
         // 两次获取父文件跳到 name 层, 避免重复加载同一个依赖 (的不同版本)
+        // 同时加入 relocation 规则的 hashCode, 使不同 relocate 规则的同一依赖可以分别加载
+        // 解决多个 TabooLib 插件使用不同 Kotlin/Coroutines 版本时的 NoClassDefFoundError
         String id = file.getParentFile().getParentFile().getPath()
-                + ":" + PrimitiveSettings.IS_ISOLATED_MODE; // 区分类加载器 (隔离类加载器或插件类加载器)
+                + ":" + PrimitiveSettings.IS_ISOLATED_MODE // 区分类加载器 (隔离类加载器或插件类加载器)
+                + ":" + (relocation != null ? relocation.hashCode() : 0); // 区分不同的重定向规则
         if (injectedDependencies.contains(id)) return null;
         else injectedDependencies.add(id);
         // 如果没有重定向规则，直接注入


### PR DESCRIPTION
## 问题描述

当服务器上多个 TabooLib 插件使用不同版本的 Kotlin Coroutines 时（例如插件 A 使用 1.10.1，插件 B 使用 1.9.0），后加载的插件会抛出 `NoClassDefFoundError`：

```
java.lang.NoClassDefFoundError: kotlin2120x/coroutines1101/CoroutineExceptionHandler
```

单独加载任一插件均正常，仅在多插件共存且协程版本不同时触发。

## 根因分析

`AetherResolver.inject()` 的去重逻辑中，id 仅包含依赖的 `group/name` 和 `IS_ISOLATED_MODE`，不包含 relocate 规则信息：

```java
String id = file.getParentFile().getParentFile().getPath()
        + ":" + PrimitiveSettings.IS_ISOLATED_MODE;
```

这导致：
1. 插件 A 先加载 `kotlinx-coroutines-core-jvm:1.10.1`，relocate 为 `kotlin2120x.coroutines1101.*`，注入成功
2. 插件 B 后加载 `kotlinx-coroutines-core-jvm:1.9.0`，由于 `group/name` 相同被去重跳过
3. 但插件 B 的模块代码已被 relocate 为引用 `kotlin2120x.coroutines190.*`
4. 实际只有 `kotlin2120x.coroutines1101.*` 被加载 → `NoClassDefFoundError`

## 修复方案

在去重 id 中加入 `relocation` 规则的 `hashCode`，使不同 relocate 规则的同一依赖可以分别加载，而相同 relocate 规则的同一依赖仍然会被正确去重：

```java
String id = file.getParentFile().getParentFile().getPath()
        + ":" + PrimitiveSettings.IS_ISOLATED_MODE
        + ":" + (relocation != null ? relocation.hashCode() : 0);
```

## 影响范围

- 仅修改 `AetherResolver.java` 一个文件
- 不影响隔离模式和 Legacy 依赖加载路径
- 向后兼容：无 relocate 规则时 hashCode 为 0，行为与原逻辑一致