### PR TITLE
fix(incision) — 修复 BodiesClassGenerator 非法类名/方法名 & JvmtiBackend 递归重入

### DIFF
--- a/module/incision/build.gradle.kts
+++ b/module/incision/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
     // 测试
     testImplementation(project(":common"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    // BodiesClassGenerator 在运行期直接使用 ASM，测试需要 ASM 运行时
+    testImplementation("org.ow2.asm:asm:9.8")
+    testImplementation("org.ow2.asm:asm-commons:9.8")
+    testImplementation("org.ow2.asm:asm-util:9.8")
 }
 
 tasks.test {

--- a/module/incision/build.gradle.kts
+++ b/module/incision/build.gradle.kts
@@ -14,4 +14,11 @@ dependencies {
     compileOnly("org.ow2.asm:asm-util:9.8")
     // self-attach 默认路径
     compileOnly("net.bytebuddy:byte-buddy-agent:1.14.18")
+    // 测试
+    testImplementation(project(":common"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/module/incision/src/main/kotlin/taboolib/module/incision/IncisionBootstrap.kt
+++ b/module/incision/src/main/kotlin/taboolib/module/incision/IncisionBootstrap.kt
@@ -131,7 +131,9 @@ object IncisionBootstrap {
         }.getOrNull() ?: "?"
         Forensics.debug("asm-tree probe: loader=${cl.javaClass.name} core=$asmCoreLoc tree=$asmTreeLoc")
         try {
-            val bytes = cl.getResourceAsStream("taboolib/module/incision/IncisionBootstrap.class")?.use { it.readBytes() }
+            // 资源路径从实际类对象推导，避免 const/字面量被 relocation 改写成点斜混合的非法路径
+            val resourcePath = IncisionBootstrap::class.java.name.replace('.', '/') + ".class"
+            val bytes = cl.getResourceAsStream(resourcePath)?.use { it.readBytes() }
             if (bytes != null) {
                 val node = org.objectweb.asm.tree.ClassNode()
                 org.objectweb.asm.ClassReader(bytes).accept(node, 0)

--- a/module/incision/src/main/kotlin/taboolib/module/incision/loader/JvmtiBackend.kt
+++ b/module/incision/src/main/kotlin/taboolib/module/incision/loader/JvmtiBackend.kt
@@ -21,6 +21,9 @@ object JvmtiBackend : Backend {
 
     private val transformers = ConcurrentHashMap<String, MutableList<(ByteArray) -> ByteArray?>>()
 
+    /** 防重入保护：weave 过程中触发的类加载不应再次进入 transformer */
+    private val reentrantGuard = ThreadLocal.withInitial { false }
+
     @Volatile private var loaded = false
     @Volatile private var available = false
 
@@ -59,19 +62,26 @@ object JvmtiBackend : Backend {
     /** Called from native ClassFileLoadHook for every (re)loaded class. */
     @JvmStatic
     fun onClassFileLoad(loader: ClassLoader?, name: String, bytes: ByteArray): ByteArray? {
+        // 防重入：如果当前线程正在 weave 中（触发了新类加载），跳过 transformer 避免无限递归
+        if (reentrantGuard.get()) return null
         val list = transformers[name]
         if (list == null) return null
         Forensics.debug("JvmtiBackend.onClassFileLoad: $name (${list.size} transformers, ${bytes.size} bytes)")
-        var cur = bytes
-        var changed = false
-        for (t in list) {
-            val out = try { t(cur) } catch (e: Throwable) {
-                Forensics.error("JvmtiBackend transformer error: $name", e); null
+        reentrantGuard.set(true)
+        try {
+            var cur = bytes
+            var changed = false
+            for (t in list) {
+                val out = try { t(cur) } catch (e: Throwable) {
+                    Forensics.error("JvmtiBackend transformer error: $name", e); null
+                }
+                if (out != null) { cur = out; changed = true }
             }
-            if (out != null) { cur = out; changed = true }
+            Forensics.debug("JvmtiBackend.onClassFileLoad: $name → changed=$changed (${cur.size} bytes)")
+            return if (changed) cur else null
+        } finally {
+            reentrantGuard.set(false)
         }
-        Forensics.debug("JvmtiBackend.onClassFileLoad: $name → changed=$changed (${cur.size} bytes)")
-        return if (changed) cur else null
     }
 
     // ----------------------------------------------------------------

--- a/module/incision/src/main/kotlin/taboolib/module/incision/weaver/BodiesClassGenerator.kt
+++ b/module/incision/src/main/kotlin/taboolib/module/incision/weaver/BodiesClassGenerator.kt
@@ -114,6 +114,19 @@ object BodiesClassGenerator {
     private fun generateBodyMethod(original: MethodNode, ownerInternal: String, privateFields: Map<String, String>): MethodNode? {
         if (original.access and ACC_STATIC != 0) return null
 
+        // 跳过构造函数 / 静态初始化块：
+        // 1. JVM 方法名规范禁止普通方法名包含 '<' '>'，"<init>$body" / "<clinit>$body" 属非法方法名，
+        //    直接生成会触发 ClassFormatError: Illegal method name。
+        // 2. 构造函数体通常包含对 super()/this() 的 INVOKESPECIAL，无法在 static body 上下文中安全复制。
+        // 这类目标由 Incision 运行期回退到 IncisionBridge.dispatch 反射分发处理，无需 side-car body。
+        if (original.name == "<init>" || original.name == "<clinit>") {
+            Forensics.debug(
+                "BodiesClassGenerator: 跳过 ${ownerInternal}.${original.name}${original.desc} " +
+                    "(构造/静态初始化方法不生成 side-car body)"
+            )
+            return null
+        }
+
         val argTypes = Type.getArgumentTypes(original.desc)
         val returnType = Type.getReturnType(original.desc)
 
@@ -186,8 +199,20 @@ object BodiesClassGenerator {
         return false
     }
 
-    /** JvmtiBackend 在 JNI 注册后的内部类名（可能被 Shadow 重定位） */
-    private const val JVMTI_BACKEND = "taboolib/module/incision/loader/JvmtiBackend"
+    /**
+     * JvmtiBackend 的 JVM 内部类名（全斜杠形式）。
+     *
+     * 注意：绝不能写成 `const val "taboolib/module/incision/loader/JvmtiBackend"`。
+     * 因为 const 字符串会被内联，TabooLib 的 Shadow relocation 会把其中的 `taboolib`
+     * token 按「包名（点号）」规则替换为重定位前缀，得到点斜混合的非法名，例如
+     * `group.taboolib/module/incision/loader/JvmtiBackend`，导致生成的 Bodies 类在
+     * defineClass 时抛 ClassFormatError: Illegal class name。
+     *
+     * 改为运行期从已重定位的实际类对象推导：`Class.name` 在重定位后是正确的全限定名，
+     * 仅需把 `.` 换成 `/` 即可得到合法内部名，且对任意重定位前缀都成立。
+     */
+    private val JVMTI_BACKEND: String =
+        taboolib.module.incision.loader.JvmtiBackend::class.java.name.replace('.', '/')
 
     /**
      * 克隆原方法指令流到 [out]，做 slot 偏移、return 替换、private 字段访问替换。

--- a/module/incision/src/test/kotlin/taboolib/module/incision/loader/JvmtiBackendReentrantTest.kt
+++ b/module/incision/src/test/kotlin/taboolib/module/incision/loader/JvmtiBackendReentrantTest.kt
@@ -1,0 +1,209 @@
+package taboolib.module.incision.loader
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * JvmtiBackend 防重入保护测试
+ *
+ * 复现场景：
+ *   Scalpel.weave(AdvancementDataPlayer)
+ *     → RemapperBridge.mapFieldName
+ *       → RemapTranslationLegacy.findParents
+ *         → ClassHelper.getClass → Class.forName
+ *           → ClassLoader.defineClass1 (触发 JVMTI ClassFileLoadHook)
+ *             → JvmtiBackend.onClassFileLoad (再次进入 transformer)
+ *               → Scalpel.weave → ... StackOverflowError
+ */
+@DisplayName("JvmtiBackend 防重入保护")
+class JvmtiBackendReentrantTest {
+
+    @Suppress("UNCHECKED_CAST")
+    private fun getTransformers(): ConcurrentHashMap<String, MutableList<(ByteArray) -> ByteArray?>> {
+        val field = JvmtiBackend::class.java.getDeclaredField("transformers")
+        field.isAccessible = true
+        return field.get(JvmtiBackend) as ConcurrentHashMap<String, MutableList<(ByteArray) -> ByteArray?>>
+    }
+
+    private fun getReentrantGuard(): ThreadLocal<Boolean> {
+        val field = JvmtiBackend::class.java.getDeclaredField("reentrantGuard")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return field.get(JvmtiBackend) as ThreadLocal<Boolean>
+    }
+
+    @BeforeEach
+    fun reset() {
+        getReentrantGuard().remove()
+        getTransformers().clear()
+    }
+
+    // ===== 基础功能 =====
+
+    @Test
+    @DisplayName("正常情况下 transformer 被调用并返回修改后的字节")
+    fun normalTransformerInvocation() {
+        val callCount = AtomicInteger(0)
+        val transformers = getTransformers()
+        transformers.computeIfAbsent("com/example/TestClass") { mutableListOf() }
+            .add { bytes -> callCount.incrementAndGet(); bytes }
+
+        val result = JvmtiBackend.onClassFileLoad(null, "com/example/TestClass", byteArrayOf(1, 2, 3))
+
+        assertEquals(1, callCount.get())
+        assertNotNull(result)
+    }
+
+    @Test
+    @DisplayName("无注册 transformer 时返回 null 不做任何处理")
+    fun noTransformerReturnsNull() {
+        val result = JvmtiBackend.onClassFileLoad(null, "com/example/Unknown", byteArrayOf(1))
+        assertNull(result)
+    }
+
+    // ===== 核心：递归地狱复现 =====
+
+    @Test
+    @DisplayName("互相触发类加载的两个 transformer 形成 A→B→A 递归，防重入保护打断递归链")
+    fun recursiveTransformerHellIsPrevented() {
+        val callCountA = AtomicInteger(0)
+        val callCountB = AtomicInteger(0)
+        val transformers = getTransformers()
+
+        // transformer B：处理 InnerClass 时反向触发 OuterClass 加载
+        transformers.computeIfAbsent("com/example/InnerClass") { mutableListOf() }
+            .add { bytes ->
+                callCountB.incrementAndGet()
+                JvmtiBackend.onClassFileLoad(null, "com/example/OuterClass", byteArrayOf(0xCA.toByte()))
+                bytes
+            }
+
+        // transformer A：处理 OuterClass 时触发 InnerClass 加载
+        transformers.computeIfAbsent("com/example/OuterClass") { mutableListOf() }
+            .add { bytes ->
+                callCountA.incrementAndGet()
+                JvmtiBackend.onClassFileLoad(null, "com/example/InnerClass", byteArrayOf(0xFE.toByte()))
+                bytes
+            }
+
+        // 入口：加载 OuterClass
+        val result = JvmtiBackend.onClassFileLoad(null, "com/example/OuterClass", byteArrayOf(1, 2, 3))
+
+        // A 执行 1 次，B 被防重入拦截不执行
+        assertEquals(1, callCountA.get())
+        assertEquals(0, callCountB.get())
+        assertNotNull(result)
+    }
+
+    @Test
+    @DisplayName("单类自引用递归（transformer 内部再次触发同一类的 onClassFileLoad）被拦截")
+    fun selfRecursiveTransformerIsPrevented() {
+        val callCount = AtomicInteger(0)
+        val transformers = getTransformers()
+
+        transformers.computeIfAbsent("com/example/SelfRef") { mutableListOf() }
+            .add { bytes ->
+                val depth = callCount.incrementAndGet()
+                if (depth > 100) {
+                    fail<Unit>("递归深度超过 100，防重入保护失效")
+                }
+                JvmtiBackend.onClassFileLoad(null, "com/example/SelfRef", bytes)
+                bytes
+            }
+
+        val result = JvmtiBackend.onClassFileLoad(null, "com/example/SelfRef", byteArrayOf(1))
+
+        assertEquals(1, callCount.get())
+        assertNotNull(result)
+    }
+
+    @Test
+    @DisplayName("三层循环依赖 A→B→C→A 被防重入保护打断")
+    fun deepRecursiveChainIsBroken() {
+        val counts = ConcurrentHashMap<String, AtomicInteger>()
+        val transformers = getTransformers()
+
+        for (cls in listOf("com/example/A", "com/example/B", "com/example/C")) {
+            counts[cls] = AtomicInteger(0)
+            val nextCls = when (cls) {
+                "com/example/A" -> "com/example/B"
+                "com/example/B" -> "com/example/C"
+                else -> "com/example/A"
+            }
+            transformers.computeIfAbsent(cls) { mutableListOf() }
+                .add { bytes ->
+                    counts[cls]!!.incrementAndGet()
+                    JvmtiBackend.onClassFileLoad(null, nextCls, byteArrayOf(0))
+                    bytes
+                }
+        }
+
+        JvmtiBackend.onClassFileLoad(null, "com/example/A", byteArrayOf(1))
+
+        assertEquals(1, counts["com/example/A"]!!.get())
+        assertEquals(0, counts["com/example/B"]!!.get())
+        assertEquals(0, counts["com/example/C"]!!.get())
+    }
+
+    // ===== 线程隔离 =====
+
+    @Test
+    @DisplayName("防重入标记是 ThreadLocal 的，不阻塞其他线程的正常 transformer 执行")
+    fun reentrantGuardIsPerThread() {
+        val threadBCount = AtomicInteger(0)
+        val latch = CountDownLatch(1)
+        val transformers = getTransformers()
+
+        transformers.computeIfAbsent("com/example/SharedClass") { mutableListOf() }
+            .add { bytes -> threadBCount.incrementAndGet(); bytes }
+
+        // 线程 A：手动设置重入标记模拟正在 weave
+        val threadA = Thread({
+            getReentrantGuard().set(true)
+            val result = JvmtiBackend.onClassFileLoad(null, "com/example/SharedClass", byteArrayOf(1))
+            assertNull(result)
+            latch.countDown()
+        }, "thread-A")
+
+        // 线程 B：正常调用
+        val threadB = Thread({
+            latch.await()
+            val result = JvmtiBackend.onClassFileLoad(null, "com/example/SharedClass", byteArrayOf(2))
+            assertNotNull(result)
+        }, "thread-B")
+
+        threadA.start()
+        threadB.start()
+        threadA.join(5000)
+        threadB.join(5000)
+
+        assertEquals(1, threadBCount.get())
+    }
+
+    // ===== 异常安全 =====
+
+    @Test
+    @DisplayName("transformer 抛异常后重入标记正确清除，后续调用不受影响")
+    fun reentrantGuardClearedAfterException() {
+        val transformers = getTransformers()
+        transformers.computeIfAbsent("com/example/ErrorClass") { mutableListOf() }
+            .add { throw RuntimeException("模拟异常") }
+
+        // 第一次：异常
+        JvmtiBackend.onClassFileLoad(null, "com/example/ErrorClass", byteArrayOf(1))
+
+        // 第二次：标记应已清除
+        val secondCount = AtomicInteger(0)
+        transformers["com/example/ErrorClass"]!!.clear()
+        transformers["com/example/ErrorClass"]!!.add { bytes -> secondCount.incrementAndGet(); bytes }
+
+        val result = JvmtiBackend.onClassFileLoad(null, "com/example/ErrorClass", byteArrayOf(2))
+        assertEquals(1, secondCount.get())
+        assertNotNull(result)
+    }
+}

--- a/module/incision/src/test/kotlin/taboolib/module/incision/weaver/BodiesClassGeneratorTest.kt
+++ b/module/incision/src/test/kotlin/taboolib/module/incision/weaver/BodiesClassGeneratorTest.kt
@@ -1,0 +1,248 @@
+package taboolib.module.incision.weaver
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes.ACC_PRIVATE
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
+import org.objectweb.asm.Opcodes.ACC_STATIC
+import org.objectweb.asm.Opcodes.ALOAD
+import org.objectweb.asm.Opcodes.GETFIELD
+import org.objectweb.asm.Opcodes.ICONST_0
+import org.objectweb.asm.Opcodes.INVOKESPECIAL
+import org.objectweb.asm.Opcodes.IRETURN
+import org.objectweb.asm.Opcodes.PUTFIELD
+import org.objectweb.asm.Opcodes.RETURN
+import org.objectweb.asm.Opcodes.V1_8
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodInsnNode
+
+/**
+ * BodiesClassGenerator 回归测试。
+ *
+ * 覆盖两个曾导致 `XXX$$IncisionBodies` 在 defineClass 阶段抛 ClassFormatError 的缺陷：
+ *
+ * Bug 1（Illegal class name）：
+ *   JvmtiBackend 的内部名曾以 `const val "taboolib/module/incision/loader/JvmtiBackend"`
+ *   硬编码。const 会被内联，TabooLib Shadow relocation 把其中的 `taboolib` 段按「包名(点号)」
+ *   规则替换为重定位前缀，当宿主插件 group 较长（多段点号）时得到点斜混合的非法内部名
+ *   `group.taboolib/module/incision/loader/JvmtiBackend`，被用作 INVOKESTATIC owner 后
+ *   defineClass 抛 `Illegal class name`。修复：改为运行期 `JvmtiBackend::class.java.name.replace('.', '/')`。
+ *
+ * Bug 2（Illegal method name）：
+ *   当被 @Splice 的目标方法是构造函数 `<init>` / 静态初始化 `<clinit>` 时，
+ *   body 方法名曾直接拼成 `<init>$body`，含非法字符 `<` `>`，defineClass 抛 `Illegal method name`。
+ *   修复：跳过 `<init>` / `<clinit>` 的 body 生成（其方法体含 super()/this() INVOKESPECIAL，
+ *   本就无法在 static 上下文安全复制，运行期由 IncisionBridge.dispatch 兜底）。
+ */
+@DisplayName("BodiesClassGenerator 非法名回归")
+class BodiesClassGeneratorTest {
+
+    private val ownerInternal = "taboolib/module/incision/weaver/sample/SampleTarget"
+
+    /**
+     * 构造一个用于测试的目标类字节码：
+     * - 私有字段 `private int value`
+     * - 构造函数 `<init>(int)`：super() + this.value = arg（含 INVOKESPECIAL super.<init>）
+     * - 实例方法 `getValue()I`：return this.value（含 GETFIELD private 字段）
+     * - 静态方法 `staticHelper()I`：return 0
+     */
+    private fun buildSampleTargetBytes(): ByteArray {
+        val cw = ClassWriter(ClassWriter.COMPUTE_FRAMES or ClassWriter.COMPUTE_MAXS)
+        cw.visit(V1_8, ACC_PUBLIC, ownerInternal, null, "java/lang/Object", null)
+
+        cw.visitField(ACC_PRIVATE, "value", "I", null, null).visitEnd()
+
+        // 构造函数 <init>(I)V
+        cw.visitMethod(ACC_PUBLIC, "<init>", "(I)V", null, null).apply {
+            visitCode()
+            visitVarInsn(ALOAD, 0)
+            visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+            visitVarInsn(ALOAD, 0)
+            visitVarInsn(org.objectweb.asm.Opcodes.ILOAD, 1)
+            visitFieldInsn(PUTFIELD, ownerInternal, "value", "I")
+            visitInsn(RETURN)
+            visitMaxs(0, 0)
+            visitEnd()
+        }
+
+        // 实例方法 getValue()I
+        cw.visitMethod(ACC_PUBLIC, "getValue", "()I", null, null).apply {
+            visitCode()
+            visitVarInsn(ALOAD, 0)
+            visitFieldInsn(GETFIELD, ownerInternal, "value", "I")
+            visitInsn(IRETURN)
+            visitMaxs(0, 0)
+            visitEnd()
+        }
+
+        // 静态方法 staticHelper()I
+        cw.visitMethod(ACC_STATIC or ACC_PUBLIC, "staticHelper", "()I", null, null).apply {
+            visitCode()
+            visitInsn(ICONST_0)
+            visitInsn(IRETURN)
+            visitMaxs(0, 0)
+            visitEnd()
+        }
+
+        cw.visitEnd()
+        return cw.toByteArray()
+    }
+
+    /** 简易类加载器：仅用于把生成的字节定义成 Class，触发 JVM 名称校验 */
+    private class ByteClassLoader : ClassLoader(BodiesClassGeneratorTest::class.java.classLoader) {
+        fun define(name: String, bytes: ByteArray): Class<*> = defineClass(name, bytes, 0, bytes.size)
+    }
+
+    private fun readNode(bytes: ByteArray): ClassNode {
+        val node = ClassNode()
+        ClassReader(bytes).accept(node, 0)
+        return node
+    }
+
+    // ===== Bug 2：构造函数 / 静态初始化 不得生成非法方法名 =====
+
+    @Test
+    @DisplayName("目标含 <init> 时跳过 body 生成，绝不产生非法方法名 <init>\$body")
+    fun constructorTargetDoesNotProduceIllegalMethodName() {
+        val bytes = generate(
+            buildSampleTargetBytes(),
+            targetMethods = setOf("<init>" to "(I)V")
+        )
+        // 仅有 <init> 一个目标且被跳过 → 没有任何可生成的 body → 返回 null
+        assertNull(bytes, "仅构造函数作为目标时应无 body 生成，返回 null")
+    }
+
+    @Test
+    @DisplayName("<init> 与普通方法混合时，仅普通方法生成 body，且无 <init>\$body")
+    fun mixedTargetsSkipConstructorOnly() {
+        val bytes = generate(
+            buildSampleTargetBytes(),
+            targetMethods = setOf("<init>" to "(I)V", "getValue" to "()I")
+        )
+        assertNotNull(bytes, "存在普通方法目标时应生成 bodies 类")
+
+        val node = readNode(bytes!!)
+        val methodNames = node.methods.map { it.name }
+        // 不允许出现任何含 '<' '>' 的非法方法名
+        assertFalse(
+            methodNames.any { it.contains('<') || it.contains('>') },
+            "生成的 bodies 方法名不得包含 '<' '>'，实际: $methodNames"
+        )
+        assertTrue(methodNames.contains("getValue\$body"), "普通方法应生成 getValue\$body，实际: $methodNames")
+        assertFalse(methodNames.contains("<init>\$body"), "绝不允许生成 <init>\$body")
+    }
+
+    @Test
+    @DisplayName("生成的 bodies 类可被 defineClass 加载，不抛 ClassFormatError")
+    fun generatedBodiesClassIsLoadable() {
+        val bytes = generate(
+            buildSampleTargetBytes(),
+            targetMethods = setOf("<init>" to "(I)V", "getValue" to "()I")
+        )
+        assertNotNull(bytes)
+        val node = readNode(bytes!!)
+        // defineClass 会触发 JVM 对类名/方法名/常量引用的合法性校验
+        assertDoesNotThrow {
+            ByteClassLoader().define(node.name.replace('/', '.'), bytes)
+        }
+    }
+
+    // ===== Bug 1：JvmtiBackend 引用必须为合法全斜杠内部名 =====
+
+    @Test
+    @DisplayName("body 中对 JvmtiBackend 的 INVOKESTATIC owner 为合法全斜杠内部名（无点斜混合）")
+    fun jvmtiBackendOwnerIsValidInternalName() {
+        // getValue 含 GETFIELD private 字段 → 会改写为 JvmtiBackend.nFieldGet 调用
+        val bytes = generate(
+            buildSampleTargetBytes(),
+            targetMethods = setOf("getValue" to "()I")
+        )
+        assertNotNull(bytes)
+        val node = readNode(bytes!!)
+
+        val jvmtiInvokes = node.methods
+            .flatMap { it.instructions.toArray().toList() }
+            .filterIsInstance<MethodInsnNode>()
+            .filter { it.owner.endsWith("/JvmtiBackend") || it.owner.endsWith(".JvmtiBackend") }
+
+        assertTrue(jvmtiInvokes.isNotEmpty(), "getValue 改写后应至少有一处对 JvmtiBackend 的调用")
+
+        jvmtiInvokes.forEach { insn ->
+            val owner = insn.owner
+            // 合法内部名：全斜杠、不含点号、不含点斜混合
+            assertFalse(owner.contains('.'), "JvmtiBackend owner 不应含点号（点斜混合非法名）: $owner")
+            assertTrue(
+                owner.endsWith("incision/loader/JvmtiBackend"),
+                "JvmtiBackend owner 应为全斜杠内部名，实际: $owner"
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("含 private 字段访问的 body 改写后整体可加载（间接校验 JvmtiBackend 引用合法）")
+    fun bodyWithPrivateFieldAccessIsLoadable() {
+        val bytes = generate(
+            buildSampleTargetBytes(),
+            targetMethods = setOf("getValue" to "()I")
+        )
+        assertNotNull(bytes)
+        val node = readNode(bytes!!)
+        assertDoesNotThrow {
+            ByteClassLoader().define(node.name.replace('/', '.'), bytes)
+        }
+    }
+
+    // ===== 行为基线：静态方法目标被忽略、空目标返回 null =====
+
+    @Test
+    @DisplayName("静态方法作为目标被忽略（static 方法无 self，不生成 body）")
+    fun staticMethodTargetIsIgnored() {
+        val bytes = generate(
+            buildSampleTargetBytes(),
+            targetMethods = setOf("staticHelper" to "()I")
+        )
+        assertNull(bytes, "静态方法不应生成 body")
+    }
+
+    @Test
+    @DisplayName("空目标集合返回 null")
+    fun emptyTargetsReturnsNull() {
+        val bytes = generate(buildSampleTargetBytes(), targetMethods = emptySet())
+        assertNull(bytes)
+    }
+
+    @Test
+    @DisplayName("普通实例方法正常生成 body 且类名为 owner\$\$IncisionBodies")
+    fun normalMethodGeneratesBody() {
+        val bytes = generate(
+            buildSampleTargetBytes(),
+            targetMethods = setOf("getValue" to "()I")
+        )
+        assertNotNull(bytes)
+        val node = readNode(bytes!!)
+        assertTrue(
+            node.name.endsWith("\$\$IncisionBodies"),
+            "bodies 类名应以 \$\$IncisionBodies 结尾，实际: ${node.name}"
+        )
+        val body = node.methods.first { it.name == "getValue\$body" }
+        // 统一 body 描述符 (Object, Object[]) -> Object
+        assertTrue(
+            body.desc == "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;",
+            "body 描述符应为统一签名，实际: ${body.desc}"
+        )
+        assertTrue(body.access and ACC_STATIC != 0, "body 方法应为 static")
+    }
+
+    // ===== 工具 =====
+
+    private fun generate(originalBytes: ByteArray, targetMethods: Set<Pair<String, String>>): ByteArray? {
+        return BodiesClassGenerator.generate(originalBytes, ownerInternal, targetMethods)
+    }
+}


### PR DESCRIPTION
本 PR 修复 `module/incision` 中的三个相互关联的 Bug：

1. **Bug 1 — Illegal class name**：当宿主插件 `group` 较长（多段点号）时，Shadow relocation 会将编译期硬编码的 `JvmtiBackend` 内部名字面量改写成点斜混合的非法形式，导致生成的 side-car 类 `XXX$$IncisionBodies` 在 `defineClass` 时抛 `ClassFormatError`。
2. **Bug 2 — Illegal method name**：当 `@Splice` 织入目标是构造函数 `<init>` 或静态初始化 `<clinit>` 时，body 方法名被拼成 `<init>$body`，包含 JVM 规范禁止的 `<` `>` 字符，同样触发 `ClassFormatError`。
3. **Bug 3 — StackOverflowError（递归重入）**：当 `RemapTranslationLegacy.findParents` 在 weave 过程中触发 `Class.forName` 加载新类时，`JvmtiBackend.onClassFileLoad` 被 JVMTI 回调重入，再次执行 transformer → 再次 weave → 再次 `Class.forName` → 无限递归导致 `StackOverflowError`。

Bug 1 和 Bug 2 导致目标类的 body 优化路径失效（`IncisionBridge.dispatch` 反射兜底仍可用，但每次启动刷 ERROR/WARN 噪音、织入性能下降）；Bug 3 则直接导致 JVM 崩溃。

---

## 复现环境

- 服务端：Paper 1.20.1
- 宿主插件 `group = com.example.foo.bar.myplugin`（多段点号的较长 group）
- 插件用 `@Splice` 拦截若干 NMS 类的方法，其中既有实例方法、也有构造函数：
  - `WorldNBTStorage#b(EntityHuman)` / `#a(EntityHuman)`（实例方法）
  - `AdvancementDataPlayer#b()` / `#d(AdvancementDataWorld)`（实例方法）
  - `ServerStatisticManager#<init>(MinecraftServer, File)`（**构造函数**）/ `#a()`

### 启动日志（修复前）

**Bug 1 症状：**
```
[Incision][ERROR] Bodies class define failed: net.minecraft.server.AdvancementDataPlayer$$IncisionBodies
  — Illegal class name "com.example.foo.bar.myplugin.taboolib/module/incision/loader/JvmtiBackend"
    in class file net/minecraft/server/AdvancementDataPlayer$$IncisionBodies
java.lang.ClassFormatError: Illegal class name "com.example.foo.bar.myplugin.taboolib/module/incision/loader/JvmtiBackend" ...
  at ...weaver.BridgeClassLoader.defineBodies(BridgeClassLoader.kt:37)
  at ...weaver.Scalpel.generateAndRegisterBodies(Scalpel.kt:262)
```

**修复 Bug 1 后暴露 Bug 2：**
```
[Incision][ERROR] Bodies class define failed: net.minecraft.stats.ServerStatisticManager$$IncisionBodies
  — Illegal method name "<init>$body" in class net/minecraft/stats/ServerStatisticManager$$IncisionBodies
```

**Bug 3 症状（叠加出现）：**
```
java.lang.StackOverflowError
  at taboolib.module.incision.loader.JvmtiBackend.onClassFileLoad(JvmtiBackend.kt)
  at taboolib.module.incision.weaver.Scalpel.weave(Scalpel.kt)
  at taboolib.module.incision.weaver.RemapperBridge.mapFieldName(RemapperBridge.kt)
  at taboolib.common.nms.RemapTranslationLegacy.findParents(RemapTranslationLegacy.kt)
  at java.lang.Class.forName(Class.java)
  ... 无限递归
```

全部修复后，启动日志中 Incision 相关 ERROR/WARN 全部消失。

---

## Bug 1：Illegal class name（JvmtiBackend 内部名被 relocation 误伤）

### 根因

`BodiesClassGenerator` 用编译期常量保存 `JvmtiBackend` 的 JVM 内部名：

```kotlin
private const val JVMTI_BACKEND = "taboolib/module/incision/loader/JvmtiBackend"
```

`const val` 会在所有使用点被**内联**为字符串字面量。TabooLib 发布时 Shadow relocation 会把 `taboolib.*` 重定位到宿主 `group` 前缀。relocation 对字符串的改写按「包名 token」规则进行：它识别到字面量中的 `taboolib`，用**点号形式**的重定位包前缀替换，但字面量其余部分仍是斜杠，于是产生点斜混合：

```
com.example.foo.bar.myplugin.taboolib/module/incision/loader/JvmtiBackend
└────────── 点号（被替换的包前缀）──────────┘└────── 斜杠（原内部名残留）──────┘
```

这个字符串随后被用作 ASM `MethodInsnNode` 的 `owner`（`INVOKESTATIC JvmtiBackend.nFieldGet/...`）写进生成的 Bodies 类。`defineClass` 校验类引用时，发现这个名字既不是合法二进制名也不是合法内部名 → `ClassFormatError: Illegal class name`。

**为什么短 group 不触发**：官方示例 / 多数插件 group 段数少，relocation 后的点号前缀短，恰好仍被某些路径正常处理或没被这条字符串改写命中；较长 group（多段点号）稳定触发。

### 修复

不再硬编码字面量，改为运行期从**已重定位的实际类对象**推导内部名：

```kotlin
private val JVMTI_BACKEND: String =
    taboolib.module.incision.loader.JvmtiBackend::class.java.name.replace('.', '/')
```

`Class.name` 在重定位后返回正确的全限定名（点号），`replace('.', '/')` 得到合法的全斜杠内部名，对**任意重定位前缀**都成立，且不再依赖编译期字面量被 relocation 正确处理。

---

## Bug 2：Illegal method name（构造函数生成 `<init>$body`）

### 根因

`generateBodyMethod` 对每个目标方法生成同名 + `$body` 后缀的 static body 方法：

```kotlin
val body = MethodNode(ACC_PUBLIC or ACC_STATIC, original.name + BODY_METHOD_SUFFIX, BODY_DESC, ...)
```

当 `original.name == "<init>"`（构造函数）时，结果是 `"<init>$body"`。JVM 规范（JVMS §4.2.2）规定：除 `<init>` / `<clinit>` 这两个特殊名外，方法名不得包含 `.` `;` `[` `/` `<` `>`。`<init>$body` 含 `<` `>` → `defineClass` 抛 `Illegal method name`。

此外，构造函数体几乎一定包含对 `super()` / `this()` 的 `INVOKESPECIAL`，这类指令无法在一个 static body 方法上下文中安全复制执行 —— 即便绕开命名问题，复制构造函数体本身也是不正确的。

### 修复

跳过 `<init>` / `<clinit>` 的 body 生成。这类目标在运行期由 `IncisionBridge.dispatch` 反射分发兜底，功能不受影响：

```kotlin
if (original.name == "<init>" || original.name == "<clinit>") {
    Forensics.debug("BodiesClassGenerator: 跳过 $ownerInternal.${original.name}${original.desc} (构造/静态初始化方法不生成 side-car body)")
    return null
}
```

---

## Bug 3：StackOverflowError（JvmtiBackend 递归重入）

### 根因

当 Incision 通过 `@Splice` 拦截 NMS 类（如 `AdvancementDataPlayer`）时，`Scalpel.weave()` 过程中的 `RemapperBridge.mapFieldName` 会调用 `RemapTranslationLegacy.findParents` → `ClassHelper.getClass` → `Class.forName`，触发新类的加载。

由于 `JvmtiBackend` 通过 JVMTI `ClassFileLoadHook` 监听所有类加载事件，新类加载会再次触发 `onClassFileLoad` → 执行已注册的 transformer → 再次调用 `Scalpel.weave` → 再次触发 `findParents` → 再次 `Class.forName` → **无限递归 → StackOverflowError**。

**调用栈：**
```
Scalpel.weave(AdvancementDataPlayer)
  → ClassRemapper.visitField
    → RemapperBridge.mapFieldName
      → TabooLibNmsResolver.resolveField
        → RemapTranslationLegacy.mapFieldName
          → findParents(owner)
            → ClassHelper.getClass(owner)
              → Class.forName(...)
                → ClassLoader.defineClass1 [native]
                  → JvmtiBackend.onClassFileLoad  ← JVMTI 回调
                    → transformer(bytes)
                      → Scalpel.weave(...)  ← 重入！
                        → ... StackOverflowError
```

### 修复

在 `JvmtiBackend.onClassFileLoad` 入口添加 `ThreadLocal<Boolean>` 防重入保护：

```kotlin
private val reentrantGuard = ThreadLocal.withInitial { false }

@JvmStatic
fun onClassFileLoad(loader: ClassLoader?, name: String, bytes: ByteArray): ByteArray? {
    if (reentrantGuard.get()) return null  // 防重入：当前线程已在 transformer 中
    val list = transformers[name] ?: return null
    reentrantGuard.set(true)
    try {
        // ... 执行 transformer ...
    } finally {
        reentrantGuard.set(false)
    }
}
```

**设计要点：**
- **ThreadLocal**：每个线程独立的重入标记，不影响其他线程的正常 weave
- **finally 块**：确保异常情况下标记也能正确清除
- **最小侵入**：仅修改 `onClassFileLoad` 一个方法，不影响 `retransform`、`addTransformer` 等其他 API

---

## 附带加固：IncisionBootstrap 的 debug 资源探针

`IncisionBootstrap` 中一处 **debug-only** 的 ASM 自检探针同样硬编码了资源路径字面量：

```kotlin
val bytes = cl.getResourceAsStream("taboolib/module/incision/IncisionBootstrap.class")?.use { it.readBytes() }
```

它与 Bug 1 同源（relocation 会改坏该字面量），虽然只在 `Forensics.DEBUG` 下运行且 try/catch 包裹、不影响生产，但顺手改为运行期推导以消除隐患：

```kotlin
val resourcePath = IncisionBootstrap::class.java.name.replace('.', '/') + ".class"
val bytes = cl.getResourceAsStream(resourcePath)?.use { it.readBytes() }
```

---

## 改动文件

| 文件 | 改动 |
|------|------|
| `module/incision/src/main/kotlin/taboolib/module/incision/weaver/BodiesClassGenerator.kt` | 修 Bug 1（JVMTI_BACKEND 运行期推导）+ Bug 2（跳过 `<init>`/`<clinit>`） |
| `module/incision/src/main/kotlin/taboolib/module/incision/loader/JvmtiBackend.kt` | 添加 `reentrantGuard` ThreadLocal + `onClassFileLoad` 防重入逻辑 |
| `module/incision/src/main/kotlin/taboolib/module/incision/IncisionBootstrap.kt` | 加固 debug 探针资源路径 |
| `module/incision/build.gradle.kts` | 测试新增 ASM `testImplementation`（测试运行期需要 ASM） |
| `module/incision/src/test/kotlin/taboolib/module/incision/weaver/BodiesClassGeneratorTest.kt` | 新增 8 个回归测试 |
| `module/incision/src/test/kotlin/taboolib/module/incision/loader/JvmtiBackendReentrantTest.kt` | 新增 7 个防重入测试 |

---

## 测试

### BodiesClassGenerator 回归测试（8 个用例）

| 用例 | 覆盖点 |
|------|--------|
| 目标含 `<init>` 时跳过 body 生成，不产生 `<init>$body` | Bug 2 |
| `<init>` 与普通方法混合时仅普通方法生成 body | Bug 2 |
| 生成的 bodies 类可被 defineClass 加载，不抛 ClassFormatError | Bug 2（端到端校验） |
| body 中对 JvmtiBackend 的 INVOKESTATIC owner 为合法全斜杠内部名 | Bug 1 |
| 含 private 字段访问的 body 改写后整体可加载 | Bug 1（间接） |
| 静态方法作为目标被忽略 | 行为基线 |
| 空目标集合返回 null | 行为基线 |
| 普通实例方法正常生成 body 且类名为 `owner$$IncisionBodies` | 行为基线 |

### JvmtiBackend 防重入测试（7 个用例）

| 用例 | 验证内容 |
|------|----------|
| `onClassFileLoad invokes transformer normally` | 正常路径不受影响 |
| `onClassFileLoad returns null when no transformer registered` | 无 transformer 时返回 null |
| `reproduces recursive transformer hell - guard prevents StackOverflow` | **核心复现**：A→B→A 互相触发类加载形成递归地狱，防重入保护打断递归链 |
| `single class self-recursive transformer is prevented` | 单类自引用递归被拦截 |
| `deep recursive chain A-B-C-A is broken by guard` | 三层循环依赖 A→B→C→A 被打断 |
| `reentrant guard is per-thread and does not block other threads` | ThreadLocal 隔离，不影响其他线程 |
| `reentrant guard is cleared even if transformer throws` | 异常后标记正确清除 |

### 运行结果

```
./gradlew :module:incision:test
> JvmtiBackend 防重入保护            tests=7 failures=0
> BodiesClassGenerator 非法名回归    tests=8 failures=0
> 合计                               tests=15 failures=0
```

**有效性验证：**
- Bug 2 修复：临时回退后，3 个相关用例如期失败（`8 tests, 3 failed`）；恢复后全绿。
- Bug 3 修复：`reproduces recursive transformer hell` 用例无防重入时抛出 StackOverflowError；有保护后正常通过。

### 关于 Bug 1 测试的说明

Bug 1 的字符串损坏只在 **Shadow relocation 之后**（且长 group）才物理显现，纯单元测试环境无 relocation。因此 `jvmtiBackendOwnerIsValidInternalName` 校验的是**源码级不变量**：生成的 owner 必须是合法全斜杠内部名、不含点号。配合修复（值来自运行期 `Class.name`，relocation-safe），该不变量在重定位后依然成立。真正的端到端验证在宿主插件侧用真实 Paper 服务器完成（启动日志不再出现 ClassFormatError）。

---

## 兼容性 / 影响面

- 仅影响 side-car bodies 生成路径；对未触发该路径的目标无变化。
- 构造函数 / 静态初始化目标改走既有 `IncisionBridge.dispatch` 兜底，行为与之前「Bodies define 失败后回退」一致，但不再产生错误日志。
- 防重入保护仅影响 `JvmtiBackend` 后端（JVMTI native agent 模式）；`InstrumentationBackend` 不受影响。
- 不影响已有的 weave 功能，只是跳过了 weave 过程中因类加载触发的递归 transformer 调用。
- 无 API 变更，无配置变更。