### PR TITLE
fix(kether): 修复异步上下文完成与线程切换

### DIFF
--- a/module/minecraft/minecraft-kether/build.gradle.kts
+++ b/module/minecraft/minecraft-kether/build.gradle.kts
@@ -4,8 +4,10 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 dependencies {
     compileOnly(project(":common"))
+    testImplementation(project(":common"))
     compileOnly(project(":common-env"))
     compileOnly(project(":common-util"))
+    testImplementation(project(":common-util"))
     compileOnly(project(":common-legacy-api"))
     compileOnly(project(":common-platform-api"))
     compileOnly(project(":module:minecraft:minecraft-chat"))

--- a/module/minecraft/minecraft-kether/src/main/java/taboolib/library/kether/AbstractQuestContext.java
+++ b/module/minecraft/minecraft-kether/src/main/java/taboolib/library/kether/AbstractQuestContext.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -15,8 +16,8 @@ public abstract class AbstractQuestContext<T extends AbstractQuestContext<T>> im
     protected final Frame rootFrame;
     protected final Quest quest;
     protected final QuestExecutor executor;
-    protected ExitStatus exitStatus;
-    protected CompletableFuture<Object> future;
+    protected volatile ExitStatus exitStatus;
+    protected volatile CompletableFuture<Object> future;
 
     protected AbstractQuestContext(QuestService<T> service, Quest quest, String playerIdentifier) {
         this.service = service;
@@ -61,22 +62,47 @@ public abstract class AbstractQuestContext<T extends AbstractQuestContext<T>> im
     }
 
     @Override
-    public CompletableFuture<Object> runActions() {
+    public synchronized CompletableFuture<Object> runActions() {
         Preconditions.checkState(future == null, "already running");
-        return future = rootFrame.run().thenApply(o -> {
-            if (this.exitStatus == null) {
-                this.exitStatus = ExitStatus.success();
+        CompletableFuture<Object> frameFuture = rootFrame.run();
+        CompletableFuture<Object> contextFuture = new CompletableFuture<>();
+        frameFuture.whenComplete((result, ex) -> {
+            if (ex != null) {
+                completeFailure(contextFuture, ex);
+            } else {
+                if (this.exitStatus == null) {
+                    this.exitStatus = ExitStatus.success();
+                }
+                contextFuture.complete(result);
             }
-            return o;
         });
+        contextFuture.whenComplete((result, ex) -> {
+            if (contextFuture.isCancelled()) {
+                frameFuture.cancel(false);
+            }
+        });
+        this.future = contextFuture;
+        return contextFuture;
     }
 
     @Override
-    public void terminate() {
+    public synchronized void terminate() {
         this.rootFrame.close();
         if (future != null) {
             future.completeExceptionally(new QuestCloseException());
             future = null;
+        }
+    }
+
+    private static void completeFailure(CompletableFuture<?> future, Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause instanceof CompletionException && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        if (cause instanceof CancellationException) {
+            future.cancel(false);
+        } else {
+            future.completeExceptionally(cause);
         }
     }
 
@@ -104,7 +130,7 @@ public abstract class AbstractQuestContext<T extends AbstractQuestContext<T>> im
         protected final List<Frame> frames;
         protected final VarTable varTable;
         protected final QuestContext questContext;
-        protected CompletableFuture<?> future;
+        protected volatile CompletableFuture<?> future;
         protected final Deque<AutoCloseable> closeables = new LinkedBlockingDeque<>();
 
         public AbstractFrame(Frame parent, List<Frame> frames, VarTable varTable, QuestContext questContext) {
@@ -162,12 +188,14 @@ public abstract class AbstractQuestContext<T extends AbstractQuestContext<T>> im
 
         @Override
         public void close() {
-            if (this.future == null) return;
+            CompletableFuture<?> runningFuture = this.future;
+            if (runningFuture == null) return;
+            this.future = null;
             for (Frame frame : this.frames) {
                 frame.close();
             }
             this.cleanup();
-            this.future = null;
+            runningFuture.completeExceptionally(new QuestCloseException());
         }
 
         @Override
@@ -191,6 +219,7 @@ public abstract class AbstractQuestContext<T extends AbstractQuestContext<T>> im
         private final String name;
         private Quest.Block block, next;
         private int sp = -1, np = -1;
+        private volatile CompletableFuture<?> runningAction;
 
         public SimpleNamedFrame(Frame parent, List<Frame> frames, VarTable varTable, String name, QuestContext questContext) {
             super(parent, frames, varTable, questContext);
@@ -236,35 +265,99 @@ public abstract class AbstractQuestContext<T extends AbstractQuestContext<T>> im
         }
 
         @Override
+        public synchronized void close() {
+            CompletableFuture<?> actionFuture = this.runningAction;
+            this.runningAction = null;
+            super.close();
+            if (actionFuture != null) {
+                actionFuture.cancel(false);
+            }
+        }
+
+        @Override
         @SuppressWarnings("unchecked")
-        public <T> CompletableFuture<T> run() {
+        public synchronized <T> CompletableFuture<T> run() {
             Preconditions.checkState(this.future == null, "already running");
             varTable.initialize(this);
             future = new CompletableFuture<>();
-            process(future);
-            return (CompletableFuture<T>) future;
+            CompletableFuture<?> resultFuture = future;
+            resultFuture.whenComplete((result, ex) -> {
+                if (resultFuture.isCancelled()) {
+                    this.close();
+                }
+            });
+            process(null);
+            return (CompletableFuture<T>) resultFuture;
         }
 
-        @SuppressWarnings("unchecked")
-        private void process(CompletableFuture<?> future) {
+        private synchronized void process(CompletableFuture<?> previousFuture) {
+            CompletableFuture<?> resultFuture = this.future;
+            if (resultFuture == null || resultFuture.isDone()) {
+                return;
+            }
             while (!context().getExitStatus().isPresent()) {
                 this.cleanup();
                 this.frames.removeIf(Frame::isDone);
                 Optional<? extends ParsedAction<?>> optional = nextAction();
-                if (optional.isPresent()) {
-                    ParsedAction<?> action = optional.get();
-                    CompletableFuture<?> newFuture = action.process(this);
-                    if (!newFuture.isDone()) {
-                        newFuture.thenRun(() -> this.process(newFuture));
-                        return;
-                    } else {
-                        future = newFuture;
-                    }
-                } else {
-                    ((CompletableFuture<Object>) this.future).complete(future != null && future.isDone() ? future.join() : null);
+                if (!optional.isPresent()) {
+                    completeResult(resultFuture, previousFuture);
                     return;
                 }
+                ParsedAction<?> action = optional.get();
+                CompletableFuture<?> actionFuture;
+                try {
+                    actionFuture = Objects.requireNonNull(action.process(this), "Quest action returned null future: " + action);
+                } catch (Throwable ex) {
+                    fail(resultFuture, ex);
+                    return;
+                }
+                this.runningAction = actionFuture;
+                if (!actionFuture.isDone()) {
+                    actionFuture.whenComplete((result, ex) -> resume(resultFuture, actionFuture, ex));
+                    return;
+                }
+                this.runningAction = null;
+                if (actionFuture.isCancelled()) {
+                    resultFuture.cancel(false);
+                    return;
+                }
+                try {
+                    actionFuture.join();
+                } catch (Throwable ex) {
+                    fail(resultFuture, ex);
+                    return;
+                }
+                previousFuture = actionFuture;
             }
+            this.cleanup();
+            this.frames.removeIf(Frame::isDone);
+            completeResult(resultFuture, previousFuture);
+        }
+
+        private synchronized void resume(CompletableFuture<?> resultFuture, CompletableFuture<?> actionFuture, Throwable throwable) {
+            if (this.runningAction == actionFuture) {
+                this.runningAction = null;
+            }
+            if (this.future != resultFuture || resultFuture.isDone()) {
+                return;
+            }
+            if (throwable != null) {
+                fail(resultFuture, throwable);
+            } else {
+                process(actionFuture);
+            }
+        }
+
+        private void fail(CompletableFuture<?> resultFuture, Throwable throwable) {
+            this.cleanup();
+            this.frames.removeIf(Frame::isDone);
+            completeFailure(resultFuture, throwable);
+        }
+
+        @SuppressWarnings("unchecked")
+        private void completeResult(CompletableFuture<?> resultFuture, CompletableFuture<?> previousFuture) {
+            Object result = previousFuture != null ? previousFuture.getNow(null) : null;
+            ((CompletableFuture<Object>) resultFuture).complete(result);
         }
 
         private Optional<? extends ParsedAction<?>> nextAction() {
@@ -309,10 +402,17 @@ public abstract class AbstractQuestContext<T extends AbstractQuestContext<T>> im
 
         @Override
         @SuppressWarnings("unchecked")
-        public <T> CompletableFuture<T> run() {
+        public synchronized <T> CompletableFuture<T> run() {
             Preconditions.checkState(this.future == null, "already running");
             this.varTable.initialize(this);
-            return (CompletableFuture<T>) (this.future = this.action.process(this));
+            try {
+                this.future = Objects.requireNonNull(this.action.process(this), "Quest action returned null future: " + action);
+            } catch (Throwable ex) {
+                CompletableFuture<Object> failed = new CompletableFuture<>();
+                completeFailure(failed, ex);
+                this.future = failed;
+            }
+            return (CompletableFuture<T>) this.future;
         }
     }
 

--- a/module/minecraft/minecraft-kether/src/main/kotlin/taboolib/module/kether/RemoteQuestReader.kt
+++ b/module/minecraft/minecraft-kether/src/main/kotlin/taboolib/module/kether/RemoteQuestReader.kt
@@ -12,44 +12,54 @@ import taboolib.library.kether.QuestReader
 @Suppress("UNCHECKED_CAST")
 class RemoteQuestReader(val remote: OpenContainer, val source: Any) : QuestReader {
 
+    @Synchronized
     override fun peek(): Char {
         return source.invokeMethod("peek", remap = false)!!
     }
 
+    @Synchronized
     override fun peek(n: Int): Char {
         return peekIntMethod[source].invoke(source, n) as Char
     }
 
+    @Synchronized
     override fun getIndex(): Int {
         return source.invokeMethod("getIndex", remap = false)!!
     }
 
+    @Synchronized
     override fun getMark(): Int {
         return source.invokeMethod("getMark", remap = false)!!
     }
 
+    @Synchronized
     override fun hasNext(): Boolean {
         return source.invokeMethod("hasNext", remap = false)!!
     }
 
+    @Synchronized
     override fun nextToken(): String {
         return source.invokeMethod("nextToken", remap = false)!!
     }
 
+    @Synchronized
     override fun mark() {
         source.invokeMethod<Void>("mark", remap = false)
     }
 
+    @Synchronized
     override fun reset() {
         source.invokeMethod<Void>("reset", remap = false)
     }
 
+    @Synchronized
     override fun <T> nextAction(): ParsedAction<T> {
         val action = source.invokeMethod<T>("nextAction", remap = false)!!
         val questAction = RemoteQuestAction<T>(remote, action.getProperty<Any>("action", remap = false)!!)
         return ParsedAction(questAction, action.getProperty<Map<String, Any>>("properties", remap = false)!!)
     }
 
+    @Synchronized
     override fun <T : Any?> nextAction(namespace: String?): ParsedAction<T> {
         return try {
             val action = nextActionStringMethod[source].invoke(source, namespace)!!
@@ -60,6 +70,7 @@ class RemoteQuestReader(val remote: OpenContainer, val source: Any) : QuestReade
         }
     }
 
+    @Synchronized
     override fun expect(value: String) {
         expectMethod[source].invoke(source, value)
     }

--- a/module/minecraft/minecraft-kether/src/main/kotlin/taboolib/module/kether/action/game/bukkit/ActionScoreboard.kt
+++ b/module/minecraft/minecraft-kether/src/main/kotlin/taboolib/module/kether/action/game/bukkit/ActionScoreboard.kt
@@ -4,9 +4,14 @@ import org.bukkit.entity.Player
 import taboolib.common.Inject
 import taboolib.common.platform.Platform
 import taboolib.common.platform.PlatformSide
+import taboolib.common.platform.function.submit
 import taboolib.common.util.asList
 import taboolib.module.kether.*
 import taboolib.module.nms.sendScoreboard
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.atomic.AtomicReference
 
 @Inject
 @PlatformSide(Platform.BUKKIT)
@@ -15,16 +20,84 @@ object ActionScoreboard {
     @KetherParser(["scoreboard"])
     fun actionScoreboard() = scriptParser {
         val value = it.nextParsedAction()
-        actionNow {
-            run(value).thenAccept { o ->
-                val viewer = player().cast<Player>()
-                if (o == null) {
-                    viewer.sendScoreboard()
-                } else {
-                    val body = if (o is Collection<*> || o is Array<*>) o.asList() else o.toString().trimIndent().lines()
-                    viewer.sendScoreboard(body[0], *body.filterIndexed { index, _ -> index > 0 }.toTypedArray())
+        actionTake {
+            val viewer = player().cast<Player>()
+            val result = CompletableFuture<Any?>()
+            val updateFuture = AtomicReference<CompletableFuture<Any?>?>()
+            val contentFuture = run(value)
+            contentFuture.whenComplete { content, ex ->
+                if (ex != null) {
+                    completeFailure(result, ex)
+                } else if (!result.isDone) {
+                    val scoreboardFuture = updateScoreboard(viewer, content)
+                    updateFuture.set(scoreboardFuture)
+                    if (result.isCancelled) {
+                        scoreboardFuture.cancel(false)
+                    } else {
+                        scoreboardFuture.whenComplete { _, updateEx ->
+                            if (updateEx != null) {
+                                completeFailure(result, updateEx)
+                            } else {
+                                result.complete(null)
+                            }
+                        }
+                    }
                 }
             }
+            result.whenComplete { _, _ ->
+                if (result.isCancelled) {
+                    contentFuture.cancel(false)
+                    updateFuture.get()?.cancel(false)
+                }
+            }
+            result
         }
+    }
+
+    private fun completeFailure(future: CompletableFuture<*>, throwable: Throwable) {
+        var cause = throwable
+        while (cause is CompletionException) {
+            val nested = cause.cause ?: break
+            cause = nested
+        }
+        if (cause is CancellationException) {
+            future.cancel(false)
+        } else {
+            future.completeExceptionally(cause)
+        }
+    }
+
+    private fun updateScoreboard(viewer: Player, content: Any?): CompletableFuture<Any?> {
+        val future = CompletableFuture<Any?>()
+        try {
+            val task = submit {
+                if (future.isCancelled) {
+                    return@submit
+                }
+                try {
+                    val body = when (content) {
+                        null -> emptyList()
+                        is Collection<*>, is Array<*> -> content.asList()
+                        else -> content.toString().trimIndent().lines()
+                    }
+                    if (body.isEmpty()) {
+                        viewer.sendScoreboard()
+                    } else {
+                        viewer.sendScoreboard(body.first(), *body.drop(1).toTypedArray())
+                    }
+                    future.complete(null)
+                } catch (ex: Throwable) {
+                    future.completeExceptionally(ex)
+                }
+            }
+            future.whenComplete { _, _ ->
+                if (future.isCancelled) {
+                    task.cancel()
+                }
+            }
+        } catch (ex: Throwable) {
+            future.completeExceptionally(ex)
+        }
+        return future
     }
 }

--- a/module/minecraft/minecraft-kether/src/test/java/taboolib/library/kether/AbstractQuestContextTest.java
+++ b/module/minecraft/minecraft-kether/src/test/java/taboolib/library/kether/AbstractQuestContextTest.java
@@ -1,0 +1,219 @@
+package taboolib.library.kether;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractQuestContextTest {
+
+    @Test
+    void asynchronousActionFailureCompletesContextExceptionally() {
+        CompletableFuture<Object> actionFuture = new CompletableFuture<>();
+        IllegalStateException failure = new IllegalStateException("boom");
+        TestQuestContext context = context(action(frame -> actionFuture));
+
+        CompletableFuture<Object> result = context.runActions();
+        actionFuture.completeExceptionally(failure);
+
+        CompletionException thrown = assertThrows(CompletionException.class, result::join);
+        assertSame(failure, thrown.getCause());
+    }
+
+    @Test
+    void completedExceptionalActionDoesNotEscapeRunActions() {
+        IllegalStateException failure = new IllegalStateException("boom");
+        CompletableFuture<Object> failed = new CompletableFuture<>();
+        failed.completeExceptionally(failure);
+        TestQuestContext context = context(action(frame -> failed));
+
+        CompletableFuture<Object> result = assertDoesNotThrow(context::runActions);
+
+        CompletionException thrown = assertThrows(CompletionException.class, result::join);
+        assertSame(failure, thrown.getCause());
+    }
+
+    @Test
+    void synchronousActionFailureStopsFollowingActions() {
+        IllegalStateException failure = new IllegalStateException("boom");
+        AtomicInteger followingRuns = new AtomicInteger();
+        TestQuestContext context = context(
+            action(frame -> {
+                throw failure;
+            }),
+            action(frame -> {
+                followingRuns.incrementAndGet();
+                return CompletableFuture.completedFuture(null);
+            })
+        );
+
+        CompletableFuture<Object> result = assertDoesNotThrow(context::runActions);
+
+        CompletionException thrown = assertThrows(CompletionException.class, result::join);
+        assertSame(failure, thrown.getCause());
+        assertEquals(0, followingRuns.get());
+    }
+
+    @Test
+    void actionFrameConvertsSynchronousFailureToFuture() {
+        IllegalStateException failure = new IllegalStateException("boom");
+        TestQuestContext context = context();
+        QuestContext.Frame frame = context.rootFrame().newFrame(action(ignored -> {
+            throw failure;
+        }));
+
+        CompletableFuture<Object> result = assertDoesNotThrow(() -> {
+            return frame.run();
+        });
+
+        CompletionException thrown = assertThrows(CompletionException.class, result::join);
+        assertSame(failure, thrown.getCause());
+    }
+
+    @Test
+    void exitStatusCompletesWithLastActionValue() {
+        AtomicInteger closes = new AtomicInteger();
+        TestQuestContext context = context(action(frame -> {
+            frame.addClosable(closes::incrementAndGet);
+            frame.context().setExitStatus(ExitStatus.success());
+            return CompletableFuture.completedFuture(7);
+        }));
+
+        assertEquals(7, context.runActions().join());
+        assertEquals(1, closes.get());
+    }
+
+    @Test
+    void cancellingContextCancelsRunningAction() {
+        CompletableFuture<Object> actionFuture = new CompletableFuture<>();
+        TestQuestContext context = context(action(frame -> actionFuture));
+        CompletableFuture<Object> result = context.runActions();
+
+        assertTrue(result.cancel(false));
+
+        assertTrue(actionFuture.isCancelled());
+        assertTrue(result.isCancelled());
+    }
+
+    @Test
+    void terminatingContextClosesFrameAndRunningAction() {
+        CompletableFuture<Object> actionFuture = new CompletableFuture<>();
+        TestQuestContext context = context(action(frame -> actionFuture));
+        CompletableFuture<Object> result = context.runActions();
+
+        context.terminate();
+
+        assertTrue(actionFuture.isCancelled());
+        assertTrue(result.isCompletedExceptionally());
+        assertFalse(result.isCancelled());
+    }
+
+    @SafeVarargs
+    private final TestQuestContext context(ParsedAction<?>... actions) {
+        return new TestQuestContext(new TestQuest(Arrays.asList(actions)));
+    }
+
+    private ParsedAction<Object> action(ActionProcessor processor) {
+        return new ParsedAction<>(new QuestAction<Object>() {
+            @Override
+            public CompletableFuture<Object> process(@NotNull QuestContext.Frame frame) {
+                return processor.process(frame);
+            }
+        });
+    }
+
+    private interface ActionProcessor {
+
+        CompletableFuture<Object> process(QuestContext.Frame frame);
+    }
+
+    private static class TestQuestContext extends AbstractQuestContext<TestQuestContext> {
+
+        TestQuestContext(Quest quest) {
+            super(null, quest, "test");
+        }
+
+        @Override
+        protected Executor createExecutor() {
+            return Runnable::run;
+        }
+    }
+
+    private static class TestQuest implements Quest {
+
+        private final Map<String, Block> blocks;
+
+        TestQuest(List<ParsedAction<?>> actions) {
+            Map<String, Block> values = new LinkedHashMap<>();
+            values.put(QuestContext.BASE_BLOCK, new TestBlock(QuestContext.BASE_BLOCK, actions));
+            this.blocks = Collections.unmodifiableMap(values);
+        }
+
+        @Override
+        public String getId() {
+            return "test";
+        }
+
+        @Override
+        public Optional<Block> getBlock(@NotNull String label) {
+            return Optional.ofNullable(blocks.get(label));
+        }
+
+        @Override
+        public Map<String, Block> getBlocks() {
+            return blocks;
+        }
+
+        @Override
+        public Optional<Block> blockOf(@NotNull ParsedAction<?> action) {
+            return blocks.values().stream().filter(block -> block.indexOf(action) >= 0).findFirst();
+        }
+    }
+
+    private static class TestBlock implements Quest.Block {
+
+        private final String label;
+        private final List<ParsedAction<?>> actions;
+
+        TestBlock(String label, List<ParsedAction<?>> actions) {
+            this.label = label;
+            this.actions = actions;
+        }
+
+        @Override
+        public String getLabel() {
+            return label;
+        }
+
+        @Override
+        public List<ParsedAction<?>> getActions() {
+            return actions;
+        }
+
+        @Override
+        public int indexOf(@NotNull ParsedAction<?> action) {
+            return actions.indexOf(action);
+        }
+
+        @Override
+        public Optional<ParsedAction<?>> get(int index) {
+            return index >= 0 && index < actions.size() ? Optional.of(actions.get(index)) : Optional.empty();
+        }
+    }
+}

--- a/module/minecraft/minecraft-kether/src/test/kotlin/taboolib/module/kether/RemoteQuestReaderTest.kt
+++ b/module/minecraft/minecraft-kether/src/test/kotlin/taboolib/module/kether/RemoteQuestReaderTest.kt
@@ -1,0 +1,64 @@
+package taboolib.module.kether
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import taboolib.common.OpenContainer
+import taboolib.common.OpenResult
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
+
+class RemoteQuestReaderTest {
+
+    @Test
+    fun `reader operations are serialized per remote source`() {
+        val source = ConcurrentReaderSource()
+        val reader = RemoteQuestReader(TestContainer, source)
+        val executor = Executors.newFixedThreadPool(8)
+        val start = CountDownLatch(1)
+        try {
+            val tasks = List(32) {
+                executor.submit<String> {
+                    start.await()
+                    reader.nextToken()
+                }
+            }
+            start.countDown()
+            tasks.forEach { future ->
+                assertEquals("token", future.get(5, TimeUnit.SECONDS))
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals(1, source.maxConcurrentCalls.get())
+    }
+
+    private class ConcurrentReaderSource {
+
+        private val activeCalls = AtomicInteger()
+        val maxConcurrentCalls = AtomicInteger()
+
+        fun nextToken(): String {
+            val active = activeCalls.incrementAndGet()
+            maxConcurrentCalls.updateAndGet { current -> maxOf(current, active) }
+            try {
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(2))
+                return "token"
+            } finally {
+                activeCalls.decrementAndGet()
+            }
+        }
+    }
+
+    private object TestContainer : OpenContainer {
+
+        override fun isValid() = true
+
+        override fun getName() = "test"
+
+        override fun call(name: String, args: Array<out Any>) = OpenResult.failed()
+    }
+}


### PR DESCRIPTION
## 原有问题

Kether 异步上下文在异常、取消和线程切换方面存在三类问题：

- 动作同步抛错、返回的 Future 异常完成或被取消时，Quest frame 没有完整传播终态，后续动作与父上下文可能继续等待。
- `RemoteQuestReader` 的读取游标和反射状态可被多个线程同时访问，缺少串行化保护。
- 计分板动作可能从 Kether 的异步执行线程直接访问 Bukkit/NMS 对象。

## 典型触发场景与后果

- 脚本中的异步动作访问数据库、网络或用户代码并失败：脚本 Future 永久 pending，调用命令或任务无法结束。
- 嵌套 frame 被取消后，子 Future 仍运行或后续动作继续执行：产生重复副作用和无法回收的任务。
- 多线程复用远程脚本 Reader：读取位置互相覆盖，可能解析出错误 token 或抛出随机异常。
- 异步 Kether 动作更新计分板：在 Bukkit/Folia 下触发异步线程访问异常，严重时导致状态竞态。

## 本 PR 修改

- 在 `AbstractQuestContext` 中统一传播动作的同步异常、异步异常和取消，并停止后续动作、反向取消仍在运行的 Future。
- 串行化 `RemoteQuestReader` 的反射读取状态，避免共享游标竞态。
- 将计分板 Bukkit/NMS 更新封送回平台同步调度线程，并传播调度失败、回调异常和取消状态。
- 增加上下文生命周期、嵌套 Future 和远程读取并发测试。

## 修改目的

保证 Kether 脚本无论成功、失败还是取消都能可靠结束，同时遵守 Bukkit/Folia 的线程所有权要求，避免脚本挂死和跨线程平台访问。

## 兼容性与行为变化

- 不修改公开 API 签名。
- 脚本失败由“可能永久等待”改为“可观察的异常完成”。
- 计分板动作可能由错误的异步立即执行改为正确线程上的调度执行。

## 验证

- [x] `./gradlew :module:minecraft:minecraft-kether:test --rerun-tasks --no-parallel`
- [x] `./gradlew :module:minecraft:minecraft-kether:build --rerun-tasks --no-parallel`
- [x] `git diff --check`

Refs #703