### PR TITLE
fix(core): 修复异步任务与资源生命周期

### DIFF
--- a/common-env/src/main/java/taboolib/common/env/aether/AetherResolver.java
+++ b/common-env/src/main/java/taboolib/common/env/aether/AetherResolver.java
@@ -124,30 +124,38 @@ public class AetherResolver {
         String id = file.getParentFile().getParentFile().getPath()
                 + ":" + PrimitiveSettings.IS_ISOLATED_MODE // 区分类加载器 (隔离类加载器或插件类加载器)
                 + ":" + (relocation != null ? relocation.hashCode() : 0); // 区分不同的重定向规则
-        if (injectedDependencies.contains(id)) return null;
-        else injectedDependencies.add(id);
-        // 如果没有重定向规则，直接注入
-        if (relocation == null || relocation.isEmpty()) {
-            return ClassAppender.addPath(file.toPath(), PrimitiveSettings.IS_ISOLATED_MODE, isExternal);
-        } else {
-            // 获取重定向后的文件
-            String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
-            File rel = new File(file.getParentFile(), name + "_r2_" + Math.abs(relocation.hashCode()) + ".jar");
-            // 如果文件不存在或者文件大小为 0，就执行重定向逻辑
-            if (!rel.exists() || rel.length() == 0) {
-                try {
-                    // 获取重定向规则
-                    List<Relocation> rules = relocation.stream().map(JarRelocation::toRelocation).collect(Collectors.toList());
-                    // 获取临时文件
-                    File tempSourceFile = PrimitiveIO.copyFile(file, File.createTempFile(file.getName(), ".jar"));
-                    // 运行
-                    new JarRelocator(tempSourceFile, rel, rules).run();
-                } catch (IOException e) {
-                    throw new IllegalStateException(String.format("Unable to relocate %s%n", file), e);
+        if (!injectedDependencies.add(id)) return null;
+        try {
+            // 如果没有重定向规则，直接注入
+            if (relocation == null || relocation.isEmpty()) {
+                return ClassAppender.addPath(file.toPath(), PrimitiveSettings.IS_ISOLATED_MODE, isExternal);
+            } else {
+                // 获取重定向后的文件
+                String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
+                File rel = new File(file.getParentFile(), name + "_r2_" + Math.abs(relocation.hashCode()) + ".jar");
+                // 如果文件不存在或者文件大小为 0，就执行重定向逻辑
+                if (!rel.exists() || rel.length() == 0) {
+                    File tempSourceFile = File.createTempFile(file.getName(), ".jar");
+                    try {
+                        // 获取重定向规则
+                        List<Relocation> rules = relocation.stream().map(JarRelocation::toRelocation).collect(Collectors.toList());
+                        PrimitiveIO.copyFile(file, tempSourceFile);
+                        new JarRelocator(tempSourceFile, rel, rules).run();
+                    } catch (IOException e) {
+                        throw new IllegalStateException(String.format("Unable to relocate %s%n", file), e);
+                    } finally {
+                        if (!tempSourceFile.delete()) {
+                            tempSourceFile.deleteOnExit();
+                        }
+                    }
                 }
+                // 注入重定向后的文件
+                return ClassAppender.addPath(rel.toPath(), PrimitiveSettings.IS_ISOLATED_MODE, isExternal);
             }
-            // 注入重定向后的文件
-            return ClassAppender.addPath(rel.toPath(), PrimitiveSettings.IS_ISOLATED_MODE, isExternal);
+        } catch (Throwable ex) {
+            // 注入失败后允许后续调用重试，避免失败状态永久污染缓存。
+            injectedDependencies.remove(id);
+            throw ex;
         }
     }
 }

--- a/common-legacy-api/build.gradle.kts
+++ b/common-legacy-api/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     compileOnly(project(":common"))
     compileOnly(project(":common-env"))
+    testImplementation(project(":common"))
     compileOnly(project(":common-platform-api"))
     compileOnly(project(":common-util"))
 }

--- a/common-legacy-api/src/main/java/taboolib/common5/FileWatcher.java
+++ b/common-legacy-api/src/main/java/taboolib/common5/FileWatcher.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /**
@@ -50,6 +51,11 @@ public class FileWatcher {
      */
     private final WatchService watchService;
 
+    /**
+     * 监听器是否已经释放
+     */
+    private final AtomicBoolean released = new AtomicBoolean(false);
+
     public FileWatcher(int interval) {
         WatchService ws;
         try {
@@ -64,29 +70,41 @@ public class FileWatcher {
         this.watchService = ws;
         if (this.watchService != null) {
             this.executorService.scheduleAtFixedRate(() -> {
-                WatchKey key;
-                while ((key = watchService.poll()) != null) {
-                    WatchKey finalKey = key;
-                    key.pollEvents().forEach(event -> {
-                        if (event.context() instanceof Path) {
-                            Path changedPath = (Path) event.context();
-                            // 通过 WatchKey 获取监听的目录，构建完整路径
-                            Path watchedPath = (Path) finalKey.watchable();
-                            Path fullChangedPath = watchedPath.resolve(changedPath);
+                try {
+                    WatchKey key;
+                    while ((key = watchService.poll()) != null) {
+                        WatchKey finalKey = key;
+                        key.pollEvents().forEach(event -> {
+                            if (event.context() instanceof Path) {
+                                Path changedPath = (Path) event.context();
+                                // 通过 WatchKey 获取监听的目录，构建完整路径
+                                Path watchedPath = (Path) finalKey.watchable();
+                                Path fullChangedPath = watchedPath.resolve(changedPath).toAbsolutePath().normalize();
+                                fileListenerMap.forEach((file, listener) -> {
+                                    try {
+                                        listener.handleEvent(fullChangedPath);
+                                    } catch (Throwable ex) {
+                                        ex.printStackTrace();
+                                    }
+                                });
+                            }
+                        });
+                        if (!key.reset()) {
                             fileListenerMap.forEach((file, listener) -> {
-                                try {
-                                    listener.handleEvent(fullChangedPath);
-                                } catch (Throwable ex) {
-                                    ex.printStackTrace();
+                                if (listener.watchKey == finalKey) {
+                                    fileListenerMap.remove(file, listener);
                                 }
                             });
                         }
-                    });
-                    key.reset();
+                    }
+                } catch (ClosedWatchServiceException ignored) {
+                    // 正常释放时关闭 WatchService，会终止后续轮询
                 }
             }, 1000, interval, TimeUnit.MILLISECONDS);
             // 注册关闭回调
             TabooLib.registerLifeCycleTask(LifeCycle.DISABLE, 0, this::release);
+        } else {
+            this.executorService.shutdownNow();
         }
     }
 
@@ -108,14 +126,19 @@ public class FileWatcher {
      * @param runImmediately 是否在添加监听器时立即执行一次
      */
     public void addSimpleListener(File file, Consumer<File> runnable, boolean runImmediately) {
-        if (watchService == null) {
+        if (watchService == null || released.get()) {
             return;
         }
         if (runImmediately) {
             runnable.accept(file);
         }
         try {
-            fileListenerMap.put(file, new FileListener(file, runnable, this));
+            File canonicalFile = file.getCanonicalFile();
+            FileListener listener = new FileListener(canonicalFile, runnable, this);
+            FileListener previous = fileListenerMap.put(canonicalFile, listener);
+            if (previous != null) {
+                previous.cancel();
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -127,7 +150,13 @@ public class FileWatcher {
      * @param file 要移除监听的文件
      */
     public void removeListener(File file) {
-        FileListener listener = fileListenerMap.remove(file);
+        File canonicalFile;
+        try {
+            canonicalFile = file.getCanonicalFile();
+        } catch (IOException ignored) {
+            canonicalFile = file.getAbsoluteFile();
+        }
+        FileListener listener = fileListenerMap.remove(canonicalFile);
         if (listener != null) {
             listener.cancel();
         }
@@ -137,8 +166,18 @@ public class FileWatcher {
      * 释放资源
      */
     public void release() {
-        executorService.shutdown();
+        if (!released.compareAndSet(false, true)) {
+            return;
+        }
         fileListenerMap.values().forEach(FileListener::cancel);
+        fileListenerMap.clear();
+        if (watchService != null) {
+            try {
+                watchService.close();
+            } catch (IOException ignored) {
+            }
+        }
+        executorService.shutdownNow();
     }
 
     /**
@@ -170,29 +209,25 @@ public class FileWatcher {
         }
 
         public void handleEvent(Path fullChangedPath) {
+            Path watchedFile = file.toPath().toAbsolutePath().normalize();
+            Path changedFile = fullChangedPath.toAbsolutePath().normalize();
             // 监听目录
             if (file.isDirectory()) {
-                try {
-                    // 使用 relativize 检查路径关系，更加准确
-                    file.toPath().relativize(fullChangedPath);
-                    callback.accept(fullChangedPath.toFile());
-                } catch (IllegalArgumentException ignored) {
-                    // 如果不是子路径，会抛出异常，直接忽略
+                if (changedFile.startsWith(watchedFile)) {
+                    callback.accept(changedFile.toFile());
                 }
             }
-            // 监听文件
-            else if (isSameFile(fullChangedPath, file.toPath())) {
-                callback.accept(fullChangedPath.toFile());
+            // 监听文件。删除事件发生时目标文件已不存在，Files.isSameFile 会失败，
+            // 因此先比较规范化路径，再用 isSameFile 兼容符号链接。
+            else if (changedFile.equals(watchedFile) || isSameFile(changedFile, watchedFile)) {
+                callback.accept(changedFile.toFile());
             }
         }
 
         public boolean isSameFile(Path path1, Path path2) {
             try {
-                // 使用 Files.isSameFile() 判断两个路径是否指向同一个文件
-                // 该方法会考虑符号链接等情况
                 return Files.isSameFile(path1, path2);
             } catch (IOException e) {
-                // 如果出现 IO 异常则返回 false
                 return false;
             }
         }

--- a/common-legacy-api/src/test/kotlin/taboolib/common5/FileWatcherTest.kt
+++ b/common-legacy-api/src/test/kotlin/taboolib/common5/FileWatcherTest.kt
@@ -1,0 +1,36 @@
+package taboolib.common5
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class FileWatcherTest {
+
+    @TempDir
+    lateinit var tempDirectory: Path
+
+    @Test
+    fun `file deletion is reported and watcher can be released repeatedly`() {
+        val file = Files.write(tempDirectory.resolve("watched.txt"), byteArrayOf(1)).toFile()
+        val deleted = CountDownLatch(1)
+        val watcher = FileWatcher(20)
+        try {
+            watcher.addSimpleListener(file, { changed ->
+                if (changed.absoluteFile == file.absoluteFile && !changed.exists()) {
+                    deleted.countDown()
+                }
+            })
+            Files.delete(file.toPath())
+
+            assertTrue(deleted.await(5, TimeUnit.SECONDS))
+        } finally {
+            watcher.release()
+            watcher.release()
+            FileWatcher.INSTANCE.release()
+        }
+    }
+}

--- a/common-platform-api/src/main/kotlin/taboolib/common/util/SyncExecutor.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/util/SyncExecutor.kt
@@ -4,6 +4,14 @@ import taboolib.common.platform.function.isPrimaryThread
 import taboolib.common.platform.function.submit
 import java.util.concurrent.CompletableFuture
 
+internal fun <T> CompletableFuture<T>.completeWith(func: () -> T) {
+    try {
+        complete(func())
+    } catch (ex: Throwable) {
+        completeExceptionally(ex)
+    }
+}
+
 /**
  * 在异步线程执行一个同步任务，并等待其完成
  *
@@ -15,7 +23,7 @@ fun <T> sync(func: () -> T): T {
         error("Cannot run sync task in main thread.")
     }
     val future = CompletableFuture<T>()
-    submit { future.complete(func()) }
+    submit { future.completeWith(func) }
     return future.join()
 }
 
@@ -30,6 +38,6 @@ fun <T> runSync(func: () -> T): T {
         return func()
     }
     val future = CompletableFuture<T>()
-    submit { future.complete(func()) }
+    submit { future.completeWith(func) }
     return future.join()
 }

--- a/common-platform-api/src/test/kotlin/taboolib/common/util/SyncExecutorTest.kt
+++ b/common-platform-api/src/test/kotlin/taboolib/common/util/SyncExecutorTest.kt
@@ -1,0 +1,31 @@
+package taboolib.common.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+
+class SyncExecutorTest {
+
+    @Test
+    fun `completeWith completes successful result`() {
+        val future = CompletableFuture<Int>()
+
+        future.completeWith { 42 }
+
+        assertEquals(42, future.join())
+    }
+
+    @Test
+    fun `completeWith propagates task failure`() {
+        val future = CompletableFuture<Int>()
+        val failure = IllegalStateException("boom")
+
+        future.completeWith { throw failure }
+
+        val thrown = assertThrows<CompletionException> { future.join() }
+        assertSame(failure, thrown.cause)
+    }
+}

--- a/common-util/src/main/kotlin/taboolib/common/function/Throttle.kt
+++ b/common-util/src/main/kotlin/taboolib/common/function/Throttle.kt
@@ -2,6 +2,7 @@ package taboolib.common.function
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
 
 abstract class ThrottleFunction<K : Any>(
     val keyType: Class<K>,
@@ -22,11 +23,16 @@ abstract class ThrottleFunction<K : Any>(
      */
     open fun canExecute(key: K, delay: Long = this.delay): Boolean {
         val currentTime = System.currentTimeMillis()
-        val lastExecuteTime = throttleMap.getOrDefault(key, 0L)
-        return if (currentTime - lastExecuteTime >= delay) {
-            throttleMap[key] = currentTime
-            true
-        } else false
+        var allowed = false
+        throttleMap.compute(key) { _, lastExecuteTime ->
+            if (lastExecuteTime == null || delay <= 0 || currentTime < lastExecuteTime || currentTime - lastExecuteTime >= delay) {
+                allowed = true
+                currentTime
+            } else {
+                lastExecuteTime
+            }
+        }
+        return allowed
     }
 
     /**
@@ -56,7 +62,7 @@ abstract class ThrottleFunction<K : Any>(
         val action: () -> Unit,
     ) : ThrottleFunction<Unit>(Unit::class.java, delay) {
 
-        private var lastExecuteTime = 0L
+        private val lastExecuteTime = AtomicLong(Long.MIN_VALUE)
 
         fun canExecute(delay: Long = this.delay): Boolean {
             return canExecute(Unit, delay)
@@ -64,10 +70,15 @@ abstract class ThrottleFunction<K : Any>(
 
         override fun canExecute(key: Unit, delay: Long): Boolean {
             val currentTime = System.currentTimeMillis()
-            return if (currentTime - lastExecuteTime >= delay) {
-                lastExecuteTime = currentTime
-                true
-            } else false
+            while (true) {
+                val last = lastExecuteTime.get()
+                if (last != Long.MIN_VALUE && delay > 0 && currentTime >= last && currentTime - last < delay) {
+                    return false
+                }
+                if (lastExecuteTime.compareAndSet(last, currentTime)) {
+                    return true
+                }
+            }
         }
 
         /**

--- a/common-util/src/main/kotlin/taboolib/common/io/FileDeleteAsync.kt
+++ b/common-util/src/main/kotlin/taboolib/common/io/FileDeleteAsync.kt
@@ -1,10 +1,15 @@
 package taboolib.common.io
 
 import java.io.File
-import java.util.concurrent.Executors
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
-
-private val executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors())!!
 
 /**
  * Delete the directory and all its contents asynchronously.<br/>
@@ -15,27 +20,32 @@ private val executor = Executors.newFixedThreadPool(Runtime.getRuntime().availab
  * @author Kylepoops
  */
 fun File.deepDeleteAsync(await: Boolean = false, futures: MutableSet<Future<*>>? = null) {
-    // first submit the task and get the future
-    val future = executor.submit {
-        if (this.exists()) {
-            if (this.isDirectory) {
-                listFiles()?.let { files ->
-                    // Construct another future set here
-                    // Because we need all the subdirectories and files to be deleted before this directory is deleted
-                    val thisFutures = mutableSetOf<Future<*>>()
-                    // Pass the future set to this, so we can store all the future
-                    files.forEach { it.deepDeleteAsync(futures = thisFutures) }
-                    // Wait for all the subdirectories and files to be deleted
-                    thisFutures.forEach(Future<*>::get)
-                }
-            }
-            // Finally, delete this file or directory
-            this.delete()
-        }
-    }
-    // Add the future to the future set
+    // Traverse the whole tree in one asynchronous task. Submitting child tasks and waiting for them
+    // from the same bounded executor can exhaust every worker and deadlock on sufficiently deep trees.
+    val future = CompletableFuture.runAsync { deleteTree(toPath()) }
     futures?.add(future)
-    // Wait the task to finish before returning if await is true
-    // It shouldn't be called inside this function
-    if (await) future.get()
+    if (await) {
+        future.get()
+    }
+}
+
+private fun deleteTree(root: Path) {
+    if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+        return
+    }
+    Files.walkFileTree(root, object : SimpleFileVisitor<Path>() {
+
+        override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+            Files.deleteIfExists(file)
+            return FileVisitResult.CONTINUE
+        }
+
+        override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+            if (exc != null) {
+                throw exc
+            }
+            Files.deleteIfExists(dir)
+            return FileVisitResult.CONTINUE
+        }
+    })
 }

--- a/common-util/src/main/kotlin/taboolib/common/util/Random.kt
+++ b/common-util/src/main/kotlin/taboolib/common/util/Random.kt
@@ -18,7 +18,7 @@ fun random(): Random {
  * @param v 0-1
  */
 fun random(v: Double): Boolean {
-    return ThreadLocalRandom.current().nextDouble() <= v
+    return ThreadLocalRandom.current().nextDouble() < v
 }
 
 /**
@@ -37,9 +37,12 @@ fun random(v: Int): Int {
  * @param num2 最大值
  */
 fun random(num1: Int, num2: Int): Int {
-    val min = min(num1, num2)
-    val max = max(num1, num2)
-    return ThreadLocalRandom.current().nextInt(min, max + 1)
+    val min = min(num1, num2).toLong()
+    val max = max(num1, num2).toLong()
+    if (min == max) {
+        return min.toInt()
+    }
+    return ThreadLocalRandom.current().nextLong(min, max + 1).toInt()
 }
 
 /**

--- a/common-util/src/test/kotlin/taboolib/common/function/ThrottleTest.kt
+++ b/common-util/src/test/kotlin/taboolib/common/function/ThrottleTest.kt
@@ -1,0 +1,34 @@
+package taboolib.common.function
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ThrottleTest {
+
+    @Test
+    fun `first invocation is allowed for any delay`() {
+        val throttle = throttle(Long.MAX_VALUE)
+
+        assertTrue(throttle.canExecute())
+        assertFalse(throttle.canExecute())
+    }
+
+    @Test
+    fun `non-positive delay never suppresses invocation`() {
+        val throttle = throttle(0)
+
+        repeat(10) {
+            assertTrue(throttle.canExecute())
+        }
+    }
+
+    @Test
+    fun `keyed throttle treats each key independently`() {
+        val throttle = throttle<String>(Long.MAX_VALUE)
+
+        assertTrue(throttle.canExecute("first"))
+        assertFalse(throttle.canExecute("first"))
+        assertTrue(throttle.canExecute("second"))
+    }
+}

--- a/common-util/src/test/kotlin/taboolib/common/io/FileDeleteAsyncTest.kt
+++ b/common-util/src/test/kotlin/taboolib/common/io/FileDeleteAsyncTest.kt
@@ -1,0 +1,43 @@
+package taboolib.common.io
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Collections
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
+class FileDeleteAsyncTest {
+
+    @TempDir
+    lateinit var tempDirectory: Path
+
+    @Test
+    fun `large directory tree completes without executor starvation`() {
+        val root = Files.createDirectory(tempDirectory.resolve("root"))
+        val branchCount = maxOf(16, Runtime.getRuntime().availableProcessors() * 2)
+        repeat(branchCount) { index ->
+            val branch = Files.createDirectory(root.resolve("branch-$index"))
+            Files.write(branch.resolve("value.txt"), index.toString().toByteArray())
+        }
+        val futures = Collections.synchronizedSet(mutableSetOf<Future<*>>())
+
+        root.toFile().deepDeleteAsync(futures = futures)
+
+        futures.single().get(10, TimeUnit.SECONDS)
+        assertFalse(Files.exists(root))
+    }
+
+    @Test
+    fun `missing path is a successful no-op`() {
+        val missing = tempDirectory.resolve("missing").toFile()
+        val futures = mutableSetOf<Future<*>>()
+
+        missing.deepDeleteAsync(futures = futures)
+
+        futures.single().get(5, TimeUnit.SECONDS)
+        assertFalse(missing.exists())
+    }
+}

--- a/common-util/src/test/kotlin/taboolib/common/util/RandomTest.kt
+++ b/common-util/src/test/kotlin/taboolib/common/util/RandomTest.kt
@@ -1,0 +1,37 @@
+package taboolib.common.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RandomTest {
+
+    @Test
+    fun `zero probability is always false`() {
+        repeat(10_000) {
+            assertFalse(random(0.0))
+        }
+    }
+
+    @Test
+    fun `probability at least one is always true`() {
+        repeat(100) {
+            assertTrue(random(1.0))
+            assertTrue(random(Double.POSITIVE_INFINITY))
+        }
+    }
+
+    @Test
+    fun `inclusive int range supports full integer domain`() {
+        repeat(10_000) {
+            val value = random(Int.MIN_VALUE, Int.MAX_VALUE)
+            assertTrue(value in Int.MIN_VALUE..Int.MAX_VALUE)
+        }
+    }
+
+    @Test
+    fun `equal maximum bounds return maximum value`() {
+        assertEquals(Int.MAX_VALUE, random(Int.MAX_VALUE, Int.MAX_VALUE))
+    }
+}

--- a/common/src/main/java/taboolib/common/PrimitiveIO.java
+++ b/common/src/main/java/taboolib/common/PrimitiveIO.java
@@ -225,16 +225,20 @@ public class PrimitiveIO {
      * @param url 地址
      * @param out 目标文件
      */
-    @SuppressWarnings("StatementWithEmptyBody")
     public static void downloadFile(URL url, File out) throws IOException {
-        out.getParentFile().mkdirs();
-        InputStream ins = url.openStream();
-        OutputStream outs = Files.newOutputStream(out.toPath());
-        byte[] buffer = new byte[BUFFER_SIZE];
-        for (int len; (len = ins.read(buffer)) > 0; outs.write(buffer, 0, len))
-            ;
-        outs.close();
-        ins.close();
+        File parent = out.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        try (InputStream input = url.openStream(); OutputStream output = Files.newOutputStream(out.toPath())) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int length;
+            while ((length = input.read(buffer)) != -1) {
+                if (length > 0) {
+                    output.write(buffer, 0, length);
+                }
+            }
+        }
     }
 
     public static String getRunningFileName() {

--- a/common/src/main/java/taboolib/common/PrimitiveLoader.java
+++ b/common/src/main/java/taboolib/common/PrimitiveLoader.java
@@ -242,12 +242,18 @@ public class PrimitiveLoader {
             String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
             jar = new File(getCacheFile(), name + "-" + hash.substring(0, 8) + ".jar");
             // 文件为空 || 开发模式 || 强制重定向
-            if ((!jar.exists() && jar.length() == 0) || (IS_FORCE_DOWNLOAD_IN_DEV_MODE && IS_DEV_MODE) || forceRelocate) {
+            if (shouldRelocate(jar, forceRelocate)) {
                 jar.getParentFile().mkdirs();
+                File tempSourceFile = File.createTempFile(file.getName(), ".jar");
                 try {
-                    new JarRelocator(PrimitiveIO.copyFile(file, File.createTempFile(file.getName(), ".jar")), jar, rel).run();
+                    PrimitiveIO.copyFile(file, tempSourceFile);
+                    new JarRelocator(tempSourceFile, jar, rel).run();
                 } catch (Throwable e) {
                     throw new RuntimeException(t("无法重定向 " + file, "Failed to relocate " + file), e);
+                } finally {
+                    if (!tempSourceFile.delete()) {
+                        tempSourceFile.deleteOnExit();
+                    }
                 }
             }
         }
@@ -258,7 +264,9 @@ public class PrimitiveLoader {
             if (extra != null) {
                 PrimitiveIO.debug("从 {0} 中加载 extra.properties 配置", jar.getName());
                 Properties extraProps = new Properties();
-                extraProps.load(jarFile.getInputStream(extra));
+                try (java.io.InputStream input = jarFile.getInputStream(extra)) {
+                    extraProps.load(input);
+                }
                 // 获取主类
                 String main = extraProps.getProperty("main");
                 String mainMethod = extraProps.getProperty("main-method");
@@ -308,10 +316,12 @@ public class PrimitiveLoader {
         try {
             String metadataUrl = String.format("%s/%s/%s/%s/maven-metadata.xml",
                     repo, group.replace(".", "/"), name, version);
-            java.io.InputStream ins = new URL(metadataUrl).openStream();
+            org.w3c.dom.Document doc;
             javax.xml.parsers.DocumentBuilderFactory factory = javax.xml.parsers.DocumentBuilderFactory.newInstance();
             javax.xml.parsers.DocumentBuilder builder = factory.newDocumentBuilder();
-            org.w3c.dom.Document doc = builder.parse(ins);
+            try (java.io.InputStream input = new URL(metadataUrl).openStream()) {
+                doc = builder.parse(input);
+            }
             org.w3c.dom.NodeList timestampNodes = doc.getElementsByTagName("timestamp");
             org.w3c.dom.NodeList buildNumberNodes = doc.getElementsByTagName("buildNumber");
             if (timestampNodes.getLength() > 0 && buildNumberNodes.getLength() > 0) {
@@ -341,6 +351,10 @@ public class PrimitiveLoader {
         } catch (IOException e) {
             PrimitiveIO.debug("无法生成 {0}，将用 jar 自行生成。", shaFile.getName());
         }
+    }
+
+    static boolean shouldRelocate(File jar, boolean forceRelocate) {
+        return !jar.exists() || jar.length() == 0 || (IS_FORCE_DOWNLOAD_IN_DEV_MODE && IS_DEV_MODE) || forceRelocate;
     }
 
     static int deepHashCode(List<String[]> array) {

--- a/common/src/test/kotlin/taboolib/common/PrimitiveIOTest.kt
+++ b/common/src/test/kotlin/taboolib/common/PrimitiveIOTest.kt
@@ -1,0 +1,65 @@
+package taboolib.common
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PrimitiveIOTest {
+
+    @TempDir
+    lateinit var tempDirectory: Path
+
+    @Test
+    fun `download closes input after success`() {
+        val content = "taboolib".toByteArray()
+        val input = TrackingInputStream(content)
+        val target = tempDirectory.resolve("download.bin").toFile()
+
+        PrimitiveIO.downloadFile(memoryUrl(input), target)
+
+        assertTrue(input.closed)
+        assertArrayEquals(content, Files.readAllBytes(target.toPath()))
+    }
+
+    @Test
+    fun `download closes input when output cannot be opened`() {
+        val input = TrackingInputStream("taboolib".toByteArray())
+        val targetDirectory = Files.createDirectory(tempDirectory.resolve("target")).toFile()
+
+        assertThrows<IOException> {
+            PrimitiveIO.downloadFile(memoryUrl(input), targetDirectory)
+        }
+        assertTrue(input.closed)
+    }
+
+    private fun memoryUrl(input: TrackingInputStream): URL {
+        return URL(null, "memory://download", object : URLStreamHandler() {
+            override fun openConnection(url: URL): URLConnection {
+                return object : URLConnection(url) {
+                    override fun connect() = Unit
+                    override fun getInputStream() = input
+                }
+            }
+        })
+    }
+
+    private class TrackingInputStream(content: ByteArray) : ByteArrayInputStream(content) {
+
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+}

--- a/common/src/test/kotlin/taboolib/common/PrimitiveLoaderTest.kt
+++ b/common/src/test/kotlin/taboolib/common/PrimitiveLoaderTest.kt
@@ -1,0 +1,22 @@
+package taboolib.common
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PrimitiveLoaderTest {
+
+    @TempDir
+    lateinit var tempDirectory: Path
+
+    @Test
+    fun `missing and empty relocation targets are regenerated`() {
+        val missing = tempDirectory.resolve("missing.jar").toFile()
+        val empty = Files.createFile(tempDirectory.resolve("empty.jar")).toFile()
+
+        assertTrue(PrimitiveLoader.shouldRelocate(missing, false))
+        assertTrue(PrimitiveLoader.shouldRelocate(empty, false))
+    }
+}


### PR DESCRIPTION
## 原有问题

核心异步与资源工具中存在多条“任务已经失败，但调用方永远等不到终态”的路径：

- `SyncExecutor` 包装的平台任务一旦抛出异常，异常只会逃逸到调度器，返回的 `CompletableFuture` 不会成功也不会异常完成。
- 异步递归删除会在同一个有界线程池中继续提交子任务并等待结果，深层目录下可能出现线程池自等待；调用结束后执行器也可能长期存活。
- 文件监听器、WatchService、下载流、Jar 输入流和重定位临时文件在异常或重复关闭路径中没有统一释放。
- `Throttle` 的首次调用、零延迟参数以及完整 `Int` 随机区间存在边界计算错误。

## 典型触发场景与后果

- 插件通过 Future 等待同步线程任务，而任务内部抛错：Future 永久 pending，后续加载、命令或脚本流程一直卡住。
- 删除层级较深、文件较多的目录：工作线程互相等待，删除任务死锁；反复调用还可能积累后台线程。
- Windows 上反复热重载、监听配置或下载依赖：未关闭的流和 WatchService 会锁住文件、占用句柄，导致更新、删除失败。
- 使用零节流时间或完整整数范围生成随机数：出现首次调用被错误拦截、溢出或范围不完整。

## 本 PR 修改

- 捕获同步调度任务中的所有异常，并让 Future 以 `completeExceptionally` 收敛；成功、失败和取消都只能完成一次。
- 将递归删除改为单个根任务内遍历整棵目录树，不再让父子任务在同一有界线程池中互相等待，并明确关闭执行器。
- 为文件监听、依赖解析、Jar 读取和临时文件增加幂等关闭及失败清理。
- 修复空重定位缓存、Throttle 首次/零延迟语义和完整 `Int` 随机区间计算。
- 增加 Future、目录树、Watcher、资源关闭、节流和随机边界回归测试。

## 修改目的

确保基础工具在成功、异常、取消和关闭路径上都能得到确定终态，避免永久等待、线程泄漏、文件句柄泄漏和边界输入错误向上层模块扩散。

## 兼容性与行为变化

- 不修改公开方法签名。
- 原本“静默挂起”的任务现在会通过 Future 明确返回异常。
- `deepDeleteAsync` 的 `futures` 集合记录整棵树对应的根任务，不再暴露内部递归子任务。

## 验证

- [x] `./gradlew :common:build :common-env:build :common-util:build :common-platform-api:build :common-legacy-api:build --rerun-tasks --no-parallel`
- [x] `./gradlew :common:test :common-env:build :common-util:test :common-platform-api:test :common-legacy-api:test --rerun-tasks --no-parallel`
- [x] `git diff --check`

Refs #703