### PR TITLE
fix(fake-op): 修复 26.1+ 非混淆服务端 EntityPlayer 类查找失败

### DIFF
--- a/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMSImpl.kt
+++ b/module/bukkit/bukkit-fake-op/src/main/kotlin/taboolib/expansion/PlayerFakeOpNMSImpl.kt
@@ -17,6 +17,7 @@ import org.bukkit.craftbukkit.entity.CraftPlayer
 import org.bukkit.entity.Player
 import org.bukkit.permissions.Permission
 import taboolib.common.util.unsafeLazy
+import taboolib.module.nms.MinecraftVersion
 import taboolib.module.nms.nmsClass
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
@@ -153,7 +154,12 @@ class PlayerFakeOpNMSImpl : PlayerFakeOpNMS() {
         private lateinit var tempCraftPlayer: CraftPlayer
 
         init {
-            val entityPlayerClass = nmsClass("EntityPlayer")
+            // 26.1+ 非混淆服务端，Spigot/Paper 映射表为空，直接使用 Mojang Deobf 全限定名
+            val entityPlayerClass = if (MinecraftVersion.isUnobfuscated) {
+                Class.forName("net.minecraft.server.level.ServerPlayer")
+            } else {
+                nmsClass("EntityPlayer")
+            }
             // Generate the bytecode of the new class, which extends CraftPlayer
             val dynamicType = ByteBuddy()
                 .subclass(CraftPlayer::class.java)


### PR DESCRIPTION
26.1+ 非混淆服务端的 Spigot/Paper 映射表为空，nmsClass("EntityPlayer") 会拼成 不存在的 net.minecraft.EntityPlayer。改为在 isUnobfuscated 分支直接使用 Mojang Deobf 全限定名 net.minecraft.server.level.ServerPlayer。

修复 Paper 26.1.2 上调用 dispatchCommandAsOp 抛 ClassNotFoundException 的问题。