### PR TITLE
fix: 修复配置转换、SQL 方言与 JEXL 配置失效

### DIFF
--- a/module/basic/basic-configuration/src/main/java/com/electronwill/nightconfig/core/conversion/ObjectConverter.java
+++ b/module/basic/basic-configuration/src/main/java/com/electronwill/nightconfig/core/conversion/ObjectConverter.java
@@ -316,9 +316,16 @@ public final class ObjectConverter {
                 // --- Writes the value to the object's field, converting it if needed ---
                 Class<?> fieldType = field.getType();
                 try {
-                    if (value instanceof UnmodifiableConfig && !(fieldType.isAssignableFrom(value.getClass()))) {
+                    if ((value instanceof UnmodifiableConfig || value instanceof Map) && Map.class.isAssignableFrom(fieldType)) {
+                        // --- Reads as a map while preserving the declared map and generic value types ---
+                        Map<Object, Object> converted = convertMap(value, field.getGenericType(), fieldType);
+                        AnnotationUtils.checkField(field, converted);
+                        field.set(object, converted);
+                    } else if ((value instanceof UnmodifiableConfig || value instanceof Map) && !(fieldType.isAssignableFrom(value.getClass()))) {
                         // --- Read as a sub-object ---
-                        final UnmodifiableConfig cfg = (UnmodifiableConfig) value;
+                        final UnmodifiableConfig cfg = value instanceof UnmodifiableConfig
+                                ? (UnmodifiableConfig) value
+                                : configFromMap((Map<?, ?>) value);
                         // Gets or creates the field and convert it (if null OR not preserved)
                         Object fieldValue = field.get(object);
                         if (fieldValue == null) {
@@ -329,35 +336,10 @@ public final class ObjectConverter {
                             convertToObject(cfg, fieldValue, field.getType());
                         }
                     } else if (value instanceof Collection && Collection.class.isAssignableFrom(fieldType)) {
-                        // --- Reads as a collection, maybe a list of objects with conversion ---
-                        final Collection<?> src = (Collection<?>) value;
-                        final Class<?> srcBottomType = bottomElementType(src);
-
-                        final ParameterizedType genericType = (ParameterizedType) field.getGenericType();
-                        final List<Class<?>> dstTypes = elementTypes(genericType);
-                        final Class<?> dstBottomType = dstTypes.get(dstTypes.size() - 1);
-
-                        if (srcBottomType == null || dstBottomType == null || dstBottomType.isAssignableFrom(srcBottomType)) {
-                            // Simple list, no conversion needed
-                            AnnotationUtils.checkField(field, value);
-                            field.set(object, value);
-                        } else {
-                            // List of objects => the bottom elements need conversion
-                            // Uses the current field value if there is one, or create a new list
-                            Collection<Object> dst = (Collection<Object>) field.get(object);
-                            if (dst == null) {
-                                if (fieldType == ArrayList.class || fieldType.isInterface() || Modifier.isAbstract(fieldType.getModifiers())) {
-                                    dst = new ArrayList<>(src.size());// allocates the right size
-                                } else {
-                                    dst = (Collection<Object>) createInstance(fieldType);
-                                }
-                                field.set(object, dst);
-                            }
-                            // Converts the elements of the list
-                            convertConfigsToObject(src, dst, dstTypes, 0);
-                            // Applies the checks
-                            AnnotationUtils.checkField(field, dst);
-                        }
+                        // --- Reads as a collection while preserving the declared collection and generic element types ---
+                        Collection<Object> converted = convertCollection((Collection<?>) value, field.getGenericType(), fieldType);
+                        AnnotationUtils.checkField(field, converted);
+                        field.set(object, converted);
                     } else {
                         // --- Read as a plain value ---
                         if (value == null && AnnotationUtils.mustPreserve(field, clazz)) {
@@ -382,61 +364,213 @@ public final class ObjectConverter {
         }
     }
 
-    /**
-     * Gets the type of the "bottom element" of a list.
-     * For instance, for {@code LinkedList<List<List<Supplier<String>>>>}
-     * this method returns the class {@code Supplier}.
-     *
-     * @param genericType the generic list type
-     * @return the type of the elements of the most nested list
-     */
-    private Class<?> bottomElementType(ParameterizedType genericType) {
-        if (genericType != null && genericType.getActualTypeArguments().length > 0) {
-            Type parameter = genericType.getActualTypeArguments()[0];
-            if (parameter instanceof ParameterizedType) {
-                ParameterizedType genericParameter = (ParameterizedType) parameter;
-                Class<?> paramClass = (Class<?>) genericParameter.getRawType();
-                if (paramClass.isAssignableFrom(Collection.class)) {
-                    return bottomElementType(genericParameter);
-                } else {
-                    return paramClass;
-                }
-            }
-            if ((parameter instanceof Class)) {
-                return (Class<?>) parameter;
+    private Collection<Object> convertCollection(Collection<?> source, Type declaredType, Class<?> declaredClass) {
+        Type elementType = collectionElementType(declaredType);
+        Collection<Object> destination = createCollection(declaredClass, elementType, source.size());
+        for (Object element : source) {
+            destination.add(convertValue(element, elementType));
+        }
+        return destination;
+    }
+
+    private Object convertValue(Object value, Type declaredType) {
+        if (value == null) {
+            return null;
+        }
+        Class<?> declaredClass = rawClass(declaredType);
+        if (declaredClass == Object.class) {
+            return value;
+        }
+        if (value instanceof Collection && Collection.class.isAssignableFrom(declaredClass)) {
+            return convertCollection((Collection<?>) value, declaredType, declaredClass);
+        }
+        if ((value instanceof UnmodifiableConfig || value instanceof Map) && Map.class.isAssignableFrom(declaredClass)) {
+            return convertMap(value, declaredType, declaredClass);
+        }
+        if ((value instanceof UnmodifiableConfig || value instanceof Map) && isStructuredObjectType(declaredClass)) {
+            Object elementObject = createInstance(declaredClass);
+            UnmodifiableConfig elementConfig = value instanceof UnmodifiableConfig
+                    ? (UnmodifiableConfig) value
+                    : configFromMap((Map<?, ?>) value);
+            convertToObject(elementConfig, elementObject, declaredClass);
+            return elementObject;
+        }
+        Object unwrapped = ConfigSection.Companion.unwrap(value);
+        if (unwrapped == null || declaredClass.isAssignableFrom(unwrapped.getClass())) {
+            return unwrapped;
+        }
+        if (declaredClass.isEnum()) {
+            return EnumGetMethod.NAME_IGNORECASE.get(unwrapped, (Class<? extends Enum>) declaredClass);
+        }
+        if (unwrapped instanceof Number) {
+            Object number = convertNumber((Number) unwrapped, declaredClass);
+            if (number != null) {
+                return number;
             }
         }
+        if (declaredClass == String.class && !(unwrapped instanceof Map) && !(unwrapped instanceof Collection)) {
+            return unwrapped.toString();
+        }
+        throw new InvalidValueException("Unexpected element of type " + unwrapped.getClass() + " for " + declaredType);
+    }
+
+    private boolean isStructuredObjectType(Class<?> type) {
+        return type != String.class
+                && type != Boolean.class
+                && type != Character.class
+                && !Number.class.isAssignableFrom(type)
+                && !type.isEnum()
+                && !Collection.class.isAssignableFrom(type)
+                && !Map.class.isAssignableFrom(type);
+    }
+
+    private Map<Object, Object> convertMap(Object source, Type declaredType, Class<?> declaredClass) {
+        Map<?, ?> sourceMap;
+        if (source instanceof UnmodifiableConfig) {
+            sourceMap = ((UnmodifiableConfig) source).valueMap();
+        } else {
+            Object unwrapped = ConfigSection.Companion.unwrap(source);
+            if (!(unwrapped instanceof Map)) {
+                throw new InvalidValueException("Unexpected value of type " + source.getClass() + " for " + declaredType);
+            }
+            sourceMap = (Map<?, ?>) unwrapped;
+        }
+        Type keyType = Object.class;
+        Type valueType = Object.class;
+        Type resolvedType = boundedType(declaredType);
+        if (resolvedType instanceof ParameterizedType) {
+            Type[] typeArguments = ((ParameterizedType) resolvedType).getActualTypeArguments();
+            if (typeArguments.length > 0) {
+                keyType = typeArguments[0];
+            }
+            if (typeArguments.length > 1) {
+                valueType = typeArguments[1];
+            }
+        }
+        Map<Object, Object> destination = createMap(declaredClass);
+        for (Map.Entry<?, ?> entry : sourceMap.entrySet()) {
+            destination.put(convertValue(entry.getKey(), keyType), convertValue(entry.getValue(), valueType));
+        }
+        return destination;
+    }
+
+    private UnmodifiableConfig configFromMap(Map<?, ?> source) {
+        Config config = Config.inMemory();
+        for (Map.Entry<?, ?> entry : source.entrySet()) {
+            config.set(String.valueOf(entry.getKey()), entry.getValue());
+        }
+        return config;
+    }
+
+    private Collection<Object> createCollection(Class<?> declaredClass, Type elementType, int size) {
+        if (!declaredClass.isInterface() && !Modifier.isAbstract(declaredClass.getModifiers())) {
+            return (Collection<Object>) createInstance((Class<? extends Collection>) declaredClass);
+        }
+        if (EnumSet.class.isAssignableFrom(declaredClass)) {
+            Class<?> enumType = rawClass(elementType);
+            if (!enumType.isEnum()) {
+                throw new ReflectionException("Unable to determine enum type for " + declaredClass);
+            }
+            return (Collection<Object>) (Collection<?>) EnumSet.noneOf((Class<? extends Enum>) enumType);
+        }
+        if ((NavigableSet.class.isAssignableFrom(declaredClass) || SortedSet.class.isAssignableFrom(declaredClass))
+                && declaredClass.isAssignableFrom(TreeSet.class)) {
+            return new TreeSet<>();
+        }
+        if (Set.class.isAssignableFrom(declaredClass) && declaredClass.isAssignableFrom(LinkedHashSet.class)) {
+            return new LinkedHashSet<>(Math.max(16, size));
+        }
+        if ((Deque.class.isAssignableFrom(declaredClass) || Queue.class.isAssignableFrom(declaredClass))
+                && declaredClass.isAssignableFrom(LinkedList.class)) {
+            return new LinkedList<>();
+        }
+        if (Collection.class.isAssignableFrom(declaredClass) && declaredClass.isAssignableFrom(ArrayList.class)) {
+            return new ArrayList<>(size);
+        }
+        throw new ReflectionException("Unable to create compatible collection for " + declaredClass);
+    }
+
+    private Map<Object, Object> createMap(Class<?> declaredClass) {
+        if (!declaredClass.isInterface() && !Modifier.isAbstract(declaredClass.getModifiers())) {
+            return (Map<Object, Object>) createInstance((Class<? extends Map>) declaredClass);
+        }
+        if ((NavigableMap.class.isAssignableFrom(declaredClass) || SortedMap.class.isAssignableFrom(declaredClass))
+                && declaredClass.isAssignableFrom(TreeMap.class)) {
+            return new TreeMap<>();
+        }
+        if (Map.class.isAssignableFrom(declaredClass) && declaredClass.isAssignableFrom(LinkedHashMap.class)) {
+            return new LinkedHashMap<>();
+        }
+        throw new ReflectionException("Unable to create compatible map for " + declaredClass);
+    }
+
+    private Type collectionElementType(Type declaredType) {
+        Type resolvedType = boundedType(declaredType);
+        if (resolvedType instanceof ParameterizedType) {
+            Type[] arguments = ((ParameterizedType) resolvedType).getActualTypeArguments();
+            if (arguments.length > 0) {
+                return arguments[0];
+            }
+        }
+        return Object.class;
+    }
+
+    private Type boundedType(Type type) {
+        if (type instanceof WildcardType) {
+            WildcardType wildcardType = (WildcardType) type;
+            Type[] lowerBounds = wildcardType.getLowerBounds();
+            if (lowerBounds.length > 0) {
+                return boundedType(lowerBounds[0]);
+            }
+            Type[] upperBounds = wildcardType.getUpperBounds();
+            return upperBounds.length == 0 ? Object.class : boundedType(upperBounds[0]);
+        }
+        if (type instanceof TypeVariable) {
+            Type[] bounds = ((TypeVariable<?>) type).getBounds();
+            return bounds.length == 0 ? Object.class : boundedType(bounds[0]);
+        }
+        return type;
+    }
+
+    private Class<?> rawClass(Type type) {
+        if (type instanceof Class) {
+            return wrapPrimitive((Class<?>) type);
+        }
+        if (type instanceof ParameterizedType) {
+            return rawClass(((ParameterizedType) type).getRawType());
+        }
+        if (type instanceof WildcardType) {
+            Type[] upperBounds = ((WildcardType) type).getUpperBounds();
+            return upperBounds.length == 0 ? Object.class : rawClass(upperBounds[0]);
+        }
+        if (type instanceof TypeVariable) {
+            Type[] bounds = ((TypeVariable<?>) type).getBounds();
+            return bounds.length == 0 ? Object.class : rawClass(bounds[0]);
+        }
+        return Object.class;
+    }
+
+    private Class<?> wrapPrimitive(Class<?> type) {
+        if (!type.isPrimitive()) return type;
+        if (type == int.class) return Integer.class;
+        if (type == long.class) return Long.class;
+        if (type == double.class) return Double.class;
+        if (type == float.class) return Float.class;
+        if (type == short.class) return Short.class;
+        if (type == byte.class) return Byte.class;
+        if (type == boolean.class) return Boolean.class;
+        if (type == char.class) return Character.class;
+        return type;
+    }
+
+    private Object convertNumber(Number value, Class<?> targetType) {
+        if (targetType == Integer.class) return value.intValue();
+        if (targetType == Long.class) return value.longValue();
+        if (targetType == Double.class) return value.doubleValue();
+        if (targetType == Float.class) return value.floatValue();
+        if (targetType == Short.class) return value.shortValue();
+        if (targetType == Byte.class) return value.byteValue();
         return null;
-    }
-
-    private void detectElementTypes(ParameterizedType genericType, List<Class<?>> storage) {
-        if (genericType != null && genericType.getActualTypeArguments().length > 0) {
-            Type parameter = genericType.getActualTypeArguments()[0];
-            if (parameter instanceof ParameterizedType) {
-                ParameterizedType genericParameter = (ParameterizedType) parameter;
-                Class<?> paramClass = (Class<?>) genericParameter.getRawType();
-                storage.add(paramClass);
-                if (Collection.class.isAssignableFrom(paramClass)) {
-                    detectElementTypes(genericParameter, storage);
-                }
-            } else if ((parameter instanceof Class)) {
-                storage.add((Class<?>) parameter);
-            }
-        }
-    }
-
-    /**
-     * Returns a list of the generic parameters of a list.
-     * For instance, for {@code LinkedList<List<Collection<Supplier<String>>>>}
-     * this method returns a list containing {@code [Collection.class, Supplier.class]}.
-     *
-     * @param genericType the list generic type
-     * @return a list of the types of the list's elements
-     */
-    private List<Class<?>> elementTypes(ParameterizedType genericType) {
-        List<Class<?>> storage = new ArrayList<>();
-        detectElementTypes(genericType, storage);
-        return storage;
     }
 
     /**
@@ -456,43 +590,6 @@ public final class ObjectConverter {
             }
         }
         return null;
-    }
-
-    /**
-     * Converts a collection of configurations to a collection of objects of the type dstBottomType.
-     *
-     * @param src             the collection of configs, may be nested, source
-     * @param dst             the collection of objects, destination
-     * @param dstElementTypes the type of lists and objects in dst
-     */
-    private void convertConfigsToObject(Collection<?> src, Collection<Object> dst, List<Class<?>> dstElementTypes, int currentLevel) {
-        final Class<?> currentType = dstElementTypes.get(currentLevel);
-        for (Object elem : src) {
-            if (elem == null) {
-                dst.add(null);
-            } else if (elem instanceof Collection) {
-                final Collection<?> subSrc = (Collection<?>) elem;
-                final Collection<Object> subDst;
-
-                if (currentType == ArrayList.class
-                        || currentType.isInterface()
-                        || Modifier.isAbstract(currentType.getModifiers())) {
-
-                    subDst = new ArrayList<>();
-                } else {
-                    subDst = (Collection<Object>) createInstance(currentType);
-                }
-                convertConfigsToObject(subSrc, subDst, dstElementTypes, currentLevel + 1);
-                dst.add(subDst);
-            } else if (elem instanceof UnmodifiableConfig) {
-                Object elementObj = createInstance(currentType);
-                convertToObject((UnmodifiableConfig) elem, elementObj, currentType);
-                dst.add(elementObj);
-            } else {
-                String elemType = elem.getClass().toString();
-                throw new InvalidValueException("Unexpected element of type " + elemType + " in collection of objects");
-            }
-        }
     }
 
     /**

--- a/module/basic/basic-configuration/src/test/kotlin/TestObjectConverterCollections.kt
+++ b/module/basic/basic-configuration/src/test/kotlin/TestObjectConverterCollections.kt
@@ -1,0 +1,81 @@
+import com.electronwill.nightconfig.core.Config
+import com.electronwill.nightconfig.core.conversion.ObjectConverter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import java.util.EnumSet
+import java.util.LinkedHashSet
+import java.util.LinkedList
+import java.util.Queue
+import java.util.SortedMap
+import java.util.SortedSet
+import java.util.TreeMap
+import java.util.TreeSet
+
+class TestObjectConverterCollections {
+
+    @Test
+    fun `preserves declared collection types and converts nested elements`() {
+        val root = Config.inMemory()
+        root.set<Any>("names", listOf("alpha", "beta", "alpha"))
+        root.set<Any>("queue", listOf("first", "second"))
+        root.set<Any>("numbers", listOf(1L, 2L))
+        root.set<Any>("sorted", listOf("beta", "alpha"))
+        root.set<Any>("modes", listOf("first", "SECOND"))
+        root.set<Any>("groups", listOf(listOf(itemConfig("one"), itemConfig("two"))))
+
+        val indexed = Config.inMemory()
+        indexed.set<Any>("primary", itemConfig("indexed"))
+        root.set<Any>("indexed", indexed)
+
+        val sortedIndex = Config.inMemory()
+        sortedIndex.set<Any>("second", 2)
+        sortedIndex.set<Any>("first", 1)
+        root.set<Any>("sortedIndex", sortedIndex)
+
+        val result = CollectionHolder()
+        ObjectConverter().toObject(root, result)
+
+        assertInstanceOf(LinkedHashSet::class.java, result.names)
+        assertEquals(linkedSetOf("alpha", "beta"), result.names)
+        assertInstanceOf(LinkedList::class.java, result.queue)
+        assertEquals(listOf("first", "second"), result.queue.toList())
+        assertInstanceOf(LinkedList::class.java, result.numbers)
+        assertEquals(listOf(1, 2), result.numbers)
+        assertInstanceOf(TreeSet::class.java, result.sorted)
+        assertEquals(listOf("alpha", "beta"), result.sorted.toList())
+        assertEquals(EnumSet.of(Mode.FIRST, Mode.SECOND), result.modes)
+        assertInstanceOf(LinkedHashSet::class.java, result.groups.single())
+        assertEquals(listOf("one", "two"), result.groups.single().map { it.name })
+        assertEquals("indexed", result.indexed.getValue("primary").name)
+        assertInstanceOf(TreeMap::class.java, result.sortedIndex)
+        assertEquals(listOf("first", "second"), result.sortedIndex.keys.toList())
+        assertEquals(listOf(1L, 2L), result.sortedIndex.values.toList())
+    }
+
+    private fun itemConfig(name: String): Config {
+        return Config.inMemory().also { it.set<Any>("name", name) }
+    }
+
+    class CollectionHolder {
+
+        var names: Set<String> = emptySet()
+        var queue: Queue<String> = LinkedList()
+        var numbers: LinkedList<Int> = LinkedList()
+        var sorted: SortedSet<String> = sortedSetOf()
+        var modes: EnumSet<Mode> = EnumSet.noneOf(Mode::class.java)
+        var groups: List<Set<Item>> = emptyList()
+        var indexed: Map<String, Item> = emptyMap()
+        var sortedIndex: SortedMap<String, Long> = sortedMapOf()
+    }
+
+    class Item {
+
+        var name: String = ""
+    }
+
+    enum class Mode {
+        FIRST,
+        SECOND,
+    }
+}

--- a/module/database/build.gradle.kts
+++ b/module/database/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     compileOnly(project(":common-platform-api"))
     compileOnly(project(":common-util"))
     compileOnly(project(":module:basic:basic-configuration"))
+    testImplementation(project(":common-util"))
     testImplementation("com.zaxxer:HikariCP:4.0.3")
     testImplementation("org.xerial:sqlite-jdbc:3.42.0.0")
 }

--- a/module/database/src/main/kotlin/taboolib/module/database/ActionInsert.kt
+++ b/module/database/src/main/kotlin/taboolib/module/database/ActionInsert.kt
@@ -20,21 +20,32 @@ class ActionInsert(val table: String, val keys: Array<String>) : Action {
     /** 重复时更新 */
     private var duplicateUpdate = ArrayList<UpdateOperation>()
 
+    /** 重复键方言 */
+    private var duplicateKeyDialect = DuplicateKeyDialect.MYSQL
+
+    /** 冲突目标 */
+    private var conflictKeys: Array<String>? = null
+
     /** 语句 */
     override val query: String
-        get() = Statement("INSERT INTO")
-            .addSegment(table.asFormattedColumnName())
-            .addSegmentIfTrue(keys.isNotEmpty()) {
-                addKeys(keys)
+        get() {
+            require(table.isNotBlank()) { "Insert table must not be blank" }
+            require(keys.none { it.isBlank() }) { "Insert keys must not contain blank names" }
+            require(values.isNotEmpty()) { "Insert values must not be empty" }
+            if (keys.isNotEmpty()) {
+                require(values.all { it.size == keys.size }) { "Insert value count must match key count" }
             }
-            .addSegmentIfTrue(values.isNotEmpty()) {
-                addSegment("VALUES")
-                addValues(values)
-            }
-            .addSegmentIfTrue(duplicateUpdate.isNotEmpty()) {
-                addSegment("ON DUPLICATE KEY UPDATE")
-                addOperations(duplicateUpdate)
-            }.build()
+            return Statement("INSERT INTO")
+                .addSegment(table.asFormattedColumnName())
+                .addSegmentIfTrue(keys.isNotEmpty()) {
+                    addKeys(keys)
+                }
+                .addSegment("VALUES")
+                .addValues(values)
+                .addSegmentIfTrue(duplicateUpdate.isNotEmpty()) {
+                    addDuplicateUpdate()
+                }.build()
+        }
 
     /** 元素 */
     override val elements: List<Any?>
@@ -60,9 +71,28 @@ class ActionInsert(val table: String, val keys: Array<String>) : Action {
         values.add(args.toTypedArray())
     }
 
-    /** 重复时更新 */
+    /**
+     * 重复时更新。
+     * PostgreSQL 无法从插入字段可靠推断唯一约束，需使用带冲突字段的重载。
+     */
     fun onDuplicateKeyUpdate(func: DuplicateUpdateBehavior.() -> Unit) {
-        duplicateUpdate = DuplicateUpdateBehavior().also(func).updateOperations
+        setupDuplicateUpdate(null, func)
+    }
+
+    /**
+     * 重复时更新，并显式指定 PostgreSQL/SQLite 的冲突字段。
+     * MySQL 会忽略冲突字段并继续使用 ON DUPLICATE KEY UPDATE。
+     */
+    fun onDuplicateKeyUpdate(conflictKeys: Collection<String>, func: DuplicateUpdateBehavior.() -> Unit) {
+        setupDuplicateUpdate(conflictKeys.toTypedArray(), func)
+    }
+
+    internal fun setupDialect(host: Host<*>) {
+        duplicateKeyDialect = when (host) {
+            is HostPostgreSQL -> DuplicateKeyDialect.POSTGRESQL
+            is HostSQLite -> DuplicateKeyDialect.SQLITE
+            else -> DuplicateKeyDialect.MYSQL
+        }
     }
 
     override fun onFinally(onFinally: PreparedStatement.(Connection) -> Unit) {
@@ -73,16 +103,64 @@ class ActionInsert(val table: String, val keys: Array<String>) : Action {
         this.finallyCallback?.invoke(preparedStatement, connection)
     }
 
+    private fun setupDuplicateUpdate(conflictKeys: Array<String>?, func: DuplicateUpdateBehavior.() -> Unit) {
+        val behavior = DuplicateUpdateBehavior().also(func)
+        duplicateUpdate = behavior.updateOperations
+        this.conflictKeys = conflictKeys
+    }
+
+    private fun Statement.addDuplicateUpdate() {
+        when (duplicateKeyDialect) {
+            DuplicateKeyDialect.MYSQL -> {
+                addSegment("ON DUPLICATE KEY UPDATE")
+                addOperations(duplicateUpdate)
+            }
+            DuplicateKeyDialect.POSTGRESQL -> {
+                val targetKeys = conflictKeys
+                require(!targetKeys.isNullOrEmpty()) {
+                    "PostgreSQL duplicate update requires explicit conflict keys"
+                }
+                require(targetKeys.none { it.isBlank() }) {
+                    "PostgreSQL conflict keys must not contain blank names"
+                }
+                addSegment("ON CONFLICT")
+                addKeys(targetKeys)
+                addSegment("DO UPDATE SET")
+                addOperations(duplicateUpdate)
+            }
+            DuplicateKeyDialect.SQLITE -> {
+                addSegment("ON CONFLICT")
+                conflictKeys?.also { targetKeys ->
+                    require(targetKeys.none { it.isBlank() }) {
+                        "SQLite conflict keys must not contain blank names"
+                    }
+                    if (targetKeys.isNotEmpty()) {
+                        addKeys(targetKeys)
+                    }
+                }
+                addSegment("DO UPDATE SET")
+                addOperations(duplicateUpdate)
+            }
+        }
+    }
+
     class DuplicateUpdateBehavior {
 
         val updateOperations = ArrayList<UpdateOperation>()
 
         fun update(key: String, value: Any) {
+            require(key.isNotBlank()) { "Duplicate update key must not be blank" }
             updateOperations += if (value is PreValue) {
                 UpdateOperation("${key.asFormattedColumnName()} = ${value.asFormattedColumnName()}")
             } else {
                 UpdateOperation("${key.asFormattedColumnName()} = ?", value)
             }
         }
+    }
+
+    private enum class DuplicateKeyDialect {
+        MYSQL,
+        POSTGRESQL,
+        SQLITE,
     }
 }

--- a/module/database/src/main/kotlin/taboolib/module/database/ExecutableSource.kt
+++ b/module/database/src/main/kotlin/taboolib/module/database/ExecutableSource.kt
@@ -89,14 +89,20 @@ open class ExecutableSource(val table: Table<*, *>, var dataSource: DataSource, 
     /** 插入数据 */
     open fun insert(vararg keys: String, func: ActionInsert.() -> Unit = {}): ResultProcessor {
         setupQuoter()
-        val action = ActionInsert(table.name, arrayOf(*keys)).also(func)
+        val action = ActionInsert(table.name, arrayOf(*keys)).also {
+            it.setupDialect(table.host)
+            func(it)
+        }
         return executeUpdate(action.query, action)
     }
 
     /** 插入数据 */
     open fun insert(keys: List<String>, func: ActionInsert.() -> Unit = {}): ResultProcessor {
         setupQuoter()
-        val action = ActionInsert(table.name, keys.toTypedArray()).also(func)
+        val action = ActionInsert(table.name, keys.toTypedArray()).also {
+            it.setupDialect(table.host)
+            func(it)
+        }
         return executeUpdate(action.query, action)
     }
 
@@ -289,9 +295,9 @@ open class ExecutableSource(val table: Table<*, *>, var dataSource: DataSource, 
             .addSegmentIfTrue(index.checkExists) {
                 addSegment("IF NOT EXISTS")
             }
-            .addSegment(index.name)
+            .addSegment(index.name.asFormattedColumnName())
             .addSegment("ON")
-            .addSegment(table.name)
+            .addSegment(table.name.asFormattedColumnName())
             .addSegment("(")
             .addSegment(index.columns.joinToString(",", transform = { it.asFormattedColumnName() }))
             .addSegment(")")

--- a/module/database/src/test/kotlin/taboolib/module/database/ActionInsertDialectTest.kt
+++ b/module/database/src/test/kotlin/taboolib/module/database/ActionInsertDialectTest.kt
@@ -1,0 +1,150 @@
+package taboolib.module.database
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.sqlite.SQLiteDataSource
+import java.io.File
+
+class ActionInsertDialectTest {
+
+    @AfterEach
+    fun resetIdentifierQuoter() {
+        currentQuoter.remove()
+    }
+
+    @Test
+    fun `keeps mysql duplicate key syntax`() {
+        val host = HostSQL("localhost", "3306", "root", "", "test")
+        val action = insertAction(host, "order") {
+            onDuplicateKeyUpdate {
+                update("value", 2)
+            }
+        }
+
+        assertEquals(
+            "INSERT INTO `order` (`key`, `value`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `value` = ?",
+            action.query
+        )
+        assertEquals(listOf("entry", 1, 2), action.elements)
+    }
+
+    @Test
+    fun `uses postgresql conflict syntax and double quoted identifiers`() {
+        val host = HostPostgreSQL("localhost", "5432", "postgres", "", "test")
+        val action = insertAction(host, "public.order") {
+            onDuplicateKeyUpdate(listOf("key")) {
+                update("value", 2)
+            }
+        }
+
+        assertEquals(
+            "INSERT INTO \"public\".\"order\" (\"key\", \"value\") VALUES (?, ?) ON CONFLICT (\"key\") DO UPDATE SET \"value\" = ?",
+            action.query
+        )
+    }
+
+    @Test
+    fun `requires explicit postgresql conflict keys`() {
+        val host = HostPostgreSQL("localhost", "5432", "postgres", "", "test")
+        val action = insertAction(host, "order") {
+            onDuplicateKeyUpdate {
+                update("value", 2)
+            }
+        }
+
+        assertThrows(IllegalArgumentException::class.java) { action.query }
+    }
+
+    @Test
+    fun `uses sqlite conflict syntax without guessing a conflict target`() {
+        val action = insertAction(HostSQLite(File("database.db")), "order") {
+            onDuplicateKeyUpdate {
+                update("value", 2)
+            }
+        }
+
+        assertEquals(
+            "INSERT INTO `order` (`key`, `value`) VALUES (?, ?) ON CONFLICT DO UPDATE SET `value` = ?",
+            action.query
+        )
+    }
+
+    @Test
+    fun `keeps positional insert compatibility when keys are omitted`() {
+        setupQuoterForHost(HostSQLite(File("database.db")))
+        val action = ActionInsert("order", emptyArray()).also { it.value("entry", 1) }
+
+        assertEquals("INSERT INTO `order` VALUES (?, ?)", action.query)
+        assertEquals(listOf("entry", 1), action.elements)
+    }
+
+    @Test
+    fun `rejects incomplete insert statements`() {
+        setupQuoterForHost(HostSQLite(File("database.db")))
+
+        val noValues = ActionInsert("order", arrayOf("key"))
+        assertThrows(IllegalArgumentException::class.java) { noValues.query }
+
+        val blankKeys = ActionInsert("order", arrayOf(" ")).also { it.value("entry") }
+        assertThrows(IllegalArgumentException::class.java) { blankKeys.query }
+
+        val mismatchedValues = ActionInsert("order", arrayOf("key", "value")).also { it.value("entry") }
+        assertThrows(IllegalArgumentException::class.java) { mismatchedValues.query }
+    }
+
+    @Test
+    fun `executes generated sqlite upsert`() {
+        val action = insertAction(HostSQLite(File("database.db")), "entries") {
+            onDuplicateKeyUpdate {
+                update("value", 2)
+            }
+        }
+        val dataSource = SQLiteDataSource().also { it.url = "jdbc:sqlite::memory:" }
+
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("CREATE TABLE entries (`key` TEXT PRIMARY KEY, `value` INTEGER)")
+            }
+            repeat(2) {
+                connection.prepareStatement(action.query).use { statement ->
+                    action.elements.forEachIndexed { index, value -> statement.setObject(index + 1, value) }
+                    statement.executeUpdate()
+                }
+            }
+            connection.createStatement().use { statement ->
+                statement.executeQuery("SELECT value FROM entries WHERE `key` = 'entry'").use { result ->
+                    result.next()
+                    assertEquals(2, result.getInt(1))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `quotes index names tables and columns for postgresql`() {
+        val host = HostPostgreSQL("localhost", "5432", "postgres", "", "test")
+        val table = Table<HostPostgreSQL, PostgreSQL>("public.order", host)
+        val source = ExecutableSource(table, SQLiteDataSource(), false)
+        setupQuoterForHost(host)
+
+        val query = with(source) {
+            table.generateCreateIndexQuery(Index("select", listOf("from", "value"), unique = true, checkExists = false))
+        }
+
+        assertEquals(
+            "CREATE UNIQUE INDEX \"select\" ON \"public\".\"order\" ( \"from\",\"value\" )",
+            query
+        )
+    }
+
+    private fun insertAction(host: Host<*>, table: String, configure: ActionInsert.() -> Unit): ActionInsert {
+        setupQuoterForHost(host)
+        return ActionInsert(table, arrayOf("key", "value")).also {
+            it.setupDialect(host)
+            it.value("entry", 1)
+            configure(it)
+        }
+    }
+}

--- a/module/script/script-jexl/build.gradle.kts
+++ b/module/script/script-jexl/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     compileOnly(project(":common-env"))
     // 表达式
     compileOnly("org.apache.commons:commons-jexl3:3.2.1")
+    testImplementation("org.apache.commons:commons-jexl3:3.2.1")
 }
 
 tasks {

--- a/module/script/script-jexl/src/main/kotlin/taboolib/expansion/JexlCompiler.kt
+++ b/module/script/script-jexl/src/main/kotlin/taboolib/expansion/JexlCompiler.kt
@@ -3,7 +3,6 @@ package taboolib.expansion
 import org.apache.commons.jexl3.JexlBuilder
 import org.apache.commons.jexl3.JexlEngine
 import org.apache.commons.jexl3.MapContext
-import taboolib.common.util.unsafeLazy
 
 /**
  * TabooLib
@@ -20,7 +19,18 @@ class JexlCompiler {
         .cacheThreshold(64)  // 设置合适的缓存阈值
         .collectMode(0)      // 如果不需要变量收集，关闭它
 
-    internal val jexlEngine: JexlEngine by unsafeLazy { jexlBuilder.create() }
+    private val engineLock = Any()
+
+    @Volatile
+    private var currentEngine: JexlEngine? = null
+
+    internal val jexlEngine: JexlEngine
+        get() {
+            currentEngine?.let { return it }
+            return synchronized(engineLock) {
+                currentEngine ?: jexlBuilder.create().also { currentEngine = it }
+            }
+        }
 
     /**
      * 是否启用 Ant 风格模式
@@ -44,68 +54,57 @@ class JexlCompiler {
      * 在高频调用场景：影响会更明显
      */
     fun antish(flag: Boolean): JexlCompiler {
-        jexlBuilder.antish(flag)
-        return this
+        return configure { antish(flag) }
     }
 
     /** 设置严格模式 */
     fun strict(flag: Boolean): JexlCompiler {
-        jexlBuilder.strict(flag)
-        return this
+        return configure { strict(flag) }
     }
 
     /** 设置静默模式 */
     fun silent(flag: Boolean): JexlCompiler {
-        jexlBuilder.silent(flag)
-        return this
+        return configure { silent(flag) }
     }
 
     /** 设置安全模式 */
     fun safe(flag: Boolean): JexlCompiler {
-        jexlBuilder.safe(flag)
-        return this
+        return configure { safe(flag) }
     }
 
     /** 设置调试模式 */
     fun debug(flag: Boolean): JexlCompiler {
-        jexlBuilder.debug(flag)
-        return this
+        return configure { debug(flag) }
     }
 
     /** 设置缓存大小 */
     fun cache(size: Int): JexlCompiler {
-        jexlBuilder.cache(size)
-        return this
+        return configure { cache(size) }
     }
 
     /** 设置收集模式 */
     fun collectMode(mode: Int): JexlCompiler {
-        jexlBuilder.collectMode(mode)
-        return this
+        return configure { collectMode(mode) }
     }
 
     /** 设置是否收集所有变量 */
     fun collectAll(flag: Boolean): JexlCompiler {
-        jexlBuilder.collectAll(flag)
-        return this
+        return configure { collectAll(flag) }
     }
 
     /** 设置缓存阈值 */
     fun cacheThreshold(size: Int): JexlCompiler {
-        jexlBuilder.cacheThreshold(size)
-        return this
+        return configure { cacheThreshold(size) }
     }
 
     /** 设置堆栈大小 */
     fun stackOverflow(size: Int): JexlCompiler {
-        jexlBuilder.stackOverflow(size)
-        return this
+        return configure { stackOverflow(size) }
     }
 
     /** 设置命名空间 */
     fun namespace(namespace: Map<String, Any>): JexlCompiler {
-        jexlBuilder.namespaces(namespace)
-        return this
+        return configure { namespaces(namespace) }
     }
 
     /** 编译为脚本 */
@@ -128,6 +127,14 @@ class JexlCompiler {
                 return jexlExpression.evaluate(MapContext(map))
             }
         }
+    }
+
+    private fun configure(configureBuilder: JexlBuilder.() -> Unit): JexlCompiler {
+        synchronized(engineLock) {
+            jexlBuilder.configureBuilder()
+            currentEngine = null
+        }
+        return this
     }
 
     companion object {

--- a/module/script/script-jexl/src/main/kotlin/taboolib/expansion/JexlHelper.kt
+++ b/module/script/script-jexl/src/main/kotlin/taboolib/expansion/JexlHelper.kt
@@ -1,14 +1,26 @@
 @file:Inject
-@file:RuntimeDependency(
-    "!org.apache.commons:commons-jexl3:3.2.1",
-    test = "!org.apache.commons.jexl3_3_2_1.JexlEngine",
-    relocate = ["!org.apache.commons.jexl3", "!org.apache.commons.jexl3_3_2_1"],
-    transitive = false
+@file:RuntimeDependencies(
+    RuntimeDependency(
+        "!org.apache.commons:commons-jexl3:3.2.1",
+        test = "!org.apache.commons.jexl3_3_2_1.JexlEngine",
+        relocate = [
+            "!org.apache.commons.jexl3", "!org.apache.commons.jexl3_3_2_1",
+            "!org.apache.commons.logging", "!org.apache.commons.logging_1_2"
+        ],
+        transitive = false
+    ),
+    RuntimeDependency(
+        "!commons-logging:commons-logging:1.2",
+        test = "!org.apache.commons.logging_1_2.Log",
+        relocate = ["!org.apache.commons.logging", "!org.apache.commons.logging_1_2"],
+        transitive = false
+    )
 )
 
 package taboolib.expansion
 
 import taboolib.common.Inject
+import taboolib.common.env.RuntimeDependencies
 import taboolib.common.env.RuntimeDependency
 import taboolib.common.util.unsafeLazy
 

--- a/module/script/script-jexl/src/test/kotlin/taboolib/expansion/JexlCompilerTest.kt
+++ b/module/script/script-jexl/src/test/kotlin/taboolib/expansion/JexlCompilerTest.kt
@@ -1,0 +1,48 @@
+package taboolib.expansion
+
+import org.apache.commons.jexl3.JexlException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class JexlCompilerTest {
+
+    @Test
+    fun `rebuilds the engine when strict mode changes after first compilation`() {
+        val compiler = JexlCompiler()
+        val initialEngine = compiler.jexlEngine
+
+        assertNull(compiler.compileToExpression("missing").eval())
+
+        compiler.strict(true)
+        val strictEngine = compiler.jexlEngine
+
+        assertNotSame(initialEngine, strictEngine)
+        assertSame(strictEngine, compiler.jexlEngine)
+        assertThrows(JexlException::class.java) {
+            compiler.compileToExpression("missing").eval()
+        }
+    }
+
+    @Test
+    fun `applies namespace changes made after first compilation`() {
+        val compiler = JexlCompiler()
+        assertEquals(2, compiler.compileToExpression("1 + 1").eval())
+
+        compiler.namespace(mapOf("tools" to Tools(21)))
+        assertEquals(21, compiler.compileToExpression("tools:answer()").eval())
+
+        compiler.namespace(mapOf("tools" to Tools(42)))
+        assertEquals(42, compiler.compileToExpression("tools:answer()").eval())
+    }
+
+    class Tools(private val answer: Int) {
+
+        fun answer(): Int {
+            return answer
+        }
+    }
+}


### PR DESCRIPTION
## 原有问题

配置转换、SQL 构造和 JEXL 引擎缓存都存在“表面类型或配置已变化，内部仍按旧信息处理”的问题：

- `ObjectConverter` 在递归转换集合和映射时丢失声明泛型，嵌套对象可能按原始 `Object`、错误集合类型或错误元素类型恢复。
- `ActionInsert` 在 MySQL、PostgreSQL、SQLite 间复用不兼容的 upsert 语法，空字段、占位符和参数顺序也可能不一致。
- 表名、列名和索引名未按数据库方言引用，schema 限定名或保留字会生成非法 SQL。
- JEXL 配置发生变化后仍复用旧引擎，部分运行环境还缺少所需日志依赖。

## 典型触发场景与后果

- 配置包含 `List<Map<String, Bean>>`、Set、Queue、SortedSet 或 EnumSet：读取后出现 `ClassCastException`、元素类型错误或集合语义丢失。
- 在 PostgreSQL/SQLite 上执行按 MySQL 生成的重复键更新：直接语法错误；参数顺序不一致时还可能把值写入错误字段。
- 表名或列名使用保留字、特殊字符、schema：建表、建索引或插入失败。
- 运行中修改 JEXL strict/silent/cache 等配置：新配置看似已保存，但表达式仍按旧引擎执行；缺失日志类时可能启动失败。

## 本 PR 修改

- 按声明泛型递归恢复 Set、Queue、SortedSet、EnumSet、Map 和嵌套对象，并兼容 Kotlin 通配符签名。
- 按 MySQL、PostgreSQL、SQLite 分别生成重复键更新 SQL，校验空字段及非法结构，保持占位符和参数顺序一致。
- 对索引、表和列应用方言对应的标识符引用规则，支持 schema 限定表名。
- 在 JEXL 配置变化后线程安全地失效并重建引擎，补齐 commons-logging 运行时依赖与重定位。
- 增加嵌套集合转换、SQL 快照、SQLite 实际 upsert 和 JEXL 配置重建测试。

## 修改目的

让配置声明、数据库方言和运行时脚本配置真正决定最终行为，避免类型漂移、SQL 在不同数据库上失效以及配置修改不生效。

## 兼容性与行为变化

- 公开 API 保持不变。
- 反序列化结果会更准确地遵循字段泛型声明。
- SQL 文本会按实际数据库方言生成；非法插入结构会更早、明确地失败。

## 验证

- [x] `./gradlew :module:basic:basic-configuration:test :module:database:test :module:script:script-jexl:test --rerun-tasks --no-parallel --stacktrace`
- [x] `./gradlew :module:script:script-jexl:test :module:script:script-jexl:shadowJar --rerun-tasks --no-parallel --stacktrace`
- [x] `git diff --check`
- [x] 最终只读复审未发现阻塞问题

Refs #703