### PR TITLE
[fix] 停止 Incision 修改 attach self 全局属性

### DIFF
--- a/module/incision/TECHNICAL.md
+++ b/module/incision/TECHNICAL.md
@@ -192,7 +192,7 @@ private fun resolve(): Instrumentation? {
 
 **self-attach 的固有阻碍**：
 
-- JDK 9+：默认 `jdk.attach.allowAttachSelf=false`，需显式打开
+- JDK 9+：默认禁止当前进程 attach 自身；如需启用，必须在 JVM 启动参数中设置 `-Djdk.attach.allowAttachSelf=true`。Incision 不会在运行时修改这个进程级属性，因为 HotSpot 读取的是启动快照，而 ByteBuddy 等库读取实时属性，修改会造成策略分裂并影响其他插件
 - JDK 21+：无 `-XX:+EnableDynamicAgentLoading` 时打印警告并最终禁止
 - Paper/Spigot 生产配置：常以安全硬化名义禁用 self-attach
 - 精简 JRE：可能缺 `tools.jar` 或 `jdk.attach` 模块

--- a/module/incision/src/main/kotlin/taboolib/module/incision/loader/attach/ManualSelfAttach.kt
+++ b/module/incision/src/main/kotlin/taboolib/module/incision/loader/attach/ManualSelfAttach.kt
@@ -21,7 +21,8 @@ import java.util.jar.Manifest
  *
  * JDK 9+：
  * - 直接使用内建 `com.sun.tools.attach`（jdk.attach 模块）
- * - 若进程未启用 `jdk.attach.allowAttachSelf=true`，尝试动态 set 系统属性后再 attach
+ * - 只有 JVM 启动时已启用 `jdk.attach.allowAttachSelf=true` 才允许进程内 attach；
+ *   运行时修改该属性不会改变 HotSpot 的启动快照，且会误导其他插件的 attach 策略。
  */
 object ManualSelfAttach {
 
@@ -32,9 +33,6 @@ object ManualSelfAttach {
 
     fun attach(): Instrumentation {
         captured?.let { return it }
-
-        // 启用 self-attach（JDK 9+）
-        System.setProperty("jdk.attach.allowAttachSelf", "true")
 
         val vmClass = loadVirtualMachineClass()
         val pid = currentPid().takeIf { it > 0 }


### PR DESCRIPTION
## 问题

`ManualSelfAttach` 运行时写入 `jdk.attach.allowAttachSelf=true`，但 HotSpot 的 self-attach 权限读取启动快照，运行时写入不能真正开启 attach；ByteBuddy 等库却读取实时属性，导致后续插件误判为可进程内 attach，跳过外部 helper，影响 Iris 等 agent 用户。

## 修改

- 删除 `ManualSelfAttach` 对 `jdk.attach.allowAttachSelf` 的运行时写入。
- 仅尊重 JVM 启动时的 `-Djdk.attach.allowAttachSelf=true` 配置。
- attach 失败时保持进程级属性不变。
- 保留现有 Instrumentation 不可用时回退 JVMTI native backend 的路径；本修改不影响 JVMTI 的 `GetEnv`、`ClassFileLoadHook` 或 `RetransformClasses`。
- 更新 `module/incision/TECHNICAL.md`，记录 HotSpot 启动快照与 ByteBuddy 实时属性的差异。

## 设计取舍

没有采用“失败后恢复属性”：并发插件仍可能在恢复前读取到错误值，而且无法区分用户或其他插件原本设置的值。Incision 不应修改这个进程级共享开关。

## 验证

- `git diff --check` 通过。
- 本地 JDK 21 `javap` 验证 `HotSpotVirtualMachine` 使用 `VM.getSavedProperty` 初始化 `ALLOW_ATTACH_SELF`。
- 未执行构建（本次仅要求修复、推送和 PR，且仓库构建授权要求显式指定构建命令）。

Closes #726