### PR TITLE
fix(common): 修复共享基础组件并发竞态

### DIFF
--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/CommandRegister.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/CommandRegister.kt
@@ -4,6 +4,26 @@ import taboolib.common.platform.ProxyCommandSender
 import taboolib.common.platform.command.component.CommandBase
 import taboolib.common.platform.function.registerCommand
 
+internal data class CommandHandlers(val executor: CommandExecutor, val completer: CommandCompleter)
+
+internal fun createCommandHandlers(newParser: Boolean, commandBuilder: CommandBase.() -> Unit): CommandHandlers {
+    val commandBase = CommandBase().also(commandBuilder)
+    return CommandHandlers(
+        executor = object : CommandExecutor {
+
+            override fun execute(sender: ProxyCommandSender, command: CommandStructure, name: String, args: Array<String>): Boolean {
+                return commandBase.execute(CommandContext(sender, command, name, commandBase, newParser, args))
+            }
+        },
+        completer = object : CommandCompleter {
+
+            override fun execute(sender: ProxyCommandSender, command: CommandStructure, name: String, args: Array<String>): List<String>? {
+                return commandBase.suggest(CommandContext(sender, command, name, commandBase, newParser, args))
+            }
+        }
+    )
+}
+
 /**
  * 注册一个命令
  *
@@ -29,25 +49,13 @@ fun command(
     newParser: Boolean = false,
     commandBuilder: CommandBase.() -> Unit,
 ) {
+    val handlers = createCommandHandlers(newParser, commandBuilder)
     registerCommand(
         // 创建命令结构
         CommandStructure(name, aliases, description, usage, permission, permissionMessage, permissionDefault, permissionChildren, newParser),
-        // 创建执行器
-        object : CommandExecutor {
-
-            override fun execute(sender: ProxyCommandSender, command: CommandStructure, name: String, args: Array<String>): Boolean {
-                val commandBase = CommandBase().also(commandBuilder)
-                return commandBase.execute(CommandContext(sender, command, name, commandBase, newParser, args))
-            }
-        },
-        // 创建补全器
-        object : CommandCompleter {
-
-            override fun execute(sender: ProxyCommandSender, command: CommandStructure, name: String, args: Array<String>): List<String>? {
-                val commandBase = CommandBase().also(commandBuilder)
-                return commandBase.suggest(CommandContext(sender, command, name, commandBase, newParser, args))
-            }
-        },
+        // 复用注册阶段构建的命令树
+        handlers.executor,
+        handlers.completer,
         // 传入原始命令构建器
         commandBuilder
     )

--- a/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandBase.kt
+++ b/common-platform-api/src/main/kotlin/taboolib/common/platform/command/component/CommandBase.kt
@@ -6,11 +6,12 @@ import taboolib.common.platform.command.CommandContext
 import taboolib.common.platform.service.PlatformCommand
 import taboolib.common.util.subList
 import taboolib.common.util.t
+import java.util.ArrayDeque
 
 @Suppress("DuplicatedCode")
 class CommandBase : CommandComponent(-1, false) {
 
-    internal var result = true
+    private val resultStack = ThreadLocal.withInitial { ArrayDeque<Boolean>() }
 
     internal var commandIncorrectSender: CommandUnknownNotify<*> =
         CommandUnknownNotify(ProxyCommandSender::class.java) { sender, _, _, _ ->
@@ -65,7 +66,19 @@ class CommandBase : CommandComponent(-1, false) {
         }
 
     fun execute(context: CommandContext<*>): Boolean {
-        result = true
+        val results = resultStack.get()
+        results.addLast(true)
+        return try {
+            executeInternal(context)
+        } finally {
+            results.removeLast()
+            if (results.isEmpty()) {
+                resultStack.remove()
+            }
+        }
+    }
+
+    private fun executeInternal(context: CommandContext<*>): Boolean {
         // 空参数是一种特殊的状态，指的是玩家输入根命令且不附带任何参数，例如 [/test] 而不是 [/test ]
         if (context.realArgs.isEmpty()) {
             // 获取下级节点
@@ -84,7 +97,7 @@ class CommandBase : CommandComponent(-1, false) {
                 } else {
                     commandExecutor!!.exec(this, context, "")
                 }
-                result
+                currentResult()
             } else {
                 commandIncorrectCommand.exec(context, -1, 1)
                 false
@@ -117,7 +130,7 @@ class CommandBase : CommandComponent(-1, false) {
                         } else {
                             find.commandExecutor!!.exec(this, context, context.self())
                         }
-                        result
+                        currentResult()
                     } else {
                         commandIncorrectCommand.exec(context, cur + 1, 1)
                         false
@@ -174,7 +187,17 @@ class CommandBase : CommandComponent(-1, false) {
         this.commandIncorrectCommand = CommandUnknownNotify(ProxyCommandSender::class.java, function)
     }
 
+    private fun currentResult(): Boolean {
+        return resultStack.get().peekLast() ?: true
+    }
+
     fun setResult(value: Boolean) {
-        result = value
+        val results = resultStack.get()
+        if (results.isEmpty()) {
+            resultStack.remove()
+            return
+        }
+        results.removeLast()
+        results.addLast(value)
     }
 }

--- a/common-platform-api/src/test/kotlin/taboolib/common/platform/command/CommandRegistrationConcurrencyTest.kt
+++ b/common-platform-api/src/test/kotlin/taboolib/common/platform/command/CommandRegistrationConcurrencyTest.kt
@@ -1,0 +1,100 @@
+package taboolib.common.platform.command
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import taboolib.common.platform.ProxyCommandSender
+import taboolib.common.platform.command.component.CommandBase
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class CommandRegistrationConcurrencyTest {
+
+    @Test
+    fun `command tree is built once and reused by executions`() {
+        val builds = AtomicInteger()
+        val commandBases = CopyOnWriteArrayList<CommandBase>()
+        val handlers = createCommandHandlers(false) {
+            builds.incrementAndGet()
+            execute(ProxyCommandSender::class.java) { _, context, _ ->
+                commandBases += context.commandCompound
+            }
+            dynamic("value") {
+                suggestionUncheck<ProxyCommandSender> { _, context ->
+                    commandBases += context.commandCompound
+                    listOf("value")
+                }
+            }
+        }
+        val command = command()
+        val sender = TestSender("sender")
+
+        assertTrue(handlers.executor.execute(sender, command, command.name, emptyArray()))
+        assertEquals(listOf("value"), handlers.completer.execute(sender, command, command.name, arrayOf("")))
+
+        assertEquals(1, builds.get())
+        assertEquals(2, commandBases.size)
+        assertSame(commandBases.first(), commandBases.last())
+    }
+
+    @Test
+    fun `concurrent executions keep independent result state`() {
+        val falseResultSet = CountDownLatch(1)
+        val trueResultSet = CountDownLatch(1)
+        val handlers = createCommandHandlers(false) {
+            execute(ProxyCommandSender::class.java) { sender, context, _ ->
+                if (sender.name == "false") {
+                    context.commandCompound.setResult(false)
+                    falseResultSet.countDown()
+                    assertTrue(trueResultSet.await(5, TimeUnit.SECONDS))
+                } else {
+                    assertTrue(falseResultSet.await(5, TimeUnit.SECONDS))
+                    context.commandCompound.setResult(true)
+                    trueResultSet.countDown()
+                }
+            }
+        }
+        val command = command()
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val falseFuture = executor.submit<Boolean> {
+                handlers.executor.execute(TestSender("false"), command, command.name, emptyArray())
+            }
+            val trueFuture = executor.submit<Boolean> {
+                handlers.executor.execute(TestSender("true"), command, command.name, emptyArray())
+            }
+
+            assertFalse(falseFuture.get(10, TimeUnit.SECONDS))
+            assertTrue(trueFuture.get(10, TimeUnit.SECONDS))
+        } finally {
+            trueResultSet.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS)
+        }
+    }
+
+    private fun command(): CommandStructure {
+        return CommandStructure("test", emptyList(), "", "", "", "", PermissionDefault.OP, emptyMap(), false)
+    }
+
+    private class TestSender(override val name: String) : ProxyCommandSender {
+
+        override val origin: Any
+            get() = this
+
+        override var isOp = false
+
+        override fun isOnline() = true
+
+        override fun sendMessage(message: String) = Unit
+
+        override fun performCommand(command: String) = true
+
+        override fun hasPermission(permission: String) = true
+    }
+}

--- a/common-util/src/main/java/taboolib/common/inject/ClassVisitorHandler.java
+++ b/common-util/src/main/java/taboolib/common/inject/ClassVisitorHandler.java
@@ -13,6 +13,9 @@ import taboolib.common.platform.SkipTo;
 import taboolib.common.platform.DelayTo;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -25,9 +28,9 @@ import java.util.stream.Collectors;
 @SuppressWarnings("CallToPrintStackTrace")
 public class ClassVisitorHandler {
 
-    private static final NavigableMap<Byte, VisitorGroup> propertyMap = Collections.synchronizedNavigableMap(new TreeMap<>());
-    private static final Map<LifeCycle, Set<ReflexClass>> delayedClasses = Collections.synchronizedMap(new HashMap<>());
-    private static Set<ReflexClass> classes = null;
+    private static final NavigableMap<Byte, VisitorGroup> propertyMap = new ConcurrentSkipListMap<>();
+    private static final Map<LifeCycle, Set<ReflexClass>> delayedClasses = new ConcurrentHashMap<>();
+    private static volatile Set<ReflexClass> classes = null;
 
     /**
      * 初始化函数
@@ -49,43 +52,59 @@ public class ClassVisitorHandler {
      * 获取能够被 ClassVisitor 访问到的所有类
      */
     public static Set<ReflexClass> getClasses() {
-        if (classes == null) {
-            long time = TabooLib.execution(() -> {
-                // 获取所有类
-                // 这里会首次触发 runningClassMapInJar 的初始化
-                Map<String, ReflexClass> allClasses = ProjectScannerKt.getRunningClassMap();
-                // 第一阶段：基于类名快速过滤（不触发反序列化）
-                long phase1Start = System.currentTimeMillis();
-                List<Map.Entry<String, ReflexClass>> candidates = allClasses.entrySet().parallelStream()
-                        .filter(entry -> {
-                            String key = entry.getKey();
-                            // 排除非本项目 && 排除第三方库 && 排除匿名内部类
-                            return isProjectClass(key) && !isLibraryClass(key) && !isAnonymousInnerClass(key);
-                        })
-                        .collect(Collectors.toList());
-                long phase1Time = System.currentTimeMillis() - phase1Start;
-                PrimitiveIO.debug("ClassVisitor 第一阶段过滤: {0} -> {1} 个候选类，用时 {2} 毫秒。", allClasses.size(), candidates.size(), phase1Time);
-                // 第二阶段：并行检查注解和平台条件（会触发反序列化，但只针对候选类）
-                long phase2Start = System.currentTimeMillis();
-                classes = candidates.parallelStream()
-                        .filter(entry -> {
-                            String key = entry.getKey();
-                            ReflexClass value = entry.getValue();
-                            // 排除属于 TabooLib 但没有 Inject 注解的类
-                            if (isTabooLibClass(key) && !value.getStructure().isAnnotationPresent(Inject.class)) {
-                                return false;
-                            }
-                            // 检测有效平台 & 条件注解
-                            return checkPlatform(value) && checkRequires(value);
-                        })
-                        .map(Map.Entry::getValue)
-                        .collect(Collectors.toCollection(LinkedHashSet::new));
-                long phase2Time = System.currentTimeMillis() - phase2Start;
-                PrimitiveIO.debug("ClassVisitor 第二阶段过滤: {0} -> {1} 个有效类，用时 {2} 毫秒。", candidates.size(), classes.size(), phase2Time);
-            });
-            PrimitiveIO.debug("ClassVisitor 总用时 {0} 毫秒。", time);
+        return getOrInitializeClasses(ClassVisitorHandler::scanClasses);
+    }
+
+    static Set<ReflexClass> getOrInitializeClasses(Supplier<Set<ReflexClass>> initializer) {
+        Set<ReflexClass> current = classes;
+        if (current == null) {
+            synchronized (ClassVisitorHandler.class) {
+                current = classes;
+                if (current == null) {
+                    Set<ReflexClass> initialized = Objects.requireNonNull(initializer.get(), "Class initializer returned null");
+                    current = Collections.unmodifiableSet(new LinkedHashSet<>(initialized));
+                    classes = current;
+                }
+            }
         }
-        return classes;
+        return current;
+    }
+
+    private static Set<ReflexClass> scanClasses() {
+        long startTime = System.currentTimeMillis();
+        // 获取所有类
+        // 这里会首次触发 runningClassMapInJar 的初始化
+        Map<String, ReflexClass> allClasses = ProjectScannerKt.getRunningClassMap();
+        // 第一阶段：基于类名快速过滤（不触发反序列化）
+        long phase1Start = System.currentTimeMillis();
+        List<Map.Entry<String, ReflexClass>> candidates = allClasses.entrySet().parallelStream()
+                .filter(entry -> {
+                    String key = entry.getKey();
+                    // 排除非本项目 && 排除第三方库 && 排除匿名内部类
+                    return isProjectClass(key) && !isLibraryClass(key) && !isAnonymousInnerClass(key);
+                })
+                .collect(Collectors.toList());
+        long phase1Time = System.currentTimeMillis() - phase1Start;
+        PrimitiveIO.debug("ClassVisitor 第一阶段过滤: {0} -> {1} 个候选类，用时 {2} 毫秒。", allClasses.size(), candidates.size(), phase1Time);
+        // 第二阶段：并行检查注解和平台条件（会触发反序列化，但只针对候选类）
+        long phase2Start = System.currentTimeMillis();
+        Set<ReflexClass> filteredClasses = candidates.parallelStream()
+                .filter(entry -> {
+                    String key = entry.getKey();
+                    ReflexClass value = entry.getValue();
+                    // 排除属于 TabooLib 但没有 Inject 注解的类
+                    if (isTabooLibClass(key) && !value.getStructure().isAnnotationPresent(Inject.class)) {
+                        return false;
+                    }
+                    // 检测有效平台 & 条件注解
+                    return checkPlatform(value) && checkRequires(value);
+                })
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        long phase2Time = System.currentTimeMillis() - phase2Start;
+        PrimitiveIO.debug("ClassVisitor 第二阶段过滤: {0} -> {1} 个有效类，用时 {2} 毫秒。", candidates.size(), filteredClasses.size(), phase2Time);
+        PrimitiveIO.debug("ClassVisitor 总用时 {0} 毫秒。", System.currentTimeMillis() - startTime);
+        return filteredClasses;
     }
 
     /**
@@ -263,7 +282,7 @@ public class ClassVisitorHandler {
     public static void injectAll(@NotNull LifeCycle lifeCycle) {
         long startTime = System.currentTimeMillis();
         // 处理延迟注入的类
-        final Set<ReflexClass> delayedForThisCycle = delayedClasses.get(lifeCycle);
+        final Set<ReflexClass> delayedForThisCycle = delayedClasses.remove(lifeCycle);
         if (delayedForThisCycle != null) {
             final List<LifeCycle> cyclesUtilNow = Arrays.stream(LifeCycle.values()).filter(cycle -> cycle.ordinal() < lifeCycle.ordinal()).collect(Collectors.toList());
             for (final LifeCycle cycle : cyclesUtilNow) {
@@ -273,7 +292,6 @@ public class ClassVisitorHandler {
                     }
                 }
             }
-            delayedClasses.remove(lifeCycle);
         }
         // 处理正常的类注入
         Set<ReflexClass> allClasses = getClasses();
@@ -348,7 +366,7 @@ public class ClassVisitorHandler {
         if (lifeCycle != null && clazz.getStructure().isAnnotationPresent(DelayTo.class) && !isDelayTo) {
             final LifeCycle delayTo = clazz.getStructure().getAnnotation(DelayTo.class).getEnum("value", LifeCycle.CONST);
             if (delayTo.ordinal() > lifeCycle.ordinal()) {
-                delayedClasses.computeIfAbsent(delayTo, k -> Collections.synchronizedSet(new HashSet<>())).add(clazz);
+                delayedClasses.computeIfAbsent(delayTo, k -> ConcurrentHashMap.newKeySet()).add(clazz);
                 return;
             }
         }

--- a/common-util/src/main/kotlin/taboolib/common/event/InternalEventBus.kt
+++ b/common-util/src/main/kotlin/taboolib/common/event/InternalEventBus.kt
@@ -46,10 +46,10 @@ interface InternalEventBus {
         var impl = object : InternalEventBus {
 
             /** 已注册的监听器 */
-            val registeredListeners = ConcurrentHashMap<Class<*>, MutableMap<Int, MutableList<RegisteredListener>>>()
+            val registeredListeners = ConcurrentHashMap<Class<*>, ConcurrentSkipListMap<Int, CopyOnWriteArrayList<RegisteredListener>>>()
 
             override fun isListening(cls: Class<*>): Boolean {
-                return registeredListeners.containsKey(cls) && registeredListeners[cls]!!.any { it.value.isNotEmpty() }
+                return registeredListeners[cls]?.values?.any { it.isNotEmpty() } == true
             }
 
             override fun <T : InternalEvent> call(event: T) {
@@ -66,7 +66,9 @@ interface InternalEventBus {
             @Suppress("UNCHECKED_CAST")
             override fun <T : InternalEvent> listen(cls: Class<T>, priority: Int, ignoreCancelled: Boolean, listener: (event: T) -> Unit): InternalListener {
                 val registeredListener = RegisteredListener(cls, priority, ignoreCancelled, listener as (Any) -> Unit)
-                registeredListeners.getOrPut(cls) { ConcurrentSkipListMap() }.getOrPut(priority) { CopyOnWriteArrayList() }.add(registeredListener)
+                registeredListeners.computeIfAbsent(cls) { ConcurrentSkipListMap() }
+                    .computeIfAbsent(priority) { CopyOnWriteArrayList() }
+                    .add(registeredListener)
                 return registeredListener
             }
 

--- a/common-util/src/test/kotlin/taboolib/common/event/InternalEventBusConcurrencyTest.kt
+++ b/common-util/src/test/kotlin/taboolib/common/event/InternalEventBusConcurrencyTest.kt
@@ -1,0 +1,47 @@
+package taboolib.common.event
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class InternalEventBusConcurrencyTest {
+
+    private class TestEvent : InternalEvent()
+
+    @Test
+    fun `concurrent listeners at the same priority are not lost`() {
+        val threadCount = 24
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val registered = CopyOnWriteArrayList<InternalListener>()
+        try {
+            repeat(50) { round ->
+                val barrier = CyclicBarrier(threadCount)
+                val calls = AtomicInteger()
+                val futures = (0 until threadCount).map {
+                    CompletableFuture.supplyAsync({
+                        barrier.await(5, TimeUnit.SECONDS)
+                        InternalEventBus.listen(TestEvent::class.java, Int.MIN_VALUE + round, false) {
+                            calls.incrementAndGet()
+                        }
+                    }, executor)
+                }
+                futures.forEach { registered += it.get(10, TimeUnit.SECONDS) }
+
+                InternalEventBus.call(TestEvent())
+
+                assertEquals(threadCount, calls.get(), "round $round lost registered listeners")
+                registered.forEach(InternalListener::cancel)
+                registered.clear()
+            }
+        } finally {
+            registered.forEach(InternalListener::cancel)
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS)
+        }
+    }
+}

--- a/common-util/src/test/kotlin/taboolib/common/inject/ClassVisitorHandlerConcurrencyTest.kt
+++ b/common-util/src/test/kotlin/taboolib/common/inject/ClassVisitorHandlerConcurrencyTest.kt
@@ -1,0 +1,57 @@
+package taboolib.common.inject
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.tabooproject.reflex.ReflexClass
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class ClassVisitorHandlerConcurrencyTest {
+
+    @Test
+    fun `class set is initialized once and safely published`() {
+        val classesField = ClassVisitorHandler::class.java.getDeclaredField("classes").also { it.isAccessible = true }
+        val previous = classesField.get(null)
+        classesField.set(null, null)
+
+        val threadCount = 16
+        val ready = CountDownLatch(threadCount)
+        val start = CountDownLatch(1)
+        val initializerStarted = CountDownLatch(1)
+        val releaseInitializer = CountDownLatch(1)
+        val initializerCalls = AtomicInteger()
+        val executor = Executors.newFixedThreadPool(threadCount)
+        try {
+            val futures = (0 until threadCount).map {
+                executor.submit<Set<ReflexClass>> {
+                    ready.countDown()
+                    assertTrue(start.await(5, TimeUnit.SECONDS))
+                    ClassVisitorHandler.getOrInitializeClasses {
+                        initializerCalls.incrementAndGet()
+                        initializerStarted.countDown()
+                        assertTrue(releaseInitializer.await(5, TimeUnit.SECONDS))
+                        emptySet()
+                    }
+                }
+            }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS))
+            start.countDown()
+            assertTrue(initializerStarted.await(5, TimeUnit.SECONDS))
+            releaseInitializer.countDown()
+
+            val results = futures.map { it.get(10, TimeUnit.SECONDS) }
+            assertEquals(1, initializerCalls.get())
+            results.drop(1).forEach { assertSame(results.first(), it) }
+        } finally {
+            releaseInitializer.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS)
+            classesField.set(null, previous)
+        }
+    }
+}


### PR DESCRIPTION
## 原有问题

多个全局共享基础组件使用了非原子的“读取—修改—写回”或无保护可变集合：

- 内部事件总线在同一优先级并发注册监听器时可能互相覆盖。
- `ClassVisitorHandler` 的访问器、延迟类集合和懒加载类集在并行扫描、注册与读取时缺少安全发布。
- 命令执行与补全没有稳定复用同一命令树，执行结果状态也可能被并发或嵌套调用交叉覆盖。

## 典型触发场景与后果

- 多插件并行启动并同时注册相同优先级事件：部分监听器静默丢失，事件行为取决于线程时序。
- 类扫描、生命周期注入和延迟加载并行发生：可能出现 `ConcurrentModificationException`、漏扫类或读取到未完整初始化的集合。
- 玩家同时执行命令、请求补全，或命令内部再次执行命令：参数、执行结果和补全树可能串线，产生随机错误结果。

## 本 PR 修改

- 使用原子并发容器维护内部事件监听器，保证同优先级并发注册不会丢项。
- 为 `ClassVisitorHandler` 的共享集合增加线程安全访问和可靠发布，统一延迟初始化流程。
- 让命令执行器和补全器复用同一棵命令树，并通过线程本地栈隔离并发与嵌套执行状态。
- 增加事件总线、类集初始化、命令执行和嵌套调用并发回归测试。

## 修改目的

消除框架启动和运行阶段的时序依赖，使事件注册、类扫描和命令系统在并发环境下保持确定性，不再出现难以复现的监听器丢失或状态串扰。

## 兼容性与行为变化

- 保持现有公开注册和命令 API。
- 仅修正并发时的丢失更新、未安全发布和执行状态污染。

## 验证

- [x] `./gradlew :common-util:test :common-platform-api:test --rerun-tasks --no-parallel`
- [x] `./gradlew :common-util:build :common-platform-api:build --rerun-tasks --no-parallel`
- [x] `git diff --check`

Refs #703