### PR TITLE
fix(env): 启动主线程预热协程运行时，修复多插件共存时登录偶发 NoClassDefFoundError 崩溃

### DIFF
--- a/common-env/src/main/java/taboolib/common/env/RuntimeEnv.java
+++ b/common-env/src/main/java/taboolib/common/env/RuntimeEnv.java
@@ -2,6 +2,7 @@ package taboolib.common.env;
 
 import org.jetbrains.annotations.NotNull;
 import org.tabooproject.reflex.ReflexClass;
+import taboolib.common.ClassAppender;
 import taboolib.common.PrimitiveIO;
 import taboolib.common.PrimitiveSettings;
 import taboolib.common.TabooLib;
@@ -71,7 +72,61 @@ public class RuntimeEnv {
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }
+            // 在【启动主线程】预热协程运行时，规避其首次初始化落在 AsyncPlayerPreLogin 等敌对线程上导致的
+            // 非确定性崩溃（多 TabooLib 插件共存时偶发，详见 warmupKotlinCoroutines）。
+            if (!KOTLIN_COROUTINES_VERSION.equals("null")) {
+                warmupKotlinCoroutines();
+            }
         }));
+    }
+
+    /**
+     * 在【启动主线程】预热（强制初始化）协程运行时中那些「{@code <clinit>} 经 {@link java.util.ServiceLoader}
+     * 装配、对首次初始化所在线程 / 类加载器上下文敏感」的类。
+     *
+     * <h3>背景：为什么需要它</h3>
+     * 非隔离模式（默认）下，TabooLib 把 kotlinx-coroutines 重定位成版本键控的共享包
+     * （{@link PrimitiveSettings#getRelocatedKotlinCoroutinesVersion()}，如 {@code kotlin2120x.coroutines1101}）
+     * 加载进各插件的 PluginClassLoader；由于包名跨插件相同，Paper 的插件类加载器组会让它在多个 TabooLib 插件间
+     * 共享 / 首加载者定义。而 {@code Dispatchers} / {@code CoroutineExceptionHandler} 的首次初始化走 ServiceLoader，
+     * 一旦它**首次**被触发的线程是 Bukkit 的 {@code AsyncPlayerPreLogin}（"User Authenticator"）这类敌对线程
+     * （contextClassLoader 非插件 CL），初始化会非确定性失败（{@code NoClassDefFoundError}）并**永久毒化该共享类**，
+     * 使此后所有 TabooLib 插件的协程全部不可用。该问题仅在多个 TabooLib 插件共存时偶发，且极难排查。
+     *
+     * <h3>修复原理</h3>
+     * 在插件加载阶段（{@link #init()}，运行于启动主线程）就用 {@link Class#forName(String, boolean, ClassLoader)}
+     * 强制这些类完成首次初始化。JVM 保证类只初始化一次，之后任意线程再触碰都直接复用，不会再触发脆弱的首次初始化。
+     * 预热为尽力而为：任何失败都被吞掉，绝不影响插件正常加载。
+     */
+    private static void warmupKotlinCoroutines() {
+        try {
+            ClassLoader loader = ClassAppender.getClassLoader();
+            // 协程可能以「重定位包」(非隔离模式由 TabooLib 加载) 或「原始包」(隔离模式 / 服务端自带 / 其它来源) 存在；
+            // 两种包名都尝试，命中哪个就预热哪个，未命中的经 try/catch 无害空转。
+            warmupCoroutinePackage(loader, PrimitiveSettings.getRelocatedKotlinCoroutinesVersion());
+            warmupCoroutinePackage(loader, KOTLIN_COROUTINES_ID);
+            PrimitiveIO.debug("协程运行时已在启动线程 [{0}] 预热。", Thread.currentThread().getName());
+        } catch (Throwable ignored) {
+            // 预热为尽力而为，绝不因其失败而中断插件加载。
+        }
+    }
+
+    private static void warmupCoroutinePackage(ClassLoader loader, String pkg) {
+        // 这些类的 <clinit> 含 ServiceLoader / 对线程敏感，是历史登录崩溃的炸点；强制其在当前(启动主)线程初始化。
+        // 类名随协程版本可能有差异，逐个 try/catch（不存在则无害跳过）；其中 Dispatchers / CoroutineExceptionHandler 名称稳定。
+        String[] classes = {
+                pkg + ".Dispatchers",
+                pkg + ".CoroutineExceptionHandler",
+                pkg + ".internal.MainDispatcherLoader",
+                pkg + ".CoroutineExceptionHandlerImplKt",
+        };
+        for (String name : classes) {
+            try {
+                Class.forName(name, true, loader);
+            } catch (Throwable ignored) {
+                // 该类不存在（版本差异）或该包未加载，忽略。
+            }
+        }
     }
 
     public int inject(@NotNull ReflexClass clazz) throws Throwable {

--- a/common-env/src/main/java/taboolib/common/env/RuntimeEnv.java
+++ b/common-env/src/main/java/taboolib/common/env/RuntimeEnv.java
@@ -103,15 +103,18 @@ public class RuntimeEnv {
             ClassLoader loader = ClassAppender.getClassLoader();
             // 协程可能以「重定位包」(非隔离模式由 TabooLib 加载) 或「原始包」(隔离模式 / 服务端自带 / 其它来源) 存在；
             // 两种包名都尝试，命中哪个就预热哪个，未命中的经 try/catch 无害空转。
-            warmupCoroutinePackage(loader, PrimitiveSettings.getRelocatedKotlinCoroutinesVersion());
-            warmupCoroutinePackage(loader, KOTLIN_COROUTINES_ID);
-            PrimitiveIO.debug("协程运行时已在启动线程 [{0}] 预热。", Thread.currentThread().getName());
+            int warmed = 0;
+            warmed += warmupCoroutinePackage(loader, PrimitiveSettings.getRelocatedKotlinCoroutinesVersion());
+            warmed += warmupCoroutinePackage(loader, KOTLIN_COROUTINES_ID);
+            if (warmed > 0) {
+                PrimitiveIO.debug("协程运行时已在启动线程 [{0}] 预热 {1} 个类。", Thread.currentThread().getName(), warmed);
+            }
         } catch (Throwable ignored) {
             // 预热为尽力而为，绝不因其失败而中断插件加载。
         }
     }
 
-    private static void warmupCoroutinePackage(ClassLoader loader, String pkg) {
+    private static int warmupCoroutinePackage(ClassLoader loader, String pkg) {
         // 这些类的 <clinit> 含 ServiceLoader / 对线程敏感，是历史登录崩溃的炸点；强制其在当前(启动主)线程初始化。
         // 类名随协程版本可能有差异，逐个 try/catch（不存在则无害跳过）；其中 Dispatchers / CoroutineExceptionHandler 名称稳定。
         String[] classes = {
@@ -119,14 +122,18 @@ public class RuntimeEnv {
                 pkg + ".CoroutineExceptionHandler",
                 pkg + ".internal.MainDispatcherLoader",
                 pkg + ".CoroutineExceptionHandlerImplKt",
+                pkg + ".internal.CoroutineExceptionHandlerImplKt",
         };
+        int warmed = 0;
         for (String name : classes) {
             try {
                 Class.forName(name, true, loader);
+                warmed++;
             } catch (Throwable ignored) {
                 // 该类不存在（版本差异）或该包未加载，忽略。
             }
         }
+        return warmed;
     }
 
     public int inject(@NotNull ReflexClass clazz) throws Throwable {


### PR DESCRIPTION
## 问题

多个 TabooLib 插件共存时，玩家登录会**偶发**崩溃，且会拖垮**所有** TabooLib 插件的协程：

```
java.lang.NoClassDefFoundError: Could not initialize class <plugin>.ScopeManager
Caused by: java.lang.ExceptionInInitializerError:
  java.lang.NoClassDefFoundError: kotlin<ver>x.coroutines<ver>.CoroutineExceptionHandler
  [in thread "User Authenticator #0"]
```

特征：非确定性、仅多插件共存时出现、登录后每秒刷异常、整个数据层瘫痪。单插件 / 单元测试都复现不出。

## 根因

非隔离模式（默认）下，`RuntimeEnv` 把 `kotlinx-coroutines` 运行时下载、重定位成**版本键控的共享包**（`kotlin<ver>x.coroutines<ver>`）加载进**各插件的 PluginClassLoader**。由于包名跨插件完全相同，Paper 的插件类加载器组使其**跨插件共享、首加载者定义**。

而 `Dispatchers` / `CoroutineExceptionHandler` 的首次初始化走 `ServiceLoader`，对**首次初始化所在的线程 / 类加载器上下文**敏感。很多插件会在 `AsyncPlayerPreLogin`（Bukkit 的 "User Authenticator" 线程）做异步取数，于是该共享协程类的**首次初始化**可能落在这个敌对线程上 → 非确定性失败（`NoClassDefFoundError`）→ JVM **永久把该类标记为错误类** → 此后所有 TabooLib 插件的协程全废。

是否触发取决于"哪个插件、在哪个线程**第一个**触碰共享协程"——所以是非确定的、且只在多插件环境暴露（单插件时往往恰好先在安全线程初始化了）。

## 修复

`RuntimeEnv.init()`（插件加载阶段，运行于**启动主线程**）加载完协程后，立即用 `Class.forName(name, true, loader)` 强制这些"对线程敏感"的协程类在**主线程**完成首次初始化：

- `<coroutines>.Dispatchers`
- `<coroutines>.CoroutineExceptionHandler`
- `<coroutines>.internal.MainDispatcherLoader`
- `<coroutines>.CoroutineExceptionHandlerImplKt`

JVM 保证类只初始化一次，之后任意敌对线程再触碰都只复用，不再触发脆弱的首次初始化。重定位包与原始包名都尝试（兼容隔离 / 非隔离 / 服务端自带协程）；全程 `try/catch` 吞掉，**绝不影响插件加载**。

## 影响面

- 仅在声明了协程（`KOTLIN_COROUTINES_VERSION != null`）的插件生效。
- 不改变任何公开 API / 加载语义，无新增依赖。
- 预热失败完全静默回退（best-effort），零行为回归。

## 测试

- `gradlew publishToMavenLocal` 全模块构建通过。
- 用打补丁的框架重建插件、部署运行：调试日志确认 `warmupKotlinCoroutines()` 在 **`[Server thread]`（主线程）于加载阶段**执行，早于 enable 与任何玩家登录；插件正常启用，无回归。
- 崩溃本身为环境敏感的非确定 race（特定 Paper / JDK + 多插件版本组合），来自生产日志；修复后将该"脆弱首次初始化"确定性地移到安全线程，从原理上消除。
