### PR TITLE
fix(submit-chain): 完善异常与取消传播

### DIFF
--- a/module/basic/basic-submit-chain/build.gradle.kts
+++ b/module/basic/basic-submit-chain/build.gradle.kts
@@ -1,4 +1,6 @@
 dependencies {
     compileOnly(project(":common"))
     compileOnly(project(":common-platform-api"))
+    testImplementation(project(":common"))
+    testImplementation(project(":common-platform-api"))
 }

--- a/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/AsynchronousRepeatChain.kt
+++ b/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/AsynchronousRepeatChain.kt
@@ -1,8 +1,6 @@
 package taboolib.expansion
 
 import taboolib.common.platform.function.submit
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 class AsynchronousRepeatChain<T>(
     override val block: Cancellable.() -> T,
@@ -12,15 +10,8 @@ class AsynchronousRepeatChain<T>(
 ) : RepeatChainable<T> {
 
     override suspend fun execute(): T {
-        return suspendCoroutine { cont ->
-            val cancellable = Cancellable()
-            submit(async = true, period = period, now = now, delay = delay) {
-                val result = cancellable.call(block)
-                if (cancellable.cancelled) {
-                    cancel()
-                    cont.resume(result)
-                }
-            }
+        return executeRepeat(block) { executor ->
+            submit(async = true, period = period, now = now, delay = delay, executor = executor)
         }
     }
 }

--- a/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/Chain.kt
+++ b/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/Chain.kt
@@ -70,10 +70,30 @@ open class Chain<R>(val chain: suspend Chain<R>.() -> R) {
     }
 
     fun run(type: DispatcherType): CompletableFuture<R> {
+        return run(
+            when (type) {
+                SYNC -> SyncDispatcher
+                ASYNC -> AsyncDispatcher
+            }
+        )
+    }
+
+    internal fun run(dispatcher: CoroutineDispatcher): CompletableFuture<R> {
         val future = CompletableFuture<R>()
-        when (type) {
-            SYNC -> CoroutineScope(SyncDispatcher).launch { future.complete(chain(this@Chain)) }
-            ASYNC -> CoroutineScope(AsyncDispatcher).launch { future.complete(chain(this@Chain)) }
+        val task = CoroutineScope(dispatcher).async {
+            future.complete(chain(this@Chain))
+        }
+        task.invokeOnCompletion { cause ->
+            when (cause) {
+                null -> Unit
+                is CancellationException -> future.cancel(false)
+                else -> future.completeExceptionally(cause)
+            }
+        }
+        future.whenComplete { _, _ ->
+            if (future.isCancelled) {
+                task.cancel()
+            }
         }
         return future
     }

--- a/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/RepeatChainable.kt
+++ b/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/RepeatChainable.kt
@@ -1,8 +1,55 @@
 package taboolib.expansion
 
+import kotlinx.coroutines.suspendCancellableCoroutine
+import taboolib.common.platform.service.PlatformExecutor
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
 interface RepeatChainable<T> {
 
     val block: Cancellable.() -> T
 
     suspend fun execute(): T
+}
+
+internal suspend fun <T> executeRepeat(
+    block: Cancellable.() -> T,
+    submitTask: (PlatformExecutor.PlatformTask.() -> Unit) -> PlatformExecutor.PlatformTask,
+): T {
+    return suspendCancellableCoroutine { continuation ->
+        val taskReference = AtomicReference<PlatformExecutor.PlatformTask?>()
+        val completed = AtomicBoolean(false)
+        val cancellable = Cancellable()
+        continuation.invokeOnCancellation {
+            completed.set(true)
+            taskReference.get()?.cancel()
+        }
+        val task = try {
+            submitTask {
+                try {
+                    val result = cancellable.call(block)
+                    if (cancellable.cancelled && completed.compareAndSet(false, true)) {
+                        cancel()
+                        continuation.resume(result)
+                    }
+                } catch (ex: Throwable) {
+                    cancel()
+                    if (completed.compareAndSet(false, true)) {
+                        continuation.resumeWithException(ex)
+                    }
+                }
+            }
+        } catch (ex: Throwable) {
+            if (completed.compareAndSet(false, true)) {
+                continuation.resumeWithException(ex)
+            }
+            return@suspendCancellableCoroutine
+        }
+        taskReference.set(task)
+        if (completed.get()) {
+            task.cancel()
+        }
+    }
 }

--- a/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/SynchronousRepeatChain.kt
+++ b/module/basic/basic-submit-chain/src/main/kotlin/taboolib/expansion/SynchronousRepeatChain.kt
@@ -1,8 +1,6 @@
 package taboolib.expansion
 
 import taboolib.common.platform.function.submit
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 class SynchronousRepeatChain<T>(
     override val block: Cancellable.() -> T,
@@ -12,15 +10,8 @@ class SynchronousRepeatChain<T>(
 ) : RepeatChainable<T> {
 
     override suspend fun execute(): T {
-        return suspendCoroutine { cont ->
-            val cancellable = Cancellable()
-            submit(period = period, now = now, delay = delay) {
-                val result = cancellable.call(block)
-                if (cancellable.cancelled) {
-                    cont.resume(result)
-                    cancel()
-                }
-            }
+        return executeRepeat(block) { executor ->
+            submit(period = period, now = now, delay = delay, executor = executor)
         }
     }
 }

--- a/module/basic/basic-submit-chain/src/test/kotlin/taboolib/expansion/ChainTest.kt
+++ b/module/basic/basic-submit-chain/src/test/kotlin/taboolib/expansion/ChainTest.kt
@@ -1,0 +1,53 @@
+package taboolib.expansion
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CompletionException
+
+class ChainTest {
+
+    @Test
+    fun `successful chain completes future`() {
+        val future = Chain { 42 }.run(Dispatchers.Unconfined)
+
+        assertEquals(42, future.join())
+    }
+
+    @Test
+    fun `failed chain completes future exceptionally`() {
+        val failure = IllegalStateException("boom")
+        val future = Chain<Int> { throw failure }.run(Dispatchers.Unconfined)
+
+        val thrown = assertThrows<CompletionException> { future.join() }
+        assertSame(failure, thrown.cause)
+    }
+
+    @Test
+    fun `future cancellation cancels running chain`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val stopped = CompletableDeferred<Unit>()
+        val future = Chain<Int> {
+            try {
+                started.complete(Unit)
+                awaitCancellation()
+            } finally {
+                stopped.complete(Unit)
+            }
+        }.run(Dispatchers.Default)
+
+        started.await()
+        assertTrue(future.cancel(false))
+        withTimeout(5_000) {
+            stopped.await()
+        }
+        assertTrue(future.isCancelled)
+    }
+}

--- a/module/basic/basic-submit-chain/src/test/kotlin/taboolib/expansion/RepeatChainTest.kt
+++ b/module/basic/basic-submit-chain/src/test/kotlin/taboolib/expansion/RepeatChainTest.kt
@@ -1,0 +1,83 @@
+package taboolib.expansion
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import taboolib.common.platform.service.PlatformExecutor
+
+class RepeatChainTest {
+
+    @Test
+    fun `repeat chain resumes when block cancels itself`() = runBlocking {
+        val task = TestTask()
+
+        val result = executeRepeat({
+            cancel()
+            42
+        }) { executor ->
+            task.executor()
+            task
+        }
+
+        assertEquals(42, result)
+        assertTrue(task.cancelled)
+    }
+
+    @Test
+    fun `repeat chain propagates callback failure`() {
+        val failure = IllegalStateException("boom")
+        val task = TestTask()
+
+        val thrown = assertThrows<IllegalStateException> {
+            runBlocking {
+                executeRepeat<Int>({ throw failure }) { executor ->
+                    task.executor()
+                    task
+                }
+            }
+        }
+
+        assertTrue(thrown === failure || thrown.cause === failure)
+        assertTrue(task.cancelled)
+    }
+
+    @Test
+    fun `coroutine cancellation cancels scheduled task`() = runBlocking {
+        val task = TestTask()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            executeRepeat({ Unit }) { task }
+        }
+
+        job.cancelAndJoin()
+
+        assertTrue(task.cancelled)
+    }
+
+    @Test
+    fun `scheduler submission failure is propagated`() {
+        val failure = IllegalStateException("scheduler unavailable")
+
+        val thrown = assertThrows<IllegalStateException> {
+            runBlocking {
+                executeRepeat({ Unit }) { throw failure }
+            }
+        }
+
+        assertTrue(thrown === failure || thrown.cause === failure)
+    }
+
+    private class TestTask : PlatformExecutor.PlatformTask {
+
+        var cancelled = false
+            private set
+
+        override fun cancel() {
+            cancelled = true
+        }
+    }
+}


### PR DESCRIPTION
## 原有问题

Submit Chain 对协程、平台调度任务和 `CompletableFuture` 的完成状态桥接不完整：

- 链节点或回调抛出异常时，协程可能已经失败，但对外 Future 仍保持 pending。
- 调用方取消 Future 时，正在运行的协程和重复调度任务不会同步停止。
- 同步/异步重复链在回调异常、调度提交失败或插件关闭时，存在 continuation 不恢复、平台任务继续运行的问题。

## 典型触发场景与后果

- 命令、表单或业务流程中的任意链节点抛错：后续逻辑不执行，但调用方也收不到失败，表现为操作永久无响应。
- 外部超时后取消 Chain 返回的 Future：内部任务仍继续修改状态或重复执行，形成幽灵任务。
- 插件禁用时调度器拒绝新任务，或重复链某一轮回调抛错：协程可能永久挂起，重复任务和引用无法释放。

## 本 PR 修改

- 使用可取消协程任务桥接 `CompletableFuture`，链执行失败时让 Future 异常完成。
- 将外部 Future 取消反向传播到正在运行的 Chain 协程。
- 将同步和异步重复链统一为 `suspendCancellableCoroutine` 完成模型。
- 在回调或调度提交抛错时取消已创建的平台任务并恢复异常；协程取消时同步停止重复任务。
- 增加正常完成、节点异常、外部取消、重复回调异常和调度失败测试。

## 修改目的

让 Chain 的成功、异常和取消语义保持一致，调用方始终能观察到最终结果，并确保取消后不再有后台任务继续执行。

## 兼容性与行为变化

- 不修改公开方法签名。
- 原本可能永久等待的失败链现在会明确异常完成。
- 取消 Chain 返回的 Future 会真正停止对应协程及重复平台任务。

## 验证

- [x] `./gradlew :module:basic:basic-submit-chain:test --rerun-tasks --no-parallel`
- [x] `./gradlew :module:basic:basic-submit-chain:build --rerun-tasks --no-parallel`
- [x] `git diff --check`

Refs #703