### PR TITLE
fix: 修复导航边界与路径平滑正确性

### DIFF
--- a/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/Fluid.kt
+++ b/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/Fluid.kt
@@ -1,6 +1,8 @@
 package taboolib.module.navigation
 
 import org.bukkit.block.Block
+import org.bukkit.block.data.Waterlogged
+import taboolib.module.nms.MinecraftVersion
 
 /**
  * Navigation
@@ -26,7 +28,13 @@ enum class Fluid {
             "WATER" -> WATER
             "STATIONARY_WATER" -> WATER
             "FLOWING_WATER" -> FLOWING_WATER
-            else -> EMPTY
+            else -> {
+                if (MinecraftVersion.isHigherOrEqual(MinecraftVersion.V1_13)) {
+                    (blockData as? Waterlogged)?.takeIf { it.isWaterlogged }?.let { WATER } ?: EMPTY
+                } else {
+                    EMPTY
+                }
+            }
         }
 
         fun String.getFluid() = when (this) {

--- a/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/NodeEntity.kt
+++ b/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/NodeEntity.kt
@@ -5,6 +5,7 @@ import org.bukkit.Location
 import org.bukkit.World
 import org.bukkit.block.BlockFace
 import org.bukkit.util.Vector
+import taboolib.module.navigation.Fluid.Companion.getFluid
 import taboolib.platform.util.callRegion
 import java.util.*
 
@@ -70,8 +71,9 @@ open class NodeEntity(
     }
 
     fun getWalkTargetValue(pos: Vector): Double {
-        return location.callRegion {
-            this.getWalkTargetValue(pos, location.world!!)
+        val world = location.world!!
+        return pos.toLocation(world).callRegion {
+            this.getWalkTargetValue(pos, world)
         }
     }
 
@@ -98,7 +100,7 @@ open class NodeEntity(
 
     open fun isInWater(): Boolean {
         return location.callRegion {
-            location.block.isLiquid
+            location.block.getFluid().isWater()
         }
     }
 

--- a/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/NodeReader.kt
+++ b/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/NodeReader.kt
@@ -34,7 +34,7 @@ open class NodeReader(val entity: NodeEntity) {
     }
 
     fun getNode(x: Int, y: Int, z: Int): Node {
-        return nodes.computeIfAbsent(Node.createHash(x, y, z)) { Node(x, y, z) }
+        return getOrCreateNavigationNode(nodes, x, y, z)
     }
 
     fun getCachedBlockType(x: Int, y: Int, z: Int): PathType {
@@ -58,36 +58,40 @@ open class NodeReader(val entity: NodeEntity) {
 
     private fun getStartAtRegion(): Node {
         val position = Vector(0, 0, 0)
-        var y = entity.location.blockY
+        val minHeight = world.navigationMinHeight()
+        val maxHeight = world.maxHeight
+        var y = entity.location.blockY.coerceIn(minHeight, maxHeight - 1)
         var block = world.getBlockAt(position.set(entity.location.blockX, y, entity.location.blockZ))
         var blockposition: Vector
         if (!entity.canStandOnFluid(block.getFluid())) {
             if (entity.canFloat && entity.isInWater()) {
-                while (true) {
-                    if (!block.isLiquid) {
-                        --y
-                        break
-                    }
+                while (block.getFluid().isWater() && y < maxHeight - 1) {
                     ++y
                     block = world.getBlockAt(position.set(entity.location.blockX, y, entity.location.blockZ))
+                }
+                if (!block.getFluid().isWater()) {
+                    --y
                 }
             } else if (entity.isOnGround()) {
                 y = NumberConversions.floor(entity.location.y + 0.5)
             } else {
-                blockposition = entity.location.toVector()
-                while (!blockposition.toBlock(block.world).type.isSolid && blockposition.y > 0) {
-                    blockposition = blockposition.down()
+                blockposition = entity.location.toVector().apply {
+                    setY(blockY.coerceIn(minHeight, maxHeight - 1).toDouble())
                 }
-                y = blockposition.up().blockY
+                var ground = blockposition.toBlock(block.world)
+                while (!ground.type.isSolid && blockposition.blockY > minHeight) {
+                    blockposition = blockposition.down()
+                    ground = blockposition.toBlock(block.world)
+                }
+                y = if (ground.type.isSolid) blockposition.up().blockY.coerceAtMost(maxHeight - 1) else minHeight
             }
         } else {
-            while (true) {
-                if (!entity.canStandOnFluid(block.getFluid())) {
-                    --y
-                    break
-                }
+            while (entity.canStandOnFluid(block.getFluid()) && y < maxHeight - 1) {
                 ++y
                 block = world.getBlockAt(position.set(entity.location.blockX, y, entity.location.blockZ))
+            }
+            if (!entity.canStandOnFluid(block.getFluid())) {
+                --y
             }
         }
         blockposition = entity.location.toVector()
@@ -164,7 +168,7 @@ open class NodeReader(val entity: NodeEntity) {
                 if (getCachedBlockType(x, h - 1, z) != PathType.WATER) {
                     return node
                 }
-                while (h > 0) {
+                while (h > world.navigationMinHeight()) {
                     --h
                     pathTypes = getCachedBlockType(x, h, z)
                     if (pathTypes != PathType.WATER) {
@@ -181,7 +185,7 @@ open class NodeReader(val entity: NodeEntity) {
                 var air = h
                 while (pathTypes == PathType.OPEN) {
                     --air
-                    if (air < 0) {
+                    if (air < world.navigationMinHeight()) {
                         val node1 = getNode(x, air, z)
                         node1.type = PathType.BLOCKED
                         node1.costMalus = -1.0f
@@ -316,5 +320,22 @@ open class NodeReader(val entity: NodeEntity) {
             nodes[neighbors++] = eastSouth
         }
         return neighbors
+    }
+}
+
+@JvmSynthetic
+internal fun getOrCreateNavigationNode(nodes: MutableMap<Int, Node>, x: Int, y: Int, z: Int): Node {
+    val initialKey = Node.createHash(x, y, z)
+    var key = initialKey
+    while (true) {
+        val existing = nodes[key]
+        if (existing == null) {
+            return Node(x, y, z).also { nodes[key] = it }
+        }
+        if (existing.x == x && existing.y == y && existing.z == z) {
+            return existing
+        }
+        key = key * 31 + 1
+        check(key != initialKey) { "Unable to resolve navigation node hash collision" }
     }
 }

--- a/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/PathSmoothing.kt
+++ b/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/PathSmoothing.kt
@@ -4,9 +4,11 @@ import org.bukkit.Location
 import org.bukkit.World
 import org.bukkit.util.Vector
 import taboolib.platform.util.callRegion
+import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
-import kotlin.math.sqrt
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * 路径平滑后处理（String Pulling / 拉绳法）
@@ -19,14 +21,14 @@ import kotlin.math.sqrt
  */
 object PathSmoothing {
 
-    /** 视线检测采样步长（格） */
-    private const val SAMPLE_STEP = 0.5
-
     /**
      * 对 A* 路径进行平滑处理
      * 返回平滑后的世界坐标点列表（方块中心）
      */
     fun smooth(path: Path, entity: NodeEntity): List<Vector> {
+        if (path.nodes.isEmpty()) {
+            return emptyList()
+        }
         return entity.location.callRegion {
             smoothAtRegion(path, entity)
         }
@@ -68,16 +70,35 @@ object PathSmoothing {
     private fun hasLineOfSightAtRegion(from: Vector, to: Vector, entity: NodeEntity, world: World): Boolean {
         val dx = to.x - from.x
         val dz = to.z - from.z
-        val dist = sqrt(dx * dx + dz * dz)
-        if (dist < 1e-6) return true
-        val steps = ceil(dist / SAMPLE_STEP).toInt()
-        for (i in 0..steps) {
-            val t = i.toDouble() / steps
-            val x = from.x + dx * t
-            val z = from.z + dz * t
-            if (!isStandableAtRegion(x, from.y, z, entity, world)) return false
+        if (abs(dx) < 1.0E-6 && abs(dz) < 1.0E-6) return true
+        val boundaries = sortedSetOf(0.0, 1.0)
+        addSweepBoundaries(from.x - entity.width / 2.0, dx, boundaries)
+        addSweepBoundaries(from.x + entity.width / 2.0, dx, boundaries)
+        addSweepBoundaries(from.z - entity.depth / 2.0, dz, boundaries)
+        addSweepBoundaries(from.z + entity.depth / 2.0, dz, boundaries)
+        val samples = boundaries.toList()
+        for (index in samples.indices) {
+            val t = samples[index]
+            if (!isStandableAtRegion(from.x + dx * t, from.y, from.z + dz * t, entity, world)) return false
+            if (index + 1 < samples.size) {
+                val midpoint = (t + samples[index + 1]) / 2.0
+                if (!isStandableAtRegion(from.x + dx * midpoint, from.y, from.z + dz * midpoint, entity, world)) return false
+            }
         }
         return true
+    }
+
+    private fun addSweepBoundaries(start: Double, delta: Double, boundaries: MutableSet<Double>) {
+        if (abs(delta) < 1.0E-6) return
+        val end = start + delta
+        val first = floor(min(start, end)).toInt()
+        val last = ceil(max(start, end)).toInt()
+        for (boundary in first..last) {
+            val t = (boundary - start) / delta
+            if (t > 0.0 && t < 1.0) {
+                boundaries += t
+            }
+        }
     }
 
     /**
@@ -95,24 +116,46 @@ object PathSmoothing {
         val halfWidth = entity.width / 2.0
         val halfDepth = entity.depth / 2.0
         val minBx = floor(x - halfWidth).toInt()
-        val maxBx = floor(x + halfWidth).toInt()
+        val maxBx = ceil(x + halfWidth).toInt() - 1
         val minBz = floor(z - halfDepth).toInt()
-        val maxBz = floor(z + halfDepth).toInt()
+        val maxBz = ceil(z + halfDepth).toInt() - 1
         val by = floor(y).toInt()
         val heightBlocks = ceil(entity.height).toInt()
+        if (!isWithinNavigationHeight(by, world.navigationMinHeight(), world.maxHeight)
+            || !isWithinNavigationHeight(by + heightBlocks - 1, world.navigationMinHeight(), world.maxHeight)) {
+            return false
+        }
+        val typeFactory = PathTypeFactory(entity)
         for (bx in minBx..maxBx) {
             for (bz in minBz..maxBz) {
-                // 脚下方块必须有支撑
                 val below = world.getBlockAtIfLoaded(Vector(bx, by - 1, bz)) ?: return false
-                if (below.type.isAirLegacy()) return false
-                // 实体身体占据的空间必须可通行
+                val supportY = below.y + NMS.instance.getBlockHeight(below)
+                if (abs(supportY - y) > 1.0E-3) {
+                    return false
+                }
+                val feetType = typeFactory.getTypeAsWalkable(world, Vector(bx, by, bz))
+                if (!isSafeSmoothingFeetType(feetType, entity.getPathfindingMalus(feetType))) {
+                    return false
+                }
                 for (oy in 0 until heightBlocks) {
-                    val block = world.getBlockAtIfLoaded(Vector(bx, by + oy, bz)) ?: return false
-                    if (block.type.isSolid) return false
+                    val bodyType = typeFactory.evaluateType(PathTypeFactory.getRawType(world, Vector(bx, by + oy, bz)))
+                    if (!isSafeSmoothingBodyType(entity.getPathfindingMalus(bodyType))) {
+                        return false
+                    }
                 }
             }
         }
         return true
+    }
+
+    @JvmSynthetic
+    internal fun isSafeSmoothingFeetType(pathType: PathType, malus: Float): Boolean {
+        return pathType != PathType.OPEN && malus == 0.0f
+    }
+
+    @JvmSynthetic
+    internal fun isSafeSmoothingBodyType(malus: Float): Boolean {
+        return malus == 0.0f
     }
 
     private fun nodeCenter(node: Node): Vector {

--- a/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/RandomPositionGenerator.kt
+++ b/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/RandomPositionGenerator.kt
@@ -136,7 +136,7 @@ object RandomPositionGenerator {
                 }
             }
             var result = Vector((x + nodeEntity.x).toInt(), (y + nodeEntity.y).toInt(), (z + nodeEntity.z).toInt())
-            if (result.y < 0) {
+            if (!isWithinNavigationHeight(result.blockY, world.navigationMinHeight(), world.maxHeight)) {
                 return@repeat
             }
             if (hasRestriction && !nodeEntity.isWithinRestriction(result)) {
@@ -146,7 +146,7 @@ object RandomPositionGenerator {
                 return@repeat
             }
             if (aboveLand) {
-                result = moveUp(result, 0, 256) {
+                result = moveUp(result, 0, world.maxHeight) {
                     if (Folia.isFolia) {
                         world.getBlockAtIfLoaded(it)?.type?.isSolid == true
                     } else {
@@ -159,7 +159,7 @@ object RandomPositionGenerator {
             } else {
                 world.getBlockAt(result.toLocation(world)).type
             }
-            if (onWater || blockType?.isWater() == true) {
+            if (acceptsNavigationSurface(onWater, blockType?.isWater() == true)) {
                 val type = navigation.getTypeAsWalkable(world, result)
                 if (nodeEntity.getPathfindingMalus(type) == 0.0f) {
                     val walk = nodeEntity.getWalkTargetValue(result)
@@ -198,6 +198,11 @@ object RandomPositionGenerator {
             }
             result
         }
+    }
+
+    @JvmSynthetic
+    internal fun acceptsNavigationSurface(allowWater: Boolean, isWater: Boolean): Boolean {
+        return allowWater || !isWater
     }
 
     private fun randomDelta(random: Random, restrictX: Int, restrictY: Int, vector: Vector?): Vector? {

--- a/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/Utils.kt
+++ b/module/bukkit/bukkit-navigation/src/main/kotlin/taboolib/module/navigation/Utils.kt
@@ -21,6 +21,9 @@ fun World.getBlockAtIfLoaded(position: Vector): Block? {
     val x = position.blockX
     val y = position.blockY
     val z = position.blockZ
+    if (!isWithinNavigationHeight(y, navigationMinHeight(), maxHeight)) {
+        return null
+    }
     return callRegion(x, y, z) {
         if (ChunkAccess.instance.isChunkLoaded(this, x shr 4, z shr 4)) {
             getBlockAt(x, y, z)
@@ -28,6 +31,16 @@ fun World.getBlockAtIfLoaded(position: Vector): Block? {
             null
         }
     }
+}
+
+@JvmSynthetic
+internal fun World.navigationMinHeight(): Int {
+    return if (MinecraftVersion.isHigherOrEqual(MinecraftVersion.V1_17)) minHeight else 0
+}
+
+@JvmSynthetic
+internal fun isWithinNavigationHeight(y: Int, minHeight: Int, maxHeight: Int): Boolean {
+    return y >= minHeight && y < maxHeight
 }
 
 fun Vector.toBlock(world: World) = toLocation(world).block
@@ -115,7 +128,7 @@ fun Material.isAirLegacy(): Boolean {
 }
 
 fun Material.isWater(): Boolean {
-    return name.contains("WATER")
+    return name == "WATER" || name == "STATIONARY_WATER" || name == "FLOWING_WATER"
 }
 
 fun Block.isTrapdoorOpen(): Boolean {

--- a/module/bukkit/bukkit-navigation/src/test/kotlin/taboolib/module/navigation/NavigationCorrectnessTest.kt
+++ b/module/bukkit/bukkit-navigation/src/test/kotlin/taboolib/module/navigation/NavigationCorrectnessTest.kt
@@ -1,0 +1,67 @@
+package taboolib.module.navigation
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class NavigationCorrectnessTest {
+
+    @Test
+    fun `world height bounds include negative build height and exclude max height`() {
+        assertFalse(isWithinNavigationHeight(-65, -64, 320))
+        assertTrue(isWithinNavigationHeight(-64, -64, 320))
+        assertTrue(isWithinNavigationHeight(319, -64, 320))
+        assertFalse(isWithinNavigationHeight(320, -64, 320))
+    }
+
+    @Test
+    fun `node cache resolves legacy hash collisions across modern world heights`() {
+        val nodes = HashMap<Int, Node>()
+        assertEquals(Node.createHash(4, -64, 8), Node.createHash(4, 192, 8))
+
+        val low = getOrCreateNavigationNode(nodes, 4, -64, 8)
+        val high = getOrCreateNavigationNode(nodes, 4, 192, 8)
+
+        assertNotSame(low, high)
+        assertEquals(-64, low.y)
+        assertEquals(192, high.y)
+        assertSame(low, getOrCreateNavigationNode(nodes, 4, -64, 8))
+        assertSame(high, getOrCreateNavigationNode(nodes, 4, 192, 8))
+    }
+
+    @Test
+    fun `surface selection only rejects water when water is disabled`() {
+        assertTrue(RandomPositionGenerator.acceptsNavigationSurface(false, false))
+        assertFalse(RandomPositionGenerator.acceptsNavigationSurface(false, true))
+        assertTrue(RandomPositionGenerator.acceptsNavigationSurface(true, false))
+        assertTrue(RandomPositionGenerator.acceptsNavigationSurface(true, true))
+    }
+
+    @Test
+    fun `fluid categories keep water and lava distinct`() {
+        assertTrue(Fluid.WATER.isWater())
+        assertTrue(Fluid.FLOWING_WATER.isWater())
+        assertFalse(Fluid.LAVA.isWater())
+        assertFalse(Fluid.FLOWING_LAVA.isWater())
+        assertTrue(Fluid.LAVA.isLava())
+        assertTrue(Fluid.FLOWING_LAVA.isLava())
+        assertFalse(Fluid.WATER.isLava())
+    }
+
+    @Test
+    fun `path smoothing rejects unsupported liquid dangerous and blocked cells`() {
+        assertTrue(PathSmoothing.isSafeSmoothingFeetType(PathType.WALKABLE, 0.0f))
+        assertFalse(PathSmoothing.isSafeSmoothingFeetType(PathType.OPEN, 0.0f))
+        assertFalse(PathSmoothing.isSafeSmoothingFeetType(PathType.WATER, PathType.WATER.malus))
+        assertFalse(PathSmoothing.isSafeSmoothingFeetType(PathType.LAVA, PathType.LAVA.malus))
+        assertFalse(PathSmoothing.isSafeSmoothingFeetType(PathType.DANGER_FIRE, PathType.DANGER_FIRE.malus))
+
+        assertTrue(PathSmoothing.isSafeSmoothingBodyType(PathType.OPEN.malus))
+        assertFalse(PathSmoothing.isSafeSmoothingBodyType(PathType.WATER.malus))
+        assertFalse(PathSmoothing.isSafeSmoothingBodyType(PathType.DAMAGE_FIRE.malus))
+        assertFalse(PathSmoothing.isSafeSmoothingBodyType(PathType.BLOCKED.malus))
+    }
+}


### PR DESCRIPTION
## 原有问题

导航模块沿用了不完整的世界高度、水体和直线路径判定：

- 高度查询与纵向扫描没有始终使用目标坐标及当前世界的真实最小/最大高度，现代负高度世界可能越界。
- 节点哈希在部分坐标组合下发生碰撞，不同位置可能被当成同一节点。
- 水和岩浆、可游泳位置及随机陆地候选筛选不够严格。
- 路径平滑只验证抽象连线，未按实体碰撞箱、支撑方块、危险方块和窄通道检查整段路径。

## 典型触发场景与后果

- Minecraft 1.18+ 负 Y 世界、自定义高度世界或接近上下边界寻路：读取越界、漏掉可行节点或生成非法高度。
- 较远坐标寻路时节点哈希碰撞：开放/关闭集合错误覆盖，路径随机绕路、失败或不稳定。
- 水边、岩浆附近或 Folia 区域随机选点：把危险液体或错误区域候选当成可行位置。
- 高个/宽体实体经过墙角、台阶、窄门或悬空位置时平滑路径：删除必要节点后直线穿墙、穿过危险方块或失去地面支撑。

## 本 PR 修改

- 使用版本兼容的世界最小/最大高度，并按目标 x/z 执行边界安全的纵向扫描。
- 修复节点坐标哈希，避免不同位置碰撞。
- 明确区分水和岩浆，修正可游泳状态、Folia 目标区域评分及随机陆地候选筛选。
- 按实体完整碰撞箱扫掠验证平滑路径，检查障碍、液体、危险方块、支撑高度和通道宽度。
- 增加现代世界高度、哈希、水域筛选、墙角/窄通道和平滑安全测试。

## 修改目的

确保寻路结果与真实世界边界和实体体积一致，平滑过程只能删除真正可安全直达的节点，避免路径穿墙、越界或进入危险地形。

## 兼容性与行为变化

- 不修改公开导航 API。
- 路径结果可能改变，但变化是从不安全或越界路线修正为可通行路线。

## 验证

- [x] `./gradlew :module:bukkit:bukkit-navigation:test --rerun-tasks --no-parallel`
- [x] `./gradlew :module:bukkit:bukkit-navigation:build --rerun-tasks --no-parallel`
- [x] `git diff --check`（仅 Windows LF→CRLF 提示）

Refs #703